### PR TITLE
CODEOWNERSの記載内容を修正

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@fluct_xdc
+*	@voyagegroup/fluct_xdc


### PR DESCRIPTION
teamを指定する場合は @org / team_nameにしないといけなかった

> CODEOWNERS ファイルは、gitignore ファイルで使われているのと同じルールに従うパターンを利用します。 パターンの後には1つ以上のGitHubのユーザー名あるいはTeam名が続きます。これらの名前には標準の@usernameあるいは@org/team-nameフォーマットが使われます。 たとえば user@example.com のような、ユーザの GitHub アカウントに追加されたメールアドレスでユーザを参照することもできます。
