### PR TITLE
datepicker、daterangepicker のデザイン調整

### DIFF
--- a/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DatePicker component testing DatePicker 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm hXjxff"
+    class="sc-AxjAm capgbY"
   >
     <div
       class="SingleDatePicker SingleDatePicker_1"

--- a/src/components/DatePicker/styled.ts
+++ b/src/components/DatePicker/styled.ts
@@ -93,6 +93,25 @@ export const Container = styled.div<{ error: boolean }>`
   .CalendarDay__default {
     border: 0;
     font-size: 12px;
+    background: transparent;
+    z-index: 1;
+    &:hover {
+      background: inherit;
+      border: 0;
+      &:before {
+        content: "";
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 50% !important; /* td:nth-child(7n):beforeで上書きされるのを防ぐ */
+        transform: translate(calc(-50% - 0.5px), -50%);
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        z-index: -1;
+        background: ${({ theme }) => theme.palette.gray.main};
+      }
+    }
   }
   .CalendarDay__hovered_span {
     background: transparent;

--- a/src/components/DateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/src/components/DateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DateRangePicker component testing DateRangePicker 1`] = `
 <DocumentFragment>
   <div
-    class="sc-AxjAm kqAPYG"
+    class="sc-AxjAm fCygMV"
   >
     <div
       class="DateRangePicker DateRangePicker_1"

--- a/src/components/DateRangePicker/styled.ts
+++ b/src/components/DateRangePicker/styled.ts
@@ -92,6 +92,25 @@ export const Container = styled.div<{ error: boolean }>`
   .CalendarDay__default {
     border: 0;
     font-size: 12px;
+    background: transparent;
+    z-index: 1;
+    &:hover {
+      background: inherit;
+      border: 0;
+      &:before {
+        content: "";
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 50% !important; /* td:nth-child(7n):beforeで上書きされるのを防ぐ */
+        transform: translate(calc(-50% - 0.5px), -50%);
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        z-index: -1;
+        background: ${({ theme }) => theme.palette.gray.main};
+      }
+    }
   }
   .CalendarDay__hovered_span {
     background: transparent;


### PR DESCRIPTION
ref: https://github.com/voyagegroup/fluct_XDC/issues/69

before:
![スクリーンショット 2020-08-31 15 48 34](https://user-images.githubusercontent.com/11240481/91691078-04718800-eba2-11ea-81d8-b014e60ae800.png)

after:
![スクリーンショット 2020-08-31 15 48 21](https://user-images.githubusercontent.com/11240481/91691097-09ced280-eba2-11ea-8d21-1b623aa3f41e.png)
