### PR TITLE
<thead />ではなく<th />にスタイルを当てる

### DIFF
--- a/src/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -6,16 +6,14 @@ exports[`DataTable component testing DataTable 1`] = `
     class="sc-AxjAm kNttCc"
   >
     <table
-      class="sc-fznJRM cdciMQ"
+      class="sc-fzpjYC jZnCzf"
     >
-      <thead
-        class="sc-fzpjYC hEqWAc"
-      >
+      <thead>
         <tr
-          class="sc-fznxsB hjPEzr"
+          class="sc-fzoXzr fsOuNX"
         >
           <th
-            class="sc-AxmLO iHFTbx"
+            class="sc-AxmLO dxNAEf"
             width="auto"
           >
             <div
@@ -32,7 +30,7 @@ exports[`DataTable component testing DataTable 1`] = `
             </div>
           </th>
           <th
-            class="sc-AxmLO iHFTbx"
+            class="sc-AxmLO dxNAEf"
             width="auto"
           >
             <div
@@ -52,7 +50,7 @@ exports[`DataTable component testing DataTable 1`] = `
       </thead>
       <tbody>
         <tr
-          class="sc-fznxsB hjPEzr"
+          class="sc-fzoXzr fsOuNX"
         >
           <td
             class="sc-fzoLag emDgsi"
@@ -80,7 +78,7 @@ exports[`DataTable component testing DataTable 1`] = `
           </td>
         </tr>
         <tr
-          class="sc-fznxsB hjPEzr"
+          class="sc-fzoXzr fsOuNX"
         >
           <td
             class="sc-fzoLag emDgsi"

--- a/src/components/DataTable/internal/CellCheckbox/styled.ts
+++ b/src/components/DataTable/internal/CellCheckbox/styled.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Size } from "../../../../styles";
 
 const CELL_PADDING = 24;
 
@@ -15,4 +16,8 @@ export const HeaderCell = styled.th`
   padding: ${({ theme }) => theme.spacing * 2}px 0
     ${({ theme }) => theme.spacing * 2 - 2}px
     ${({ theme }) => theme.spacing * 3}px;
+  border-top: ${Size.Border.Small} solid ${({ theme }) => theme.palette.divider};
+  border-bottom: ${Size.Border.Small} solid
+    ${({ theme }) => theme.palette.divider};
+  background-color: ${({ theme }) => theme.palette.gray.highlight};
 `;

--- a/src/components/DataTable/internal/CellRadio/styled.ts
+++ b/src/components/DataTable/internal/CellRadio/styled.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Size } from "../../../../styles";
 
 const CELL_PADDING = 24;
 
@@ -15,4 +16,8 @@ export const HeaderCell = styled.th`
   padding: ${({ theme }) => theme.spacing * 2}px 0
     ${({ theme }) => theme.spacing * 2 - 2}px
     ${({ theme }) => theme.spacing * 3}px;
+  border-top: ${Size.Border.Small} solid ${({ theme }) => theme.palette.divider};
+  border-bottom: ${Size.Border.Small} solid
+    ${({ theme }) => theme.palette.divider};
+  background-color: ${({ theme }) => theme.palette.gray.highlight};
 `;

--- a/src/components/DataTable/internal/SortableHeaderCell/styled.ts
+++ b/src/components/DataTable/internal/SortableHeaderCell/styled.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Size } from "../../../../styles";
 
 type CellProps = {
   width: string;
@@ -6,11 +7,15 @@ type CellProps = {
 };
 
 export const HeaderCell = styled.th<CellProps>`
+  cursor: ${({ isSortable }) => (isSortable ? "pointer" : "default")};
   width: ${({ width }) => width};
   padding: ${({ theme }) => theme.spacing * 2}px
     ${({ theme }) => theme.spacing * 3}px
     ${({ theme }) => theme.spacing * 2 - 2}px;
-  cursor: ${({ isSortable }) => (isSortable ? "pointer" : "default")};
+  border-top: ${Size.Border.Small} solid ${({ theme }) => theme.palette.divider};
+  border-bottom: ${Size.Border.Small} solid
+    ${({ theme }) => theme.palette.divider};
+  background-color: ${({ theme }) => theme.palette.gray.highlight};
 `;
 
 export const IconContainer = styled.div`

--- a/src/components/DataTable/internal/Table/Cell.tsx
+++ b/src/components/DataTable/internal/Table/Cell.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
 import styled from "styled-components";
 
-import Typography from "../../../Typography";
 import { Size } from "../../../../styles/size";
-import { colors } from "../../../../styles/color";
 
 type CellProps = {
   width: string;
 };
 
-const StandardCell = styled.td<CellProps>`
+const Component = styled.td<CellProps>`
   width: ${({ width }) => width};
   padding: ${({ theme }) => theme.spacing * 2}px
     ${({ theme }) => theme.spacing * 3}px;
@@ -17,39 +15,19 @@ const StandardCell = styled.td<CellProps>`
     ${({ theme }) => theme.palette.gray.light};
 `;
 
-const HeaderCell = styled.th<CellProps>`
-  width: ${({ width }) => width};
-  padding: ${({ theme }) => theme.spacing * 2}px
-    ${({ theme }) => theme.spacing * 3}px
-    ${({ theme }) => theme.spacing * 2 - 2}px;
-  background-color: ${colors.basic[100]};
-  border-bottom: ${Size.Border.Normal} solid
-    ${({ theme }) => theme.palette.gray.light};
-`;
-
-export type Props = React.TdHTMLAttributes<HTMLTableDataCellElement> &
-  React.ThHTMLAttributes<HTMLTableHeaderCellElement> & {
-    header?: boolean;
-    width?: string;
-    children?: React.ReactNode;
-  };
+export type Props = React.TdHTMLAttributes<HTMLTableDataCellElement> & {
+  width?: string;
+  children?: React.ReactNode;
+};
 
 export const Cell: React.FunctionComponent<Props> = ({
-  header = false,
   width = "auto",
   children,
   ...rest
 }) => {
-  const Component = header ? HeaderCell : StandardCell;
   return (
     <Component width={width} {...rest}>
-      {header ? (
-        <Typography color="secondary" weight="bold" size="md">
-          {children}
-        </Typography>
-      ) : (
-        children
-      )}
+      {children}
     </Component>
   );
 };

--- a/src/components/DataTable/internal/Table/Header.tsx
+++ b/src/components/DataTable/internal/Table/Header.tsx
@@ -1,16 +1,7 @@
 import * as React from "react";
-import styled from "styled-components";
-import { Size } from "../../../../styles";
 
 export type Props = {};
 
-const Component = styled.thead`
-  border-top: ${Size.Border.Small} solid ${({ theme }) => theme.palette.divider};
-  border-bottom: ${Size.Border.Small} solid
-    ${({ theme }) => theme.palette.divider};
-  background-color: ${({ theme }) => theme.palette.gray.highlight};
-`;
-
 export const Header: React.FunctionComponent<Props> = ({ children }) => (
-  <Component>{children}</Component>
+  <thead>{children}</thead>
 );


### PR DESCRIPTION
`position: sticky`を当てる事ができる`<th />`にbackgroundやborderを当てる事で、利用者側が見出し行の固定スクロールを実装できるようにする。