### PR TITLE
<NavigationRails />, <ContextMenu />の微調整

### DIFF
--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
+import * as Styled from "./styled";
 import * as PopperJS from "@popperjs/core";
 import { ContentProp } from "../MenuList/MenuList";
-import ActionButton from "../ActionButton";
 import Menu from "../Menu";
 
 type Props = {
@@ -25,7 +25,7 @@ const ContextMenu: React.FunctionComponent<Props> = ({
 
   return (
     <>
-      <ActionButton
+      <Styled.ActionButton
         ref={setIconWrapperElement}
         data-testid="icon-wrapper"
         icon="more_vert"

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ContextMenu component testing ContextMenu 1`] = `
 <DocumentFragment>
   <button
-    class="sc-AxjAm jXWceb"
+    class="sc-AxjAm jXWceb sc-AxhUy kFchZA"
     data-testid="icon-wrapper"
   >
     <div
@@ -36,41 +36,41 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     />
   </button>
   <div
-    class="sc-AxmLO kBckan"
+    class="sc-fzozJi jXQLm"
   >
     <div
-      class="sc-AxhUy kMyssT"
+      class="sc-AxgMl fFPQpl"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
       style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
     >
       <div
-        class="sc-AxgMl cjBIvb"
+        class="sc-AxheI eiSJQV"
       >
         <hr
-          class="sc-Axmtr bybBIf"
+          class="sc-AxmLO iPeyVm"
         />
         <div
-          class="sc-AxheI gETZIx"
+          class="sc-Axmtr euYqaa"
         >
           保存する
         </div>
         <div
-          class="sc-AxheI gETZIx"
+          class="sc-Axmtr euYqaa"
         >
           保存して実行する
         </div>
         <hr
-          class="sc-Axmtr bybBIf"
+          class="sc-AxmLO iPeyVm"
         />
         <div
-          class="sc-AxheI gETZIx"
+          class="sc-Axmtr euYqaa"
         >
           下書きとして保存する
         </div>
         <div
-          class="sc-AxheI gETZIx"
+          class="sc-Axmtr euYqaa"
         >
           やっぱり何もしない
         </div>

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -39,38 +39,38 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     class="sc-fzozJi jXQLm"
   >
     <div
-      class="sc-AxgMl fFPQpl"
+      class="sc-AxmLO kcpTOR"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
       style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
     >
       <div
-        class="sc-AxheI eiSJQV"
+        class="sc-AxgMl daAZqM"
       >
         <hr
-          class="sc-AxmLO iPeyVm"
+          class="sc-Axmtr bybBIf"
         />
         <div
-          class="sc-Axmtr euYqaa"
+          class="sc-AxheI gETZIx"
         >
           保存する
         </div>
         <div
-          class="sc-Axmtr euYqaa"
+          class="sc-AxheI gETZIx"
         >
           保存して実行する
         </div>
         <hr
-          class="sc-AxmLO iPeyVm"
+          class="sc-Axmtr bybBIf"
         />
         <div
-          class="sc-Axmtr euYqaa"
+          class="sc-AxheI gETZIx"
         >
           下書きとして保存する
         </div>
         <div
-          class="sc-Axmtr euYqaa"
+          class="sc-AxheI gETZIx"
         >
           やっぱり何もしない
         </div>

--- a/src/components/ContextMenu/styled.ts
+++ b/src/components/ContextMenu/styled.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+import OriginalActionButton from "../ActionButton";
+
+export const ActionButton = styled(OriginalActionButton)`
+  width: 34px;
+  height: 34px;
+`;

--- a/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
+++ b/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
@@ -37,7 +37,7 @@ const ExpantionMenu: React.FC<Props> = ({
     if (!textWrapperElement.current || !textElement.current) return;
     const wrapperWidth = textWrapperElement.current.offsetWidth;
     const textWidth = textElement.current.offsetWidth;
-    setShowTooltip(wrapperWidth < textWidth);
+    setShowTooltip(wrapperWidth === textWidth);
   }, [textWrapperElement, textElement]);
 
   const onHandleClick = (
@@ -77,13 +77,13 @@ const ExpantionMenu: React.FC<Props> = ({
             type={isActive ? "fill" : "line"}
             color={isActive ? "active" : "line"}
           />
-          <Styled.TextWrapper
+          <Styled.TextContainer
             ref={textWrapperElement}
             isActive={isActive}
             isOpen={isOpen}
           >
-            <span ref={textElement}>{title}</span>
-          </Styled.TextWrapper>
+            <Styled.TextWrapper ref={textElement}>{title}</Styled.TextWrapper>
+          </Styled.TextContainer>
           <Styled.ArrowIconWrapper isExpand={isExpand} isOpen={isOpen}>
             <Icon
               name="arrow_bottom"

--- a/src/components/NavigationRail/ExpantionMenu/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenu/styled.ts
@@ -65,7 +65,7 @@ type ExpantionProps = {
 export const Expantion = styled.div<ExpantionProps>`
   width: ${NavigationRailWidth.WIDE};
   overflow-y: hidden;
-  padding-left: ${({ theme }) => theme.spacing * 7}px;
+  /* padding-left: ${({ theme }) => theme.spacing * 7}px; */
   max-height: ${({ isExpand, height }) => (isExpand ? height : "0px")};
   transition: max-height 0.3s
     ${({ delay }) => (delay ? NavigationRailTransitionDuration : 0)}s;

--- a/src/components/NavigationRail/ExpantionMenu/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenu/styled.ts
@@ -26,18 +26,24 @@ export const Container = styled.div<{ isActive: boolean }>`
   }
 `;
 
-export const TextWrapper = styled.div<{ isActive: boolean; isOpen: boolean }>`
+export const TextContainer = styled.div<{ isActive: boolean; isOpen: boolean }>`
   flex-shrink: 1;
   flex-grow: 1;
+  display: flex;
+  align-items: center;
   margin-left: ${({ theme }) => theme.spacing * 1.5}px;
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   color: ${({ theme, isActive }) =>
     theme.palette.text[isActive ? "primary" : "secondary"]};
   font-weight: bold;
+  transition: opacity ${NavigationRailTransitionDuration}s;
+  min-width: 0;
+`;
+
+export const TextWrapper = styled.span`
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: opacity ${NavigationRailTransitionDuration}s;
 `;
 
 export const ArrowIconWrapper = styled.div<{

--- a/src/components/NavigationRail/ExpantionMenu/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenu/styled.ts
@@ -65,7 +65,6 @@ type ExpantionProps = {
 export const Expantion = styled.div<ExpantionProps>`
   width: ${NavigationRailWidth.WIDE};
   overflow-y: hidden;
-  /* padding-left: ${({ theme }) => theme.spacing * 7}px; */
   max-height: ${({ isExpand, height }) => (isExpand ? height : "0px")};
   transition: max-height 0.3s
     ${({ delay }) => (delay ? NavigationRailTransitionDuration : 0)}s;

--- a/src/components/NavigationRail/ExpantionMenuItem/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenuItem/styled.ts
@@ -12,8 +12,6 @@ export const Container = styled.div<{ isActive: boolean }>`
   white-space: nowrap;
 
   &:hover {
-    /* color: ${({ theme, isActive }) =>
-      isActive ? theme.palette.text.primary : theme.palette.gray.deepDark}; */
-    background-color: ${({ theme }) => theme.palette.gray.highlight};
+    background-color: ${({ theme }) => theme.palette.gray.light};
   }
 `;

--- a/src/components/NavigationRail/ExpantionMenuItem/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenuItem/styled.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 export const Container = styled.div<{ isActive: boolean }>`
   cursor: pointer;
   padding: ${({ theme }) => theme.spacing * 2}px 0;
+  padding-left: ${({ theme }) => theme.spacing * 7}px;
   color: ${({ theme, isActive }) =>
     isActive ? theme.palette.text.primary : theme.palette.gray.dark};
   font-weight: ${({ isActive }) => (isActive ? "bold" : "normal")};
@@ -11,7 +12,8 @@ export const Container = styled.div<{ isActive: boolean }>`
   white-space: nowrap;
 
   &:hover {
-    color: ${({ theme, isActive }) =>
-      isActive ? theme.palette.text.primary : theme.palette.gray.deepDark};
+    /* color: ${({ theme, isActive }) =>
+      isActive ? theme.palette.text.primary : theme.palette.gray.deepDark}; */
+    background-color: ${({ theme }) => theme.palette.gray.highlight};
   }
 `;

--- a/src/components/NavigationRail/ExpantionMenuItem/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenuItem/styled.ts
@@ -4,13 +4,14 @@ export const Container = styled.div<{ isActive: boolean }>`
   cursor: pointer;
   padding: ${({ theme }) => theme.spacing * 2}px 0;
   color: ${({ theme, isActive }) =>
-    theme.palette.text[isActive ? "primary" : "secondary"]};
+    isActive ? theme.palette.text.primary : theme.palette.gray.dark};
   font-weight: ${({ isActive }) => (isActive ? "bold" : "normal")};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 
   &:hover {
-    font-weight: bold;
+    color: ${({ theme, isActive }) =>
+      isActive ? theme.palette.text.primary : theme.palette.gray.deepDark};
   }
 `;

--- a/src/components/NavigationRail/Menu/Menu.tsx
+++ b/src/components/NavigationRail/Menu/Menu.tsx
@@ -47,13 +47,13 @@ const Menu: React.FC<Props> = ({
           type={isActive ? "fill" : "line"}
           color={isActive ? "active" : "line"}
         />
-        <Styled.TextWrapper
+        <Styled.TextContainer
           ref={textWrapperElement}
           isActive={isActive}
           isOpen={isOpen}
         >
-          <span ref={textElement}>{title}</span>
-        </Styled.TextWrapper>
+          <Styled.TextWrapper ref={textElement}>{title}</Styled.TextWrapper>
+        </Styled.TextContainer>
       </Styled.Container>
     </Tooltip>
   );

--- a/src/components/NavigationRail/Menu/styled.ts
+++ b/src/components/NavigationRail/Menu/styled.ts
@@ -26,16 +26,21 @@ export const Container = styled.div<{ isActive: boolean }>`
   }
 `;
 
-export const TextWrapper = styled.div<{ isActive: boolean; isOpen: boolean }>`
+export const TextContainer = styled.div<{ isActive: boolean; isOpen: boolean }>`
   flex-shrink: 1;
   flex-grow: 1;
+  display: flex;
+  align-items: center;
   margin-left: ${({ theme }) => theme.spacing * 1.5}px;
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   color: ${({ theme, isActive }) =>
     theme.palette.text[isActive ? "primary" : "secondary"]};
   font-weight: bold;
+  transition: opacity ${NavigationRailTransitionDuration}s;
+`;
+
+export const TextWrapper = styled.span`
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: opacity ${NavigationRailTransitionDuration}s;
 `;

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
         class="sc-AxhCb ekArAs"
       >
         <div
-          class="sc-fzplWN iyOXxP"
+          class="sc-fznyAO geGOcr"
         >
           <div
             class="sc-Axmtr kFYDZB"
@@ -38,14 +38,16 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             </svg>
           </div>
           <div
-            class="sc-fznyAO jDMidI"
+            class="sc-fznKkj kmYbJA"
           >
-            <span>
+            <span
+              class="sc-fznZeY cikGgr"
+            >
               設定
             </span>
           </div>
           <div
-            class="sc-fznKkj bbjLMi"
+            class="sc-fzokOt jYfWMZ"
           >
             <div
               class="sc-Axmtr kFYDZB"
@@ -68,11 +70,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           </div>
         </div>
         <div
-          class="sc-fznZeY tgBeZ"
+          class="sc-fzqBZW kahCET"
           height="auto"
         >
           <div
-            class="sc-fzokOt ehXjaF"
+            class="sc-fzqNJr hyWsTZ"
           >
             <span>
               デマンド設定
@@ -101,9 +103,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             </svg>
           </div>
           <div
-            class="sc-fzpans hXReIC"
+            class="sc-fzpans gnGizh"
           >
-            <span>
+            <span
+              class="sc-fzplWN gSMKae"
+            >
               ダッシュボード
             </span>
           </div>

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -70,11 +70,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           </div>
         </div>
         <div
-          class="sc-fzqBZW dXKHeL"
+          class="sc-fzqBZW gjtFVr"
           height="auto"
         >
           <div
-            class="sc-fzqNJr kWqUjT"
+            class="sc-fzqNJr ejpWaH"
           >
             <span>
               デマンド設定

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -70,11 +70,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           </div>
         </div>
         <div
-          class="sc-fzqBZW kahCET"
+          class="sc-fzqBZW dXKHeL"
           height="auto"
         >
           <div
-            class="sc-fzqNJr hyWsTZ"
+            class="sc-fzqNJr kWqUjT"
           >
             <span>
               デマンド設定


### PR DESCRIPTION
### やったこと
- NavigationRails
  - アイコン横のテキストの縦方向を中央に寄せる(↓ずれてる図)
![image](https://user-images.githubusercontent.com/40020812/84721233-24d67100-afbb-11ea-8359-2e0bd4b6409b.png)

  - `<ExpantionMenuItem />`をhover時に色を変える
    - `font-weight: bold;`ではなく、`background-color: background-color: ${({ theme }) => theme.palette.gray.light};`にした。(画像の下の部分のコンポーネント)
![image](https://user-images.githubusercontent.com/40020812/84721391-88609e80-afbb-11ea-80d2-1f0e06f503a1.png)


- ContextMenu
  - width, heightを固定する
    - 長方形になってしまっている↓ので、34x34pxの正方形にした。
![image](https://user-images.githubusercontent.com/40020812/84721447-a5956d00-afbb-11ea-8f05-fa1f197f08e2.png)
