### PR TITLE
ButtonGroup が<Button component={Link} />の形式も受け入れるようにする

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -100,6 +100,7 @@ export type Props = Omit<BaseButtonProps, "color"> & {
     | React.ComponentType<{ className: string }>;
   color?: ButtonColor;
   inline?: boolean;
+  disabled?: boolean;
   size?: ButtonSize;
   onClick?: () => void;
   href?: string;
@@ -110,6 +111,7 @@ const Button: React.FunctionComponent<Props> = ({
   children,
   color = "primary",
   inline = false,
+  disabled = false,
   size = "medium",
   href,
   ...rest
@@ -142,6 +144,7 @@ const Button: React.FunctionComponent<Props> = ({
       fontSize={
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
+      className={disabled ? "disabled" : ""}
       height={buttonSize[size].height}
       minWidth={buttonSize[size].minWidth}
     >

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-AxirZ sc-AxiKw jfPFaf"
+    class="sc-AxirZ sc-AxiKw erQJEi"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-AxirZ sc-AxiKw erQJEi"
+    class="sc-AxirZ sc-AxiKw wsLGD"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -13,7 +13,6 @@ export type ContainerProps = ButtonColorStyle & {
   horizontalPadding: string;
   minWidth: string;
   href?: string;
-  disabled?: boolean;
 };
 
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
@@ -26,21 +25,22 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${Radius.SMALL};
-  border: ${({ normal, disabled }) =>
-    disabled
-      ? `${Size.Border.Small} solid ${colors.basic[100]}`
-      : normal.border};
-  background: ${({ normal, disabled }) =>
-    disabled ? colors.basic[100] : normal.background};
-  color: ${({ normal, disabled, theme }) =>
-    disabled ? theme.palette.text.disabled : normal.color};
+  border: ${({ normal }) => normal.border};
+  background: ${({ normal }) => normal.background};
+  color: ${({ normal }) => normal.color};
   text-align: center;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-size: ${({ fontSize }) => fontSize};
-  box-shadow: ${({ normal, disabled }) =>
-    disabled ? "none" : normal.boxShadow};
+  box-shadow: ${({ normal }) => normal.boxShadow};
   transition: all 0.3s;
-  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
+
+  &.disabled {
+    border: ${Size.Border.Small} solid ${colors.basic[100]};
+    background: ${colors.basic[100]};
+    color: ${({ theme }) => theme.palette.text.disabled};
+    box-shadow: none;
+    pointer-events: none;
+  }
 
   &:hover {
     background: ${({ hover }) => hover.background};

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -12,6 +12,7 @@ export type ContainerProps = ButtonColorStyle & {
   horizontalPadding: string;
   minWidth: string;
   href?: string;
+  disabled?: boolean;
 };
 
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
@@ -24,14 +25,18 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${Radius.SMALL};
-  border: ${({ normal }) => normal.border};
-  background: ${({ normal }) => normal.background};
-  color: ${({ normal }) => normal.color};
+  border: ${({ normal, disabled }) => (disabled ? 0 : normal.border)};
+  background: ${({ normal, disabled }) =>
+    disabled ? colors.basic[100] : normal.background};
+  color: ${({ normal, disabled, theme }) =>
+    disabled ? theme.palette.text.disabled : normal.color};
   text-align: center;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-size: ${({ fontSize }) => fontSize};
-  box-shadow: ${({ normal }) => normal.boxShadow};
+  box-shadow: ${({ normal, disabled }) =>
+    disabled ? "none" : normal.boxShadow};
   transition: all 0.3s;
+  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
 
   &:hover {
     background: ${({ hover }) => hover.background};
@@ -40,11 +45,5 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   &:active {
     background: ${({ active }) => active.background};
     box-shadow: none;
-  }
-
-  &:disabled {
-    background-color: ${colors.basic[100]};
-    color: ${({ theme }) => theme.palette.text.disabled};
-    border: 0;
   }
 `;

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -3,6 +3,7 @@ import { Radius } from "../../styles";
 import { colors } from "../../styles/color";
 import { BaseButton } from "./internal/BaseButton";
 import { ButtonColorStyle } from "./Button";
+import { Size } from "../../styles/size";
 
 export type ContainerProps = ButtonColorStyle & {
   inline: boolean;
@@ -25,7 +26,10 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${Radius.SMALL};
-  border: ${({ normal, disabled }) => (disabled ? 0 : normal.border)};
+  border: ${({ normal, disabled }) =>
+    disabled
+      ? `${Size.Border.Small} solid ${colors.basic[100]}`
+      : normal.border};
   background: ${({ normal, disabled }) =>
     disabled ? colors.basic[100] : normal.background};
   color: ${({ normal, disabled, theme }) =>

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -47,6 +47,16 @@ export const Overview = () => {
     false,
   );
   const smallButtonLeft = boolean("Small Button Left Disable", false);
+  const linkButtonRight = boolean("Link Mixed Button Right Disable", false);
+  const linkButtonCenterLeft = boolean(
+    "Link Mixed Button Center Left Disable",
+    false,
+  );
+  const linkButtonCenterRight = boolean(
+    "Link Mixed Button Center Right Disable",
+    false,
+  );
+  const linkButtonLeft = boolean("Link Mixed Button Left Disable", false);
   return (
     <Container>
       <Typography weight="bold" size="xxl">
@@ -88,10 +98,18 @@ export const Overview = () => {
       </Typography>
       <RowContainer>
         <ButtonGroup size="small">
-          <Button component={Link}>保存する</Button>
-          <Button onClick={action("clicked")}>編集する</Button>
-          <Button component={Link}>削除する</Button>
-          <Button onClick={action("clicked")}>キャンセル</Button>
+          <Button disabled={linkButtonRight} component={Link}>
+            保存する
+          </Button>
+          <Button disabled={linkButtonCenterLeft} onClick={action("clicked")}>
+            編集する
+          </Button>
+          <Button disabled={linkButtonCenterRight} component={Link}>
+            削除する
+          </Button>
+          <Button disabled={linkButtonLeft} onClick={action("clicked")}>
+            キャンセル
+          </Button>
         </ButtonGroup>
       </RowContainer>
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -17,6 +17,16 @@ const RowContainer = styled.div`
   background-color: ${({ theme }) => theme.palette.background.default};
 `;
 
+const Link: React.FunctionComponent<{ href: string; className: string }> = ({
+  href,
+  className,
+  children,
+}) => (
+  <a href={href} className={className} onClick={action("clicked")}>
+    {children}
+  </a>
+);
+
 export default {
   title: "ButtonGroup",
   parameters: {
@@ -70,6 +80,18 @@ export const Overview = () => {
           <Button disabled={smallButtonLeft} onClick={action("clicked")}>
             キャンセル
           </Button>
+        </ButtonGroup>
+      </RowContainer>
+
+      <Typography weight="bold" size="xxl">
+        Link Mixed
+      </Typography>
+      <RowContainer>
+        <ButtonGroup size="small">
+          <Button component={Link}>保存する</Button>
+          <Button onClick={action("clicked")}>編集する</Button>
+          <Button component={Link}>削除する</Button>
+          <Button onClick={action("clicked")}>キャンセル</Button>
         </ButtonGroup>
       </RowContainer>
 

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Button component testing ButtonGroup 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm gQMLdB"
+    class="sc-AxjAm fUhBap"
     height="42px"
   >
     <button
-      class="sc-AxiKw sc-AxhCb bvHiqS"
+      class="sc-AxiKw sc-AxhCb gkGwNf"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       編集する
     </button>
     <button
-      class="sc-AxiKw sc-AxhCb bvHiqS"
+      class="sc-AxiKw sc-AxhCb gkGwNf"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Button component testing ButtonGroup 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm bYPLHT"
+    class="sc-AxjAm gQMLdB"
     height="42px"
   >
     <button
-      class="sc-AxiKw sc-AxhCb hgPQYb"
+      class="sc-AxiKw sc-AxhCb bvHiqS"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       編集する
     </button>
     <button
-      class="sc-AxiKw sc-AxhCb hgPQYb"
+      class="sc-AxiKw sc-AxhCb bvHiqS"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ButtonGroup/styled.ts
+++ b/src/components/ButtonGroup/styled.ts
@@ -18,11 +18,6 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
     padding-left: ${({ horizontalPadding }) => horizontalPadding};
   }
 
-  & > *:disabled + & > *:not(:disabled) {
-    border-left: ${Size.Border.Small} solid
-      ${({ theme }) => theme.palette.divider};
-  }
-
   & > *:not(:last-child) {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
@@ -37,5 +32,10 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
   & > *:last-child {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
+  }
+
+  & > *.disabled + *:not(.disabled) {
+    border-left: ${Size.Border.Small} solid
+      ${({ theme }) => theme.palette.divider};
   }
 `;

--- a/src/components/ButtonGroup/styled.ts
+++ b/src/components/ButtonGroup/styled.ts
@@ -10,7 +10,7 @@ export type ContainerProps = {
 export const ButtonGroupContainer = styled.div<ContainerProps>`
   display: inline-flex;
 
-  button {
+  & > * {
     min-width: ${({ minWidth }) => minWidth};
     width: auto;
     height: ${({ height }) => height};
@@ -18,23 +18,23 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
     padding-left: ${({ horizontalPadding }) => horizontalPadding};
   }
 
-  button:disabled + button:not(:disabled) {
+  & > *:disabled + & > *:not(:disabled) {
     border-left: ${Size.Border.Small} solid
       ${({ theme }) => theme.palette.divider};
   }
 
-  button:not(:last-of-type) {
+  & > *:not(:last-child) {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
   }
 
-  button:not(:first-of-type) {
+  & > *:not(:first-child) {
     border-left: none;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }
 
-  button:last-of-type {
+  & > *:last-child {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -54,6 +54,8 @@ const sampleData: SampleObject[] = [
   { id: 14, name: "9name", count: 1 },
 ];
 
+const sampleEmptyData: SampleObject[] = [];
+
 export const Overview = () => (
   <Container>
     <DataTable
@@ -299,7 +301,7 @@ export const WithStickyHeader = () => (
 export const WithEmptyTable = () => (
   <Container>
     <DataTable
-      data={[]}
+      data={sampleEmptyData}
       defaultSortField="名前"
       defaultSortOrder="desc"
       columns={[

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,9 +7,8 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw bpPlZY sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw wsLGD disabled"
       data-testid="menu-toggle"
-      disabled=""
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -45,7 +44,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw erQJEi sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw wsLGD"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -148,8 +147,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw kNnsvD sc-AxhUy bnlmnx"
-      disabled=""
+      class="sc-AxirZ sc-AxiKw ibzKfU disabled"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -157,9 +155,8 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw kNnsvD sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw ibzKfU disabled"
       data-testid="menu-toggle"
-      disabled=""
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -194,7 +191,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw eaEofR sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw ibzKfU"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -202,7 +199,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw eaEofR sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw ibzKfU"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw jfPFaf sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw lgHryL sc-AxheI cbsHKE"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -45,7 +45,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw jfPFaf sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw erQJEi sc-AxheI cbsHKE"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -148,7 +148,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw csWLbM sc-AxhUy bnlmnx"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -157,7 +157,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw csWLbM sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -194,7 +194,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw eaEofR sc-AxhUy bnlmnx"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -202,7 +202,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw eaEofR sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw lgHryL sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw bpPlZY sc-AxheI cbsHKE"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -148,7 +148,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw csWLbM sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw kNnsvD sc-AxhUy bnlmnx"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -157,7 +157,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw csWLbM sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw kNnsvD sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"


### PR DESCRIPTION
close #84 

* `<Button component={Link} />` 時の disabled-style 対応の修正も含む
* DataTableのstoryの微修正も含む(emptyTableの配列エラーの対応)