### PR TITLE
dataTable微修正(thがstickyの際にz-indexを付与

### DIFF
--- a/src/components/DataTable/internal/Table/Row.tsx
+++ b/src/components/DataTable/internal/Table/Row.tsx
@@ -37,6 +37,7 @@ const Component = styled.tr<RowProps>`
         ? css`
             position: sticky;
             top: 0;
+            z-index: 1;
           `
         : ""}
   }


### PR DESCRIPTION
こういうのを無くしたい。
![image](https://user-images.githubusercontent.com/40020812/92057727-fdc55980-edc9-11ea-8ce5-cdf2ca812d6f.png)
