### PR TITLE
ButtonGroup が<Button component={Link} />の形式も受け入れるようにする(やり直し)

### DIFF
--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-AxirZ sc-AxiKw jfPFaf"
+    class="sc-AxirZ sc-AxiKw gRAqhe"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -12,6 +12,7 @@ export type ContainerProps = ButtonColorStyle & {
   horizontalPadding: string;
   minWidth: string;
   href?: string;
+  disabled?: boolean;
 };
 
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
@@ -24,13 +25,17 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${Radius.SMALL};
-  border: ${({ normal }) => normal.border};
-  background: ${({ normal }) => normal.background};
-  color: ${({ normal }) => normal.color};
+  border: ${({ normal, disabled }) => (disabled ? 0 : normal.border)};
+  background: ${({ normal, disabled }) =>
+    disabled ? colors.basic[100] : normal.background};
+  color: ${({ normal, disabled, theme }) =>
+    disabled ? theme.palette.text.disabled : normal.color};
   text-align: center;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-size: ${({ fontSize }) => fontSize};
-  box-shadow: ${({ normal }) => normal.boxShadow};
+  box-shadow: ${({ normal, disabled }) =>
+    disabled ? "none" : normal.boxShadow};
+  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
   transition: all 0.3s;
 
   &:hover {
@@ -40,11 +45,5 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   &:active {
     background: ${({ active }) => active.background};
     box-shadow: none;
-  }
-
-  &:disabled {
-    background-color: ${colors.basic[100]};
-    color: ${({ theme }) => theme.palette.text.disabled};
-    border: 0;
   }
 `;

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -17,6 +17,16 @@ const RowContainer = styled.div`
   background-color: ${({ theme }) => theme.palette.background.default};
 `;
 
+const Link: React.FunctionComponent<{ href: string; className: string }> = ({
+  href,
+  className,
+  children,
+}) => (
+  <a href={href} className={className} onClick={action("clicked")}>
+    {children}
+  </a>
+);
+
 export default {
   title: "ButtonGroup",
   parameters: {
@@ -37,6 +47,17 @@ export const Overview = () => {
     false,
   );
   const smallButtonLeft = boolean("Small Button Left Disable", false);
+  const linkButtonRight = boolean("Link Mixed Button Right Disable", false);
+  const linkButtonCenterLeft = boolean(
+    "Link Mixed Button Center Left Disable",
+    false,
+  );
+  const linkButtonCenterRight = boolean(
+    "Link Mixed Button Center Right Disable",
+    false,
+  );
+  const linkButtonLeft = boolean("Link Mixed Button Left Disable", false);
+
   return (
     <Container>
       <Typography weight="bold" size="xxl">
@@ -68,6 +89,26 @@ export const Overview = () => {
             削除する
           </Button>
           <Button disabled={smallButtonLeft} onClick={action("clicked")}>
+            キャンセル
+          </Button>
+        </ButtonGroup>
+      </RowContainer>
+
+      <Typography weight="bold" size="xxl">
+        Link Mixed
+      </Typography>
+      <RowContainer>
+        <ButtonGroup size="small">
+          <Button disabled={linkButtonRight} component={Link}>
+            保存する
+          </Button>
+          <Button disabled={linkButtonCenterLeft} onClick={action("clicked")}>
+            編集する
+          </Button>
+          <Button disabled={linkButtonCenterRight} component={Link}>
+            削除する
+          </Button>
+          <Button disabled={linkButtonLeft} onClick={action("clicked")}>
             キャンセル
           </Button>
         </ButtonGroup>

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -21,8 +21,9 @@ const Link: React.FunctionComponent<{ href: string; className: string }> = ({
   href,
   className,
   children,
+  ...rest
 }) => (
-  <a href={href} className={className} onClick={action("clicked")}>
+  <a href={href} className={className} onClick={action("clicked")} {...rest}>
     {children}
   </a>
 );
@@ -102,7 +103,11 @@ export const Overview = () => {
           <Button disabled={linkButtonRight} component={Link}>
             保存する
           </Button>
-          <Button disabled={linkButtonCenterLeft} onClick={action("clicked")}>
+          <Button
+            disabled={linkButtonCenterLeft}
+            href="#"
+            onClick={action("clicked")}
+          >
             編集する
           </Button>
           <Button disabled={linkButtonCenterRight} component={Link}>

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as Styled from "./styled";
+import { Size } from "../../styles";
 import { ButtonSize } from "../Button/Button";
 import { useTheme } from "../../themes";
 
@@ -45,9 +46,25 @@ const ButtonGroup: React.FunctionComponent<Props> = ({
         color: "secondary",
       };
 
+  //直前のchildがdisabledだった場合にはborderLeftの設定を追加する
+  const childNeighborDisabledProps = {
+    ...childProps,
+    style: {
+      borderLeft: `${Size.Border.Small} solid ${theme.palette.divider}`,
+    },
+  };
+
+  let isBeforeChildDisabled = false;
+
   const childrenWithProps = React.Children.map(
     children,
     (child: React.ReactElement) => {
+      if (child.props.disabled) {
+        isBeforeChildDisabled = true;
+      } else if (isBeforeChildDisabled) {
+        isBeforeChildDisabled = false;
+        return React.cloneElement(child, childNeighborDisabledProps);
+      }
       return React.cloneElement(child, childProps);
     },
   );

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-AxiKw sc-AxhCb hgPQYb"
+      class="sc-AxiKw sc-AxhCb fPRoOm"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       編集する
     </button>
     <button
-      class="sc-AxiKw sc-AxhCb hgPQYb"
+      class="sc-AxiKw sc-AxhCb fPRoOm"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing ButtonGroup 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm bYPLHT"
+    class="sc-AxjAm iStGvd"
     height="42px"
   >
     <button

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing ButtonGroup 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm iStGvd"
+    class="sc-AxjAm fQkWDK"
     height="42px"
   >
     <button

--- a/src/components/ButtonGroup/styled.ts
+++ b/src/components/ButtonGroup/styled.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { Size } from "../../styles/size";
 
 export type ContainerProps = {
   height: string;
@@ -16,11 +15,6 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
     height: ${({ height }) => height};
     padding-right: ${({ horizontalPadding }) => horizontalPadding};
     padding-left: ${({ horizontalPadding }) => horizontalPadding};
-  }
-
-  *:disabled + *:not(:disabled) {
-    border-left: ${Size.Border.Small} solid
-      ${({ theme }) => theme.palette.divider};
   }
 
   & > *:not(:last-child) {

--- a/src/components/ButtonGroup/styled.ts
+++ b/src/components/ButtonGroup/styled.ts
@@ -10,7 +10,7 @@ export type ContainerProps = {
 export const ButtonGroupContainer = styled.div<ContainerProps>`
   display: inline-flex;
 
-  button {
+  & > * {
     min-width: ${({ minWidth }) => minWidth};
     width: auto;
     height: ${({ height }) => height};
@@ -18,23 +18,23 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
     padding-left: ${({ horizontalPadding }) => horizontalPadding};
   }
 
-  button:disabled + button:not(:disabled) {
+  *:disabled + *:not(:disabled) {
     border-left: ${Size.Border.Small} solid
       ${({ theme }) => theme.palette.divider};
   }
 
-  button:not(:last-of-type) {
+  & > *:not(:last-child) {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
   }
 
-  button:not(:first-of-type) {
+  & > *:not(:first-child) {
     border-left: none;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }
 
-  button:last-of-type {
+  & > *:last-child {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -54,6 +54,8 @@ const sampleData: SampleObject[] = [
   { id: 14, name: "9name", count: 1 },
 ];
 
+const sampleEmptyData: SampleObject[] = [];
+
 export const Overview = () => (
   <Container>
     <DataTable
@@ -299,7 +301,7 @@ export const WithStickyHeader = () => (
 export const WithEmptyTable = () => (
   <Container>
     <DataTable
-      data={[]}
+      data={sampleEmptyData}
       defaultSortField="名前"
       defaultSortOrder="desc"
       columns={[

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw jfPFaf sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw ekRbGL sc-AxheI cbsHKE"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -45,7 +45,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw jfPFaf sc-AxheI cbsHKE"
+      class="sc-AxirZ sc-AxiKw gRAqhe sc-AxheI cbsHKE"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -148,7 +148,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw dnBLnw sc-AxhUy bnlmnx"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -157,7 +157,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw dnBLnw sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -194,7 +194,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxhUy bnlmnx"
+      class="sc-AxirZ sc-AxiKw iwrrMN sc-AxhUy bnlmnx"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -202,7 +202,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       保存する
     </button>
     <button
-      class="sc-AxirZ sc-AxiKw cXsjbM sc-AxgMl hGPnli"
+      class="sc-AxirZ sc-AxiKw iwrrMN sc-AxgMl hGPnli"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"


### PR DESCRIPTION
close #84 
* `<Button component={Link} />` 時の disabled-style 対応の修正も含む
* DataTableのstoryの微修正も含む(emptyTableの配列エラーの対応)