### PR TITLE
fix error: The inferred type of 'ReactSelectMenuList' cannot be named without a reference to 'styled-components/node_modules/@types/react'. This is likely not portable. A type annotation is necessary.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/react-select": "^3.0.10",
     "@types/react-toast-notifications": "^2.4.0",
     "@types/react-transition-group": "^4.2.4",
-    "@types/styled-components": "^5.0.1",
+    "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "cross-env": "^5.1.4",

--- a/src/components/Select/styled.ts
+++ b/src/components/Select/styled.ts
@@ -1,4 +1,5 @@
-import styled from "styled-components";
+import * as React from "react";
+import styled, { DefaultTheme, StyledComponent } from "styled-components";
 import { components, MenuListComponentProps } from "react-select";
 import { addScrollbarProperties } from "../../utils/scrollbar";
 
@@ -6,8 +7,14 @@ export const Container = styled.div<{ minWidth?: string }>`
   min-width: ${({ minWidth }) => minWidth || "auto"};
 `;
 
-export const ReactSelectMenuList = styled(components.MenuList)<
-  MenuListComponentProps<any>
->`
+// MEMO: Add type annotations cause of Error↓
+//       The inferred type of 'ReactSelectMenuList' cannot be named without a reference to 'styled-components/node_modules/@types/react'.
+//       This is likely not portable. A type annotation is necessary.
+export const ReactSelectMenuList: StyledComponent<
+  React.FunctionComponent<MenuListComponentProps<any>>,
+  DefaultTheme,
+  {},
+  never
+> = styled(components.MenuList)<MenuListComponentProps<any>>`
   ${({ maxHeight }) => addScrollbarProperties({ maxHeight: `${maxHeight}px` })}
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,7 +2878,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/styled-components@^5.0.1":
+"@types/styled-components@^5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.4.tgz#11f167dbde268635c66adc89b5a5db2e69d75384"
   integrity sha512-78f5Zuy0v/LTQNOYfpH+CINHpchzMMmAt9amY2YNtSgsk1TmlKm8L2Wijss/mtTrsUAVTm2CdGB8VOM65vA8xg==


### PR DESCRIPTION
ref: https://app.circleci.com/pipelines/github/voyagegroup/ingred-ui/1055/workflows/4b7c1784-b6d5-4c83-bd57-fb71ed05551f/jobs/1068

```
Error: /tmp/ingred_ui/src/components/Select/styled.ts(9,14): semantic error TS2742:
The inferred type of 'ReactSelectMenuList' cannot be named without a reference to 'styled-components/node_modules/@types/react'.
This is likely not portable. A type annotation is necessary.
```

他のライブラリからみたときに参照できない型はアノテーション入れましょう。ということだと理解。