### PR TITLE
Table周りの破壊的変更

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -470,6 +470,7 @@ export const WithEmptyTable = () => {
         defaultSortField="名前"
         defaultSortOrder="desc"
         columns={columns}
+        itemEmptyProps={{ title: "アイテムが存在しません。" }}
       />
     </Container>
   );

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -21,7 +21,7 @@ import Pager, {
   getFilteredItems as getFilteredItemsByPagination,
   FilterState,
 } from "../Pager";
-import ItemEmpty from "../ItemEmpty";
+import ItemEmpty, { ItemEmptyProps } from "../ItemEmpty";
 
 import { StorageKey } from "../../constants/storageKeys";
 import { TableTabs } from "./internal/TableTabs";
@@ -127,8 +127,6 @@ export type DataTableBaseData = {
 };
 
 export type Column<T> = {
-  // MEMO: nameを廃止して、headerCellのみにすることも可能
-  //       他の破壊的変更に合わせて行うのが良さそう
   name: string;
   selector: (data: T) => string | number;
   sortable?: boolean;
@@ -145,13 +143,6 @@ type Tab<T> = {
   disabledCheck?: boolean;
 };
 
-// TODO: emptyTitle と emptySubtitle もここに移す
-type ItemEmptyProps = {
-  emptyImage?: string;
-  imageWidth?: number;
-  imageHeight?: number;
-};
-
 type Props<T> = {
   data: T[];
   columns: Column<T>[];
@@ -160,8 +151,6 @@ type Props<T> = {
   onRadioChange?: (radio: number) => void;
   clearSelectedRows?: boolean;
   tabs?: Tab<T>[];
-  emptyTitle?: string;
-  emptySubtitle?: string;
   itemEmptyProps?: ItemEmptyProps;
   per?: number; // perが指定されている場合、初期値がそれに強制されます
   defaultSortField?: string;
@@ -182,8 +171,6 @@ const DataTable = <T extends DataTableBaseData>({
   onRadioChange,
   clearSelectedRows,
   tabs,
-  emptyTitle,
-  emptySubtitle,
   itemEmptyProps,
   per,
   defaultSortField,
@@ -468,11 +455,8 @@ const DataTable = <T extends DataTableBaseData>({
                     }
                   >
                     <ItemEmpty
-                      title={emptyTitle || "見つかりませんでした"}
-                      subtitle={emptySubtitle}
-                      emptyImage={itemEmptyProps?.emptyImage}
-                      imageWidth={itemEmptyProps?.imageWidth}
-                      imageHeight={itemEmptyProps?.imageHeight}
+                      {...itemEmptyProps}
+                      title={itemEmptyProps?.title || "見つかりませんでした"}
                     />
                   </td>
                 </tr>

--- a/src/components/FixedPanel/__tests__/__snapshots__/FixedPanel.test.tsx.snap
+++ b/src/components/FixedPanel/__tests__/__snapshots__/FixedPanel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FixedPanel component testing FixedPanel 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm iaKqmZ"
+    class="sc-AxjAm PUzLH"
     height="0"
     offset="0"
   />

--- a/src/components/FixedPanel/styled.ts
+++ b/src/components/FixedPanel/styled.ts
@@ -18,7 +18,6 @@ export const Container = styled.div<ContainerProps>`
         : `${height !== 0 ? `calc(${-height}px - 10px)` : "-100vh"}`
     }`};
   width: 100%;
-  backdrop-filter: blur(2px);
   background-color: ${({ theme }) =>
     hexToRgba(theme.palette.background.default, 0.9)};
   border-top: 1px solid ${({ theme }) => theme.palette.divider};

--- a/src/components/ItemEmpty/ItemEmpty.tsx
+++ b/src/components/ItemEmpty/ItemEmpty.tsx
@@ -4,7 +4,7 @@ import Spacer from "../Spacer";
 import Typography from "../Typography";
 import { EmptyImage } from "./internal/EmptyImage";
 
-type Props = {
+export type ItemEmptyProps = {
   title: string;
   subtitle?: string;
   emptyImage?: string;
@@ -12,7 +12,7 @@ type Props = {
   imageHeight?: number;
 };
 
-const ItemEmpty: React.FunctionComponent<Props> = ({
+const ItemEmpty: React.FunctionComponent<ItemEmptyProps> = ({
   title,
   subtitle,
   emptyImage,

--- a/src/components/ItemEmpty/index.ts
+++ b/src/components/ItemEmpty/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ItemEmpty";
+export { default, ItemEmptyProps } from "./ItemEmpty";

--- a/src/components/Table/HeaderCell.tsx
+++ b/src/components/Table/HeaderCell.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import Typography from "../Typography";
-import Flex from "../Flex";
 
 const Component = styled.th<{ width: string }>`
   width: ${({ width }) => width};
@@ -10,39 +9,21 @@ const Component = styled.th<{ width: string }>`
   border-right: 1px solid ${({ theme }) => theme.palette.divider};
 `;
 
-const RequiredBadge = styled.div`
-  padding: 2px 7px;
-  background: ${({ theme }) => theme.palette.danger.main};
-  border-radius: ${({ theme }) => theme.radius}px;
-`;
-
-export type Props = React.TdHTMLAttributes<HTMLTableDataCellElement> &
-  React.ThHTMLAttributes<HTMLTableHeaderCellElement> & {
-    width?: string;
-    children?: React.ReactNode;
-    required?: boolean;
-  };
+export type Props = React.ThHTMLAttributes<HTMLTableHeaderCellElement> & {
+  width?: string;
+  children?: React.ReactNode;
+};
 
 export const HeaderCell: React.FunctionComponent<Props> = ({
   width = "auto",
   children,
-  required = false,
   ...rest
 }) => {
   return (
     <Component width={width} {...rest}>
-      <Flex display="flex" justifyContent="space-between">
-        <Typography component="div" weight="bold" size="md">
-          {children}
-        </Typography>
-        {required && (
-          <RequiredBadge>
-            <Typography color="white" weight="bold" size="xs">
-              必須
-            </Typography>
-          </RequiredBadge>
-        )}
-      </Flex>
+      <Typography component="div" weight="bold" size="md" lineHeight="normal">
+        {children}
+      </Typography>
     </Component>
   );
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import styled from "styled-components";
 
 import Table from "./";
+import Flex from "../Flex";
+import Typography from "../Typography";
+import Badge from "../Badge";
 
 export default {
   title: "Table",
@@ -20,8 +23,19 @@ export const Overview = () => (
     <Table>
       <Table.Body>
         <Table.Row>
-          <Table.HeaderCell width="177px" required={true}>
-            タイトル
+          <Table.HeaderCell width="177px">
+            <Flex
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+            >
+              <Typography component="div" weight="bold" size="md">
+                タイトル
+              </Typography>
+              <Badge color="danger" fontWeight="bold">
+                必須
+              </Badge>
+            </Flex>
           </Table.HeaderCell>
           <Table.Cell colSpan={2}>コンテンツ</Table.Cell>
         </Table.Row>

--- a/src/components/Table/__tests__/Table.test.tsx
+++ b/src/components/Table/__tests__/Table.test.tsx
@@ -12,9 +12,7 @@ describe("Table component testing", () => {
       <Table>
         <Table.Body>
           <Table.Row>
-            <Table.HeaderCell width="177px" required={true}>
-              タイトル
-            </Table.HeaderCell>
+            <Table.HeaderCell width="177px">タイトル</Table.HeaderCell>
             <Table.Cell>コンテンツ</Table.Cell>
           </Table.Row>
           <Table.Row>

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Table component testing Table 1`] = `
           width="177px"
         >
           <div
-            class="sc-AxjAm iYepyg"
+            class="sc-AxjAm gZkNeo"
             color="#041C33"
             font-size="14px"
           >
@@ -42,7 +42,7 @@ exports[`Table component testing Table 1`] = `
           width="177px"
         >
           <div
-            class="sc-AxjAm iYepyg"
+            class="sc-AxjAm gZkNeo"
             color="#041C33"
             font-size="14px"
           >
@@ -70,7 +70,7 @@ exports[`Table component testing Table 1`] = `
           width="177px"
         >
           <div
-            class="sc-AxjAm iYepyg"
+            class="sc-AxjAm gZkNeo"
             color="#041C33"
             font-size="14px"
           >

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -3,38 +3,22 @@
 exports[`Table component testing Table 1`] = `
 <DocumentFragment>
   <table
-    class="sc-AxheI klJKTW"
+    class="sc-AxhUy cANtHW"
   >
     <tbody>
       <tr
         class="sc-AxiKw evyKMu"
       >
         <th
-          class="sc-AxhUy gthNZe"
+          class="sc-AxhCb jZYsHj"
           width="177px"
         >
           <div
-            class="sc-AxhCb dzpAlW"
-            display="flex"
+            class="sc-AxjAm iYepyg"
+            color="#041C33"
+            font-size="14px"
           >
-            <div
-              class="sc-AxjAm iYepyg"
-              color="#041C33"
-              font-size="14px"
-            >
-              タイトル
-            </div>
-            <div
-              class="sc-AxgMl bVQtpP"
-            >
-              <p
-                class="sc-AxjAm fLJoJQ"
-                color="#FFFFFF"
-                font-size="12px"
-              >
-                必須
-              </p>
-            </div>
+            タイトル
           </div>
         </th>
         <td
@@ -54,20 +38,15 @@ exports[`Table component testing Table 1`] = `
         class="sc-AxiKw evyKMu"
       >
         <th
-          class="sc-AxhUy gthNZe"
+          class="sc-AxhCb jZYsHj"
           width="177px"
         >
           <div
-            class="sc-AxhCb jMXRtl"
-            display="flex"
+            class="sc-AxjAm iYepyg"
+            color="#041C33"
+            font-size="14px"
           >
-            <div
-              class="sc-AxjAm iYepyg"
-              color="#041C33"
-              font-size="14px"
-            >
-              タイトル
-            </div>
+            タイトル
           </div>
         </th>
         <td
@@ -87,20 +66,15 @@ exports[`Table component testing Table 1`] = `
         class="sc-AxiKw evyKMu"
       >
         <th
-          class="sc-AxhUy gthNZe"
+          class="sc-AxhCb jZYsHj"
           width="177px"
         >
           <div
-            class="sc-AxhCb jMXRtl"
-            display="flex"
+            class="sc-AxjAm iYepyg"
+            color="#041C33"
+            font-size="14px"
           >
-            <div
-              class="sc-AxjAm iYepyg"
-              color="#041C33"
-              font-size="14px"
-            >
-              タイトル
-            </div>
+            タイトル
           </div>
         </th>
         <td


### PR DESCRIPTION
close: #125

ついでに https://github.com/voyagegroup/fluct_XDC/issues/53 も対応。

あとは、`<DataTable />`のpropsの構造を変えた。