### PR TITLE
@storybook/addon-knobs の設定漏れを修正

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
 import "@storybook/addon-actions/register";
 import "@storybook/addon-notes/register";
 import "@storybook/addon-storysource/register";
+import "@storybook/addon-knobs/register";

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,10 +1,12 @@
 import { configure, addDecorator } from "@storybook/react";
 import * as React from "react";
+import { withKnobs } from "@storybook/addon-knobs";
 import { ThemeProvider, createTheme } from "../src/themes";
 
 const theme = createTheme();
 
 addDecorator(story => <ThemeProvider theme={theme}>{story()}</ThemeProvider>);
+addDecorator(withKnobs());
 
 configure(
   require.context("../src/components", true, /\.stories\.tsx$/),


### PR DESCRIPTION
DropdownButtonのRevertにより`@storybook/addon-knobs`の設定も消えていた。

※現状のmasterブランチのbuildには問題ない