### PR TITLE
<Select />でnumber型を扱えるようにする

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -31,54 +31,56 @@ export default {
   },
 };
 
-const options: OptionType[] = [
+type OptionTypeWithNumberValue = OptionType<number>;
+
+const options: OptionTypeWithNumberValue[] = [
   {
     label: "Adgeneration",
-    value: "1",
+    value: 1,
   },
   {
     label: "fluct",
-    value: "2",
+    value: 2,
   },
   {
     label: "Pubmatic",
-    value: "3",
+    value: 3,
   },
   {
     label: "Hoge",
-    value: "4",
+    value: 4,
   },
   {
     label: "Pubmatic",
-    value: "3",
+    value: 3,
   },
   {
     label: "Hoge",
-    value: "4",
+    value: 4,
   },
   {
     label: "Pubmatic",
-    value: "3",
+    value: 3,
   },
   {
     label: "Hoge",
-    value: "4",
+    value: 4,
   },
   {
     label: "Pubmatic",
-    value: "3",
+    value: 3,
   },
   {
     label: "Hoge",
-    value: "4",
+    value: 4,
   },
   {
     label: "Pubmatic",
-    value: "3",
+    value: 3,
   },
   {
     label: "Hoge",
-    value: "4",
+    value: 4,
   },
 ];
 
@@ -89,7 +91,8 @@ export const Overview = () => (
         <Typography weight="bold" size="xxl">
           Normal
         </Typography>
-        <Select
+        {/* MEMO: Can define Generics */}
+        <Select<number>
           options={options}
           minWidth="200px"
           onChange={action("onChange")}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -163,7 +163,7 @@ const Select: SelectComponent = ({
   const theme = useTheme();
   let i = 0;
   const filterOption: SelectProps<string | number>["filterOption"] = limit
-    ? ({ label }, query) => `${label}`.indexOf(query) >= 0 && i++ < limit
+    ? ({ label }, query) => label.indexOf(query) >= 0 && i++ < limit
     : undefined;
   const onHandleInputChange: SelectProps<string | number>["onInputChange"] = (
     newValue,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -143,13 +143,17 @@ const getOverrideStyles = (theme: Theme, error: boolean) => {
 
 export type OptionType<T = string> = { label: string; value: T };
 
-export type SelectProps = {
+export type SelectProps<T> = {
   limit?: number;
   minWidth?: string;
   error?: boolean;
-} & ReactSelectProps;
+} & ReactSelectProps<OptionType<T>>;
 
-const Select: React.FunctionComponent<SelectProps> = ({
+export type SelectComponent = <T = string>(
+  props: SelectProps<T>,
+) => React.ReactElement<SelectProps<T>>;
+
+const Select: SelectComponent = ({
   limit,
   onInputChange,
   minWidth,
@@ -158,10 +162,10 @@ const Select: React.FunctionComponent<SelectProps> = ({
 }) => {
   const theme = useTheme();
   let i = 0;
-  const filterOption: SelectProps["filterOption"] = limit
-    ? ({ label }, query) => label.indexOf(query) >= 0 && i++ < limit
+  const filterOption: SelectProps<string | number>["filterOption"] = limit
+    ? ({ label }, query) => `${label}`.indexOf(query) >= 0 && i++ < limit
     : undefined;
-  const onHandleInputChange: SelectProps["onInputChange"] = (
+  const onHandleInputChange: SelectProps<string | number>["onInputChange"] = (
     newValue,
     actionMeta,
   ) => {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,1 +1,1 @@
-export { default, SelectProps } from "./Select";
+export { default, SelectProps, OptionType, SelectComponent } from "./Select";


### PR DESCRIPTION
`options: { value: string; label: string; }`みたいになっているけれど、valueはnumber型で扱いたいシーンが多い。
なのでよしなに型をオーバーライドできるようにする。