### PR TITLE
package.jsonのバージョンアップとCIの修正

### DIFF
--- a/ci.mk
+++ b/ci.mk
@@ -25,6 +25,6 @@ lint:
 
 publish: __req_semver build
 	npm version ${SEMVER} -m "[ci skip] %s"
-	npm publish
 	git push origin master
 	git push origin --tags
+	npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingred-ui",
-  "version": "7.4.4",
+  "version": "7.4.5",
   "description": "",
   "author": "voyagegroup",
   "license": "MIT",


### PR DESCRIPTION
- release jobが失敗してpublishだけしてしまっているのでversionを整える
- そもそもpublishできてからgithubにpushするんじゃなくて、pushとtag生成が完了したらnpm publishするほうがいいので順番変えた