### PR TITLE
ConfirmModalのタイトルにfloatingTipを追加できるようにする

### DIFF
--- a/src/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import ConfirmModal from ".";
 import Spacer from "../Spacer";
 import DataTable from "../DataTable";
+import Typography from "../Typography";
 import { data } from "../DataTable/data";
 import { action } from "@storybook/addon-actions";
 
@@ -43,6 +44,26 @@ export const WithFullSize = () => (
   <Container>
     <Spacer pt={2} />
     <ConfirmModal title="タイトル" fullSize={true} onSubmit={action("submit")}>
+      コンテンツ
+    </ConfirmModal>
+  </Container>
+);
+
+export const WithTips = () => (
+  <Container>
+    <Spacer pt={2} />
+    <ConfirmModal
+      title="タイトル"
+      tipElement={
+        <Typography size="sm" lineHeight="1.7">
+          モーダルの設定内容に関する脚注を入れたい場合は、
+          &quot;tipElement&quot;
+          に表示したい内容を追加することでfloatingTipを追加できます。
+        </Typography>
+      }
+      fullSize={true}
+      onSubmit={action("submit")}
+    >
       コンテンツ
     </ConfirmModal>
   </Container>

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -4,6 +4,7 @@ import Typography from "../Typography";
 import Icon from "../Icon";
 import Spacer from "../Spacer";
 import Flex from "../Flex";
+import FloatingTip from "../FloatingTip";
 import Button from "../Button";
 import { ButtonColor } from "../Button/Button";
 import Spinner from "../Spinner";
@@ -31,6 +32,7 @@ export type Props = {
   fullSize?: boolean;
   disableHorizontalPadding?: boolean;
   subActions?: SubAction[];
+  tipElement?: JSX.Element;
 
   // TypeScriptで型エラーが出るので一旦これでしのぐ
   children?: React.ReactNode;
@@ -50,9 +52,18 @@ const ConfirmModal: React.FunctionComponent<Props> = ({
   overflowYScroll = true,
   disableHorizontalPadding = false,
   subActions = [],
+  tipElement,
 }) => {
   const theme = useTheme();
   const showFooter = !!onSubmit;
+  const [
+    iconWrapperElement,
+    setIconWrapperElement,
+  ] = React.useState<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const onHandleIsOpen = (isOpen: boolean) => () => {
+    setIsOpen(isOpen);
+  };
   return (
     <Modal hasBackground={true}>
       <Styled.ModalContainer fullSize={fullSize}>
@@ -62,6 +73,27 @@ const ConfirmModal: React.FunctionComponent<Props> = ({
               <Typography weight="bold" size="xxxl">
                 {title}
               </Typography>
+
+              {tipElement && (
+                <Styled.TipContainer>
+                  <Styled.IconContainer
+                    ref={setIconWrapperElement}
+                    onClick={onHandleIsOpen(!isOpen)}
+                  >
+                    <Icon name="question" type="fill" size="lg" />
+                  </Styled.IconContainer>
+                  <FloatingTip
+                    baseElement={iconWrapperElement}
+                    isOpen={isOpen}
+                    positionPriority={["right-start"]}
+                    onClose={onHandleIsOpen(false)}
+                  >
+                    <Styled.TipContentContainer>
+                      {tipElement}
+                    </Styled.TipContentContainer>
+                  </FloatingTip>
+                </Styled.TipContainer>
+              )}
 
               <Spacer pr={2} />
               {subActions.map(({ icon, action, title }) => (

--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`ConfirmModal component testing ConfirmModal 1`] = `
 <DocumentFragment>
   <div
-    class="sc-fzoLag cQbesB"
+    class="sc-fzoyAV jQsOXZ"
   >
     <div
-      class="sc-fzoXzr dUAKJy"
+      class="sc-fzoLag dlfFwM"
     />
     <div
       class="sc-AxiKw sc-AxhUy dywwWM"
@@ -19,7 +19,7 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
             class="sc-AxheI bKfQtn"
           >
             <p
-              class="sc-fzpans fTXtsg"
+              class="sc-fznyAO lkgidp"
               color="#041C33"
               font-size="20px"
             >
@@ -33,7 +33,7 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
             class="sc-fzozJi kQYPgQ"
           >
             <div
-              class="sc-fzplWN bGVqhG"
+              class="sc-fznKkj bcMXrP"
               size="24"
             >
               <svg

--- a/src/components/ConfirmModal/styled.ts
+++ b/src/components/ConfirmModal/styled.ts
@@ -108,3 +108,14 @@ export const LoadingContainer = styled.div`
   justify-content: center;
   align-items: center;
 `;
+
+export const TipContainer = styled.div`
+  padding-left: ${({ theme }) => theme.spacing * 0.5}px;
+`;
+
+export const TipContentContainer = styled.div`
+  min-width: ${({ theme }) =>
+    360 - (theme.spacing * 2 * 2 + theme.spacing * 2 + 18)}px;
+  max-width: ${({ theme }) =>
+    512 - (theme.spacing * 2 * 2 + theme.spacing * 2 + 18)}px;
+`;


### PR DESCRIPTION
* DATA STRAPのレポート実行結果のモーダルへのfloatingTip追加に対応するためにConfirmModalのタイトルにfloatingTipを設定できるようにする