### PR TITLE
[bugFix]navigationRailのExpantionMenuItemのtitleにJSX.Elementを指定できるようにtitleElementを別に生やす

### DIFF
--- a/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
+++ b/src/components/NavigationRail/ExpantionMenuItem/ExpantionMenuItem.tsx
@@ -9,13 +9,15 @@ import { useTheme } from "../../../themes";
 export type NavigationRailExpantionMenuItemProps = React.ComponentPropsWithRef<
   "div"
 > & {
-  title: Omit<React.ReactNode, "undefined">;
+  title: string;
+  titleElement?: JSX.Element;
   isActive?: boolean;
   notificationCount?: number;
 };
 
 const ExpantionMenuItem: React.FC<NavigationRailExpantionMenuItemProps> = ({
   title,
+  titleElement,
   isActive = false,
   onMouseEnter,
   notificationCount = 0,
@@ -54,7 +56,7 @@ const ExpantionMenuItem: React.FC<NavigationRailExpantionMenuItemProps> = ({
             color={isActive ? "primary" : theme.palette.black}
             size="sm"
           >
-            {title}
+            {titleElement ? titleElement : title}
           </Styled.TextWrapper>
         </Styled.TextContainer>
         <SideNotificationBadge

--- a/src/components/NavigationRail/NavigationRail.stories.tsx
+++ b/src/components/NavigationRail/NavigationRail.stories.tsx
@@ -22,7 +22,8 @@ type NavigationRailContents = {
   notificationCount?: number;
   path?: string;
   expantionList?: {
-    title: Omit<React.ReactNode, "undefined">;
+    title: string;
+    titleElement?: JSX.Element;
     path: string;
     isActive: boolean;
     notificationCount?: number;
@@ -93,7 +94,8 @@ const createNavigationRailContents = (path: string): NavigationRailContents => [
         isActive: path === "/statistics/summary",
       },
       {
-        title: (
+        title: "詳細版",
+        titleElement: (
           <Flex display="flex" alignItems="center" justifyContent="flex-start">
             詳細版
             <Spacer pr={0.25} />
@@ -183,6 +185,7 @@ export const Overview = () => {
                     <NavigationRail.ExpantionMenuItem
                       isActive={expantion.isActive}
                       title={expantion.title}
+                      titleElement={expantion.titleElement}
                       notificationCount={expantion.notificationCount}
                     />
                   ))}


### PR DESCRIPTION
* https://github.com/voyagegroup/ingred-ui/pull/176 の修正
* 型エラーが発生してtitleにElementを入れられなかったので、optionとしてtitleElementを別に用意することで対応