### PR TITLE
DropdownButtonにSecondaryThemeを追加

### DIFF
--- a/src/components/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/DropdownButton/DropdownButton.stories.tsx
@@ -43,6 +43,15 @@ export const Overview = () => {
     "medium",
   );
 
+  const color = select(
+    "Color",
+    {
+      Primary: "primary",
+      Secondary: "secondary",
+    },
+    "primary",
+  );
+
   const contents = [
     {
       text: "保存する",
@@ -66,12 +75,18 @@ export const Overview = () => {
   return (
     <Container>
       <Inner>
-        <DropdownButton disabled={disabled} size={size} contents={contents}>
+        <DropdownButton
+          disabled={disabled}
+          color={color}
+          size={size}
+          contents={contents}
+        >
           {title}
         </DropdownButton>
         <Spacer pr={40} />
         <DropdownButton
           disabled={disabled}
+          color={color}
           split={true}
           size={size}
           contents={contents}

--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -4,11 +4,14 @@ import * as PopperJS from "@popperjs/core";
 import { useTheme } from "../../themes";
 import Icon from "../Icon";
 import Menu from "../Menu";
-import { ButtonSize } from "../Button/Button";
+import { ButtonSize, ButtonColor } from "../Button/Button";
 import { ContentProp } from "../MenuList/MenuList";
+
+type DropdownButtonColor = Exclude<ButtonColor, "danger">;
 
 type Props = {
   size?: ButtonSize;
+  color?: DropdownButtonColor;
   onClick?: () => void;
   split?: boolean;
   contents: ContentProp[];
@@ -18,6 +21,7 @@ type Props = {
 
 const DropdownButton: React.FC<Props> = ({
   size = "medium",
+  color = "primary",
   onClick,
   split = false,
   contents,
@@ -39,6 +43,16 @@ const DropdownButton: React.FC<Props> = ({
     setShowContent(showContent);
   };
 
+  const setIconColor = (disabled: boolean, color: DropdownButtonColor) => {
+    if (disabled) {
+      return theme.palette.text.disabled;
+    } else if (color === "primary") {
+      return theme.palette.white;
+    } else {
+      return "fill";
+    }
+  };
+
   return (
     <>
       <Styled.ButtonContainer ref={setButtonElement} role="button">
@@ -46,6 +60,7 @@ const DropdownButton: React.FC<Props> = ({
           <>
             <Styled.MainButton
               size={size}
+              color={color}
               inline={true}
               disabled={disabled}
               onClick={onClick}
@@ -54,6 +69,7 @@ const DropdownButton: React.FC<Props> = ({
             </Styled.MainButton>
             <Styled.SplitToggle
               size={size}
+              color={color}
               inline={true}
               disabled={disabled}
               data-testid="menu-toggle"
@@ -62,15 +78,14 @@ const DropdownButton: React.FC<Props> = ({
               <Icon
                 name={"arrow_bottom"}
                 size="lg"
-                color={
-                  disabled ? theme.palette.text.disabled : theme.palette.white
-                }
+                color={setIconColor(disabled, color)}
               />
             </Styled.SplitToggle>
           </>
         ) : (
           <Styled.SingleButton
             size={size}
+            color={color}
             disabled={disabled}
             data-testid="menu-toggle"
             onClick={onHandleToggleContent(!showContent)}
@@ -79,9 +94,7 @@ const DropdownButton: React.FC<Props> = ({
             <Icon
               name={"arrow_bottom"}
               size="lg"
-              color={
-                disabled ? theme.palette.text.disabled : theme.palette.white
-              }
+              color={setIconColor(disabled, color)}
             />
           </Styled.SingleButton>
         )}

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy eZxGGB"
+      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -157,7 +157,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl dYeuxs"
+      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -194,7 +194,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy eZxGGB"
+      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -202,7 +202,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl dYeuxs"
+      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/styled.ts
+++ b/src/components/DropdownButton/styled.ts
@@ -8,12 +8,17 @@ export const ButtonContainer = styled.div`
 export const MainButton = styled(Button)`
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
+  border-right: none;
 `;
 
 export const SplitToggle = styled(Button)`
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
-  border-left: 1px solid ${({ theme }) => theme.palette.primary.deepDark};
+  border-left: 1px solid
+    ${({ theme, color }) =>
+      color === "primary"
+        ? theme.palette.primary.deepDark
+        : theme.palette.divider};
   padding: 0 ${({ theme, size }) => (size === "small" ? 0 : theme.spacing)}px;
   min-width: auto;
   &:disabled {


### PR DESCRIPTION
* DropdownButtonのテーマがprimaryだけだと派手すぎてページに合わない場合があるので、落ち着いたデザインとして secondary も追加する

実際のSecondaryテーマ ↓
![スクリーンショット 2020-06-22 16 13 02](https://user-images.githubusercontent.com/11240481/85259009-4778f600-b4a3-11ea-9e5f-458ee494fc92.png)
