### PR TITLE
inputのstory内のゴシガルトークを"textfield"へ変更

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -59,7 +59,7 @@ export const Overview = () => {
             Typed
           </Typography>
           <Spacer pt={2} />
-          <Input value="ゴシガルトーク" readOnly={true} />
+          <Input value="Textfield" readOnly={true} />
         </Column>
         <Column>
           <Typography weight="bold" size="xxl">
@@ -73,7 +73,7 @@ export const Overview = () => {
             Typed &amp; Disabled
           </Typography>
           <Spacer pt={2} />
-          <Input value="ゴシガルトーク" readOnly={true} disabled={true} />
+          <Input value="Textfield" readOnly={true} disabled={true} />
         </Column>
       </RowContainer>
       <RowContainer>


### PR DESCRIPTION
storyのテストテキスト内に"ゴシガルトーク"がまだ残っていたので修正
INGRED UI内を検索して全部修正したのでもう大丈夫のはずです

[経緯](https://cartaholdings.slack.com/archives/CKYAWNNLX/p1593043728238000)