### PR TITLE
SecondaryButtonの背景色を修正

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -47,7 +47,7 @@ const getContainerColorStyles = (
   },
   secondary: {
     normal: {
-      background: "transparent",
+      background: theme.palette.white,
       color: theme.palette.black,
       boxShadow: "none",
       border: `${Size.Border.Small} solid ${theme.palette.divider}`,


### PR DESCRIPTION
SecondaryButtonの背景色が `transparent` になっているのを `theme.palette.white` に修正