### PR TITLE
<DataTable />微調整

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -321,7 +321,10 @@ const DataTable = <T extends { id: number; selectDisabled?: boolean }>({
             onChange={onHandleTabChange}
           />
         )}
-        <Styled.TableContainer maxHeight={tableMaxHeight}>
+        <Styled.TableContainer
+          maxHeight={tableMaxHeight}
+          horizontalScrollable={horizontalScrollable}
+        >
           <Table horizontalScrollable={horizontalScrollable}>
             <Table.Header>
               <Table.Row isStickyHeader={tableMaxHeight !== "none"}>

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DataTable component testing DataTable 1`] = `
       class="sc-AxirZ dnbnUY"
     >
       <div
-        class="sc-AxiKw oeWKG"
+        class="sc-AxiKw gjtbZd"
       >
         <table
           class="sc-fznxsB kIHQaQ"

--- a/src/components/DataTable/styled.ts
+++ b/src/components/DataTable/styled.ts
@@ -13,7 +13,13 @@ export const BorderContainer = styled.div<{ fullWidth?: boolean }>`
   border-radius: ${({ fullWidth }) => (fullWidth ? "none" : Radius.SMALL)};
 `;
 
-export const TableContainer = styled.div<{ maxHeight: string }>`
-  overflow: scroll;
+export const TableContainer = styled.div<{
+  maxHeight: string;
+  horizontalScrollable: boolean;
+}>`
+  overflow-x: ${({ horizontalScrollable }) =>
+    horizontalScrollable ? "scroll" : "visible"};
+  overflow-y: ${({ maxHeight }) =>
+    maxHeight !== "none" ? "scroll" : "visible"};
   max-height: ${({ maxHeight }) => maxHeight};
 `;


### PR DESCRIPTION
- windowsでみる
- macで外部マウス用いてみる

ときに、常時スクロールバーが表示される状態となっている。
なので、スクロール可の時だけスクロールバーを表示するように変更。

![image](https://user-images.githubusercontent.com/40020812/88011589-a4bfa000-cb52-11ea-8be9-fb9a64671ef0.png)
