### PR TITLE
Navigation railのデザインを微調整

### DIFF
--- a/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
+++ b/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
@@ -6,7 +6,7 @@ import { NavigationRailContext } from "../utils";
 import Tooltip from "../../Tooltip";
 import { NavigationRailTransitionDuration } from "../constants";
 import NotificationBadge from "../../NotificationBadge";
-import { palette } from "../../../themes";
+import { useTheme } from "../../../themes";
 
 type Props = React.ComponentPropsWithRef<"div"> & {
   title: string;
@@ -30,6 +30,7 @@ const ExpantionMenu: React.FC<Props> = ({
   onMouseEnter,
   ...rest
 }) => {
+  const theme = useTheme();
   const { isOpen, onHandleClose } = React.useContext(NavigationRailContext);
 
   const [isExpand, setIsExpand] = React.useState<boolean>(defaultExpand);
@@ -91,7 +92,7 @@ const ExpantionMenu: React.FC<Props> = ({
               name={iconName}
               size="lg"
               type={isActive ? "fill" : "line"}
-              color={isActive ? "active" : palette.black}
+              color={isActive ? "active" : theme.palette.black}
             />
           </NotificationBadge>
           <Styled.TextContainer ref={textContainerElement} isOpen={isOpen}>
@@ -108,7 +109,7 @@ const ExpantionMenu: React.FC<Props> = ({
           <Styled.ArrowIconWrapper isExpand={isExpand} isOpen={isOpen}>
             <Icon
               name="arrow_bottom"
-              color={isActive ? "active" : palette.black}
+              color={isActive ? "active" : theme.palette.black}
               size="lg"
             />
           </Styled.ArrowIconWrapper>

--- a/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
+++ b/src/components/NavigationRail/ExpantionMenu/ExpantionMenu.tsx
@@ -6,6 +6,7 @@ import { NavigationRailContext } from "../utils";
 import Tooltip from "../../Tooltip";
 import { NavigationRailTransitionDuration } from "../constants";
 import NotificationBadge from "../../NotificationBadge";
+import { palette } from "../../../themes";
 
 type Props = React.ComponentPropsWithRef<"div"> & {
   title: string;
@@ -90,15 +91,16 @@ const ExpantionMenu: React.FC<Props> = ({
               name={iconName}
               size="lg"
               type={isActive ? "fill" : "line"}
-              color={isActive ? "active" : "line"}
+              color={isActive ? "active" : palette.black}
             />
           </NotificationBadge>
           <Styled.TextContainer ref={textContainerElement} isOpen={isOpen}>
             <Styled.TextWrapper
               ref={textElement}
               component="span"
-              color={isActive ? "primary" : "secondary"}
+              color={isActive ? "primary" : "initial"}
               weight="bold"
+              size="sm"
             >
               {title}
             </Styled.TextWrapper>
@@ -106,7 +108,7 @@ const ExpantionMenu: React.FC<Props> = ({
           <Styled.ArrowIconWrapper isExpand={isExpand} isOpen={isOpen}>
             <Icon
               name="arrow_bottom"
-              color={isActive ? "active" : "line"}
+              color={isActive ? "active" : palette.black}
               size="lg"
             />
           </Styled.ArrowIconWrapper>

--- a/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
+++ b/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
@@ -49,7 +49,8 @@ const ExpantionMenuItem: React.FC<Props> = ({
             ref={textElement}
             component="span"
             weight={isActive ? "bold" : "normal"}
-            color={isActive ? "primary" : theme.palette.gray.dark}
+            color={isActive ? "primary" : theme.palette.black}
+            size="sm"
           >
             {title}
           </Styled.TextWrapper>

--- a/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
+++ b/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
@@ -55,9 +55,10 @@ const ExpantionMenuItem: React.FC<Props> = ({
             {title}
           </Styled.TextWrapper>
         </Styled.TextContainer>
-        {notificationCount !== 0 && (
-          <SideNotificationBadge notificationCount={notificationCount} />
-        )}
+        <SideNotificationBadge
+          notificationCount={notificationCount}
+          invisible={notificationCount === 0}
+        />
       </Styled.Container>
     </Tooltip>
   );

--- a/src/components/NavigationRail/ExpantionMenuItem/styled.ts
+++ b/src/components/NavigationRail/ExpantionMenuItem/styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div`
   display: flex;
   align-items: center;
   padding: ${({ theme }) =>
-    `${theme.spacing * 2}px ${theme.spacing * 2}px ${theme.spacing * 2}px ${
+    `${theme.spacing * 1.5}px ${theme.spacing * 2}px ${theme.spacing * 1.5}px ${
       theme.spacing * 7.75
     }px`};
 

--- a/src/components/NavigationRail/Menu/Menu.tsx
+++ b/src/components/NavigationRail/Menu/Menu.tsx
@@ -7,6 +7,7 @@ import { NavigationRailContext } from "../utils";
 import { NavigationRailTransitionDuration } from "../constants";
 import NotificationBadge from "../../NotificationBadge";
 import { SideNotificationBadge } from "../internal/SideNotificationBadge";
+import { palette } from "../../../themes";
 
 type Props = React.ComponentPropsWithRef<"div"> & {
   title: string;
@@ -57,15 +58,16 @@ const Menu: React.FC<Props> = ({
             name={iconName}
             size="lg"
             type={isActive ? "fill" : "line"}
-            color={isActive ? "active" : "line"}
+            color={isActive ? "active" : palette.black}
           />
         </NotificationBadge>
         <Styled.TextContainer ref={textContainerElement} isOpen={isOpen}>
           <Styled.TextWrapper
             ref={textElement}
             component="span"
-            color={isActive ? "primary" : "secondary"}
+            color={isActive ? "primary" : "initial"}
             weight="bold"
+            size="sm"
           >
             {title}
           </Styled.TextWrapper>

--- a/src/components/NavigationRail/Menu/Menu.tsx
+++ b/src/components/NavigationRail/Menu/Menu.tsx
@@ -7,7 +7,7 @@ import { NavigationRailContext } from "../utils";
 import { NavigationRailTransitionDuration } from "../constants";
 import NotificationBadge from "../../NotificationBadge";
 import { SideNotificationBadge } from "../internal/SideNotificationBadge";
-import { palette } from "../../../themes";
+import { useTheme } from "../../../themes";
 
 type Props = React.ComponentPropsWithRef<"div"> & {
   title: string;
@@ -24,6 +24,7 @@ const Menu: React.FC<Props> = ({
   onMouseEnter,
   ...rest
 }) => {
+  const theme = useTheme();
   const { isOpen, onHandleClose } = React.useContext(NavigationRailContext);
 
   const [showTooltip, setShowTooltip] = React.useState<boolean>(false);
@@ -58,7 +59,7 @@ const Menu: React.FC<Props> = ({
             name={iconName}
             size="lg"
             type={isActive ? "fill" : "line"}
-            color={isActive ? "active" : palette.black}
+            color={isActive ? "active" : theme.palette.black}
           />
         </NotificationBadge>
         <Styled.TextContainer ref={textContainerElement} isOpen={isOpen}>
@@ -72,9 +73,10 @@ const Menu: React.FC<Props> = ({
             {title}
           </Styled.TextWrapper>
         </Styled.TextContainer>
-        {notificationCount !== 0 && (
-          <SideNotificationBadge notificationCount={notificationCount} />
-        )}
+        <SideNotificationBadge
+          notificationCount={notificationCount}
+          invisible={notificationCount === 0 || !isOpen}
+        />
       </Styled.Container>
     </Tooltip>
   );

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -50,9 +50,9 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             class="sc-fzqNJr eByRrb"
           >
             <span
-              class="sc-fzoLsD Toynz sc-fzoyAV gEdpVK"
+              class="sc-fzoLsD gMRKsY sc-fzoyAV gEdpVK"
               color="#0B82F4"
-              font-size="14px"
+              font-size="13px"
             >
               設定
             </span>
@@ -85,15 +85,15 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           height="auto"
         >
           <div
-            class="sc-fzpjYC cnHENx"
+            class="sc-fzpjYC cnnoXp"
           >
             <div
               class="sc-fznxsB iaRQNF"
             >
               <span
-                class="sc-fzoLsD Toynz sc-fznJRM brvoJE"
+                class="sc-fzoLsD gMRKsY sc-fznJRM brvoJE"
                 color="#0B82F4"
-                font-size="14px"
+                font-size="13px"
               >
                 デマンド設定
               </span>
@@ -120,7 +120,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                 />
                 <path
                   d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z"
-                  fill="#778490"
+                  fill="#041C33"
                 />
               </svg>
             </div>
@@ -134,9 +134,9 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             class="sc-fzplWN hdsezt"
           >
             <span
-              class="sc-fzoLsD jpOnuY sc-fznyAO deZnEW"
-              color="#778490"
-              font-size="14px"
+              class="sc-fzoLsD cuqxQU sc-fznyAO deZnEW"
+              color="#041C33"
+              font-size="13px"
             >
               ダッシュボード
             </span>

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -98,6 +98,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                 デマンド設定
               </span>
             </div>
+            <span
+              class="sc-fzokOt bSFcDQ"
+            >
+              0
+            </span>
           </div>
         </div>
         <div
@@ -141,6 +146,11 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
               ダッシュボード
             </span>
           </div>
+          <span
+            class="sc-fzokOt bSFcDQ"
+          >
+            0
+          </span>
         </div>
       </div>
       <div

--- a/src/components/NavigationRail/internal/SideNotificationBadge/SideNotificationBadge.tsx
+++ b/src/components/NavigationRail/internal/SideNotificationBadge/SideNotificationBadge.tsx
@@ -3,13 +3,17 @@ import * as Styled from "./styled";
 
 type Props = {
   notificationCount?: number;
+  invisible?: boolean;
 };
 
 const SideNotificationBadge: React.FunctionComponent<Props> = ({
   notificationCount = 0,
-}) =>
-  notificationCount === 0 ? null : (
-    <Styled.Container>{notificationCount}</Styled.Container>
+  invisible = false,
+}) => {
+  const displayCount = notificationCount >= 100 ? "99+" : notificationCount;
+  return (
+    <Styled.Container invisible={invisible}>{displayCount}</Styled.Container>
   );
+};
 
 export { SideNotificationBadge };

--- a/src/components/NavigationRail/internal/SideNotificationBadge/styled.ts
+++ b/src/components/NavigationRail/internal/SideNotificationBadge/styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const Container = styled.span`
+export const Container = styled.span<{ invisible: boolean }>`
   display: flex;
   align-items: center;
   align-content: center;
@@ -14,5 +14,6 @@ export const Container = styled.span`
   background-color: ${({ theme }) => theme.palette.danger.main};
   font-size: 10.5px;
   font-weight: bold;
+  transform: ${({ invisible }) => (invisible ? "scale(0)" : "scale(1)")};
   transition: transform 0.3s;
 `;


### PR DESCRIPTION
- テキスト、アイコン、アローアイコンの色をダークに
- 子要素メニューの上下paddingを狭く
- フォントサイズを13pxに