### PR TITLE
inputのfontを指定してsystem-uiに上書きされないようにする

### DIFF
--- a/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Input component testing Input 1`] = `
     class="sc-AxjAm hPcro  "
   >
     <input
-      class="sc-AxirZ iLZthr  "
+      class="sc-AxirZ ddPDgp  "
       type="text"
     />
   </div>

--- a/src/components/Input/styled.ts
+++ b/src/components/Input/styled.ts
@@ -28,6 +28,8 @@ export const Input = styled.input<{
     ${({ theme }) => theme.palette.gray.light} inset;
   background-color: ${({ theme }) => theme.palette.background.default};
   overflow: hidden;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Proxima Nova",
+    Verdana, "游ゴシック", YuGothic, Meiryo, sans-serif;
   /* lastpassのicon用 */
   background-position: calc(100% - 35px) 50% !important;
   &:focus {

--- a/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextField component testing TextField 1`] = `
       class="sc-AxirZ hcwaaf  "
     >
       <input
-        class="sc-AxiKw eKJSkr  "
+        class="sc-AxiKw bypMCt  "
         type="text"
       />
     </div>


### PR DESCRIPTION
* [こちら](https://github.com/voyagegroup/fluct_datastrap/issues/1425) のissueを反映しての修正です
* Inputのfontがsystem-uiに上書きされてしまうのでfontを指定して上書きを防ぐ