### PR TITLE
カードに枠線を付ける

### DIFF
--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm drHOmF ciPuqS"
+    class="sc-gsTCUz sc-dlfnbm drHOmF eVHwxU"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -34,10 +34,9 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   font-size: ${({ fontSize }) => fontSize};
   box-shadow: ${({ normal, disabled }) =>
     disabled ? "none" : normal.boxShadow};
-  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
   transition: all 0.3s;
 
-  &:hover {
+  &:hover:not([disabled]) {
     background: ${({ hover }) => hover.background};
   }
 

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO mKBUh"
+      class="sc-dlfnbm sc-hKgILt iQdNXO hSrEyx"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       編集する
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO mKBUh"
+      class="sc-dlfnbm sc-hKgILt iQdNXO hSrEyx"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -22,7 +22,7 @@ It can contains `<Flex />`props & `<Spacer />`props.
     }}
   >
     {(args) => (
-      <div style={{ backgroundColor: "silver", padding: "10px" }}>
+      <div style={{ padding: "10px" }}>
         <Card {...args} />
       </div>
     )}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -17,6 +17,7 @@ const Card = styled.div<CardProps>`
   width: ${({ width }) => width || "auto"};
   min-width: ${({ minWidth }) => minWidth || "auto"};
   max-width: ${({ maxWidth }) => maxWidth || "auto"};
+  border: 1px solid ${({ theme }) => theme.palette.gray.light};
   ${spacer}
   ${flexbox}
 `;

--- a/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Card component testing Card 1`] = `
 <DocumentFragment>
   <div
-    class="sc-gsTCUz fWKYbd"
+    class="sc-gsTCUz gZoWHM"
   />
 </DocumentFragment>
 `;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,17 +11,19 @@ const Checkbox: React.FunctionComponent<CheckBoxProps> = ({
   children,
   indeterminate = false,
   error = false,
+  disabled = false,
   inputRef,
   ...rest
 }) => {
   return (
-    <Styled.Container>
+    <Styled.Container disabled={disabled}>
       <Styled.Checkbox
         ref={inputRef}
         error={error}
         readOnly={true}
         type="checkbox"
         indeterminate={indeterminate}
+        disabled={disabled}
         {...rest}
       />
       <Styled.Span

--- a/src/components/Checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`Checkbox component testing Checkbox 1`] = `
 <DocumentFragment>
   <label
-    class="sc-bdfBwQ iVZKII"
+    class="sc-gsTCUz jlyGiH"
   >
     <input
-      class="sc-gsTCUz kxRnqE"
+      class="sc-bdfBwQ isisTI"
       readonly=""
       type="checkbox"
     />
     <span
-      class="sc-dlfnbm eeJXsC"
+      class="sc-dlfnbm gMqJkK"
     />
   </label>
 </DocumentFragment>

--- a/src/components/Checkbox/styled.ts
+++ b/src/components/Checkbox/styled.ts
@@ -1,9 +1,5 @@
 import styled from "styled-components";
 
-export const Container = styled.label`
-  cursor: pointer;
-`;
-
 export const Checkbox = styled.input<{
   indeterminate: boolean;
   error: boolean;
@@ -28,6 +24,10 @@ export const Checkbox = styled.input<{
     background-repeat: no-repeat;
     background-position: center;
   }
+`;
+
+export const Container = styled.label<{ disabled: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
 `;
 
 export const Span = styled.span<{

--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
       class="sc-bkzZxe fuFIfA sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
     />
     <div
-      class="sc-gsTCUz sc-hKgILt dBataf DlKbJ sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
+      class="sc-gsTCUz sc-hKgILt jsbffe DlKbJ sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
     >
       <form>
         <div
-          class="sc-eCssSg kzpVTC"
+          class="sc-eCssSg RosqE"
         >
           <div
             class="sc-jSgupP kWrnMH"

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -52,12 +52,12 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
         class="sc-jSgupP hzoSSJ"
       >
         <hr
-          class="sc-iBPRYJ eLEeiQ"
-          color="#EFF1F2"
+          class="sc-iBPRYJ kWqbvW"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC omTrh"
+          class="sc-gKsewC kOKIon"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -68,7 +68,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC omTrh"
+          class="sc-gKsewC kOKIon"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -79,12 +79,12 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iBPRYJ eLEeiQ"
-          color="#EFF1F2"
+          class="sc-iBPRYJ kWqbvW"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC omTrh"
+          class="sc-gKsewC kOKIon"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -95,7 +95,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC omTrh"
+          class="sc-gKsewC kOKIon"
         >
           <p
             class="sc-hKgILt jKKuBF"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF bCiabC sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF hnouyd sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -46,12 +46,12 @@ exports[`DropdownButton component testing not splited disable 1`] = `
         class="sc-fubCfw SsASl"
       >
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -62,7 +62,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -73,12 +73,12 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -89,7 +89,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -112,7 +112,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF ciPuqS sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF eVHwxU sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -156,12 +156,12 @@ exports[`DropdownButton component testing not splited enable 1`] = `
         class="sc-fubCfw SsASl"
       >
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -172,7 +172,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -183,12 +183,12 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -199,7 +199,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -222,7 +222,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF ifYubB sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF cyQxHy sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -231,7 +231,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       保存する
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF ifYubB sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF cyQxHy sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -269,12 +269,12 @@ exports[`DropdownButton component testing splited disable 1`] = `
         class="sc-fubCfw SsASl"
       >
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -285,7 +285,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -296,12 +296,12 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -312,7 +312,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -335,7 +335,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kmMnXp sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF gsbZLr sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -343,7 +343,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       保存する
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kmMnXp sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF gsbZLr sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -386,12 +386,12 @@ exports[`DropdownButton component testing splited enable 1`] = `
         class="sc-fubCfw SsASl"
       >
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -402,7 +402,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -413,12 +413,12 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-jrAGrp fQySwu"
-          color="#EFF1F2"
+          class="sc-jrAGrp jgCjEA"
+          color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -429,7 +429,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ brtMAP"
+          class="sc-pFZIQ kdyKdd"
         >
           <p
             class="sc-bdfBwQ gNlqto"

--- a/src/components/FixedPanel/__tests__/__snapshots__/FixedPanel.test.tsx.snap
+++ b/src/components/FixedPanel/__tests__/__snapshots__/FixedPanel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FixedPanel component testing FixedPanel 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fdXYrt"
+    class="sc-bdfBwQ gbBDqx"
     height="0"
     offset="0"
   />

--- a/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input component testing Input 1`] = `
 <DocumentFragment>
   <input
-    class="sc-bdfBwQ hrmqcQ"
+    class="sc-bdfBwQ ihUyRH"
   />
 </DocumentFragment>
 `;
@@ -11,7 +11,7 @@ exports[`Input component testing Input 1`] = `
 exports[`Input component testing Input disabled 1`] = `
 <DocumentFragment>
   <input
-    class="sc-bdfBwQ hrmqcQ"
+    class="sc-bdfBwQ ihUyRH"
     disabled=""
   />
 </DocumentFragment>
@@ -20,7 +20,7 @@ exports[`Input component testing Input disabled 1`] = `
 exports[`Input component testing Input error 1`] = `
 <DocumentFragment>
   <input
-    class="sc-bdfBwQ dBexQR"
+    class="sc-bdfBwQ bIqYLO"
   />
 </DocumentFragment>
 `;
@@ -28,7 +28,7 @@ exports[`Input component testing Input error 1`] = `
 exports[`Input component testing Input multiline 1`] = `
 <DocumentFragment>
   <textarea
-    class="sc-bdfBwQ hrmqcQ"
+    class="sc-bdfBwQ ihUyRH"
   />
 </DocumentFragment>
 `;

--- a/src/components/Input/styled.ts
+++ b/src/components/Input/styled.ts
@@ -40,5 +40,6 @@ export const Input = styled.input<{
     border-color: ${({ theme }) => theme.palette.divider};
     box-shadow: none;
     background-color: ${({ theme }) => theme.palette.gray.light};
+    cursor: not-allowed;
   }
 `;

--- a/src/components/LoadingBar/__tests__/__snapshots__/LoadingBar.test.tsx.snap
+++ b/src/components/LoadingBar/__tests__/__snapshots__/LoadingBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`LoadingBar component testing LoadingBar 1`] = `
 <DocumentFragment>
   <span
-    class="sc-bdfBwQ CiHRq"
+    class="sc-bdfBwQ kIXAzE"
   />
 </DocumentFragment>
 `;

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`MenuList component testing MenuList splited 1`] = `
     class="sc-bdfBwQ hWeOum"
   >
     <hr
-      class="sc-dlfnbm gCtrZt"
-      color="#EFF1F2"
+      class="sc-dlfnbm jOeRSr"
+      color="#E2E8EA"
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz iuKiqj"
+      class="sc-gsTCUz jkzjCh"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -22,7 +22,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz iuKiqj"
+      class="sc-gsTCUz jkzjCh"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -33,12 +33,12 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <hr
-      class="sc-dlfnbm gCtrZt"
-      color="#EFF1F2"
+      class="sc-dlfnbm jOeRSr"
+      color="#E2E8EA"
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz iuKiqj"
+      class="sc-gsTCUz jkzjCh"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -49,7 +49,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz iuKiqj"
+      class="sc-gsTCUz jkzjCh"
     >
       <p
         class="sc-hKgILt jKKuBF"

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
     class="sc-gsTCUz iJrLGt"
   >
     <div
-      class="sc-bdfBwQ bUSsTq"
+      class="sc-bdfBwQ iDgKAs"
     >
       <div
         class="sc-dlfnbm grIrFo"
@@ -17,7 +17,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
         class="sc-hKgILt ddzPiE"
       >
         <div
-          class="sc-fodVxV ffcHCC"
+          class="sc-fodVxV cCQXcA"
         >
           <div
             class="sc-bqyKva jotvqg"
@@ -85,7 +85,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           height="auto"
         >
           <div
-            class="sc-hHftDr jKZLhr"
+            class="sc-hHftDr jHvSYB"
           >
             <div
               class="sc-dmlrTW laZXFw"
@@ -106,7 +106,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           </div>
         </div>
         <div
-          class="sc-iqHYGH jQSdCX"
+          class="sc-iqHYGH bRtsPR"
         >
           <div
             class="sc-bqyKva jotvqg"
@@ -154,10 +154,10 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
         </div>
       </div>
       <div
-        class="sc-eCssSg koJJtk"
+        class="sc-eCssSg dQoyje"
       >
         <div
-          class="sc-gKsewC jJNCvM"
+          class="sc-gKsewC bmsxba"
         >
           <div
             class="sc-iBPRYJ idfKxT"

--- a/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
+++ b/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Pager component testing Pager 1`] = `
     display="flex"
   >
     <button
-      class="sc-dlfnbm ZuLxn"
+      class="sc-dlfnbm estAez"
       disabled=""
       type="button"
     >

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -6,10 +6,11 @@ export enum RadioButtonSize {
   MEDIUM = "18px",
 }
 
-const Wrapper = styled("label")<{ size: RadioButtonSize }>`
+const Wrapper = styled.label<{ size: RadioButtonSize; disabled?: boolean }>`
   position: relative;
   display: inline-flex;
   align-items: center;
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
 
   & > input {
     position: absolute;
@@ -19,6 +20,7 @@ const Wrapper = styled("label")<{ size: RadioButtonSize }>`
     width: ${({ size }) => size};
     height: ${({ size }) => size};
     opacity: 0;
+    cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   }
 `;
 
@@ -34,7 +36,7 @@ type IndicatorProps = {
   inside: string;
   border: string;
 };
-const Indicator = styled("div")<IndicatorProps>`
+const Indicator = styled.div<IndicatorProps>`
   position: relative;
   display: block;
   flex: 1 0 auto;
@@ -114,14 +116,26 @@ class RadioButton extends React.PureComponent<RadioButtonProps> {
   };
 
   public render(): React.ReactNode {
-    const { children, size, onChange, inputRef, ...rest } = this.props;
+    const {
+      children,
+      size,
+      disabled,
+      onChange,
+      inputRef,
+      ...rest
+    } = this.props;
     const radioButtonSize = size as RadioButtonSize;
 
     return (
-      <Wrapper as={children == null ? "span" : "label"} size={radioButtonSize}>
+      <Wrapper
+        as={children == null ? "span" : "label"}
+        disabled={disabled}
+        size={radioButtonSize}
+      >
         <input
           {...rest}
           ref={inputRef}
+          disabled={disabled}
           type="radio"
           onChange={this.handleChange}
         />

--- a/src/components/RadioButton/__tests__/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/RadioButton/__tests__/__snapshots__/RadioButton.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`RadioButton component testing RadioButton 1`] = `
 <DocumentFragment>
   <label
-    class="sc-bdfBwQ gxGykb"
+    class="sc-bdfBwQ fkKwBj"
   >
     <input
       type="radio"
     />
     <div
-      class="sc-gsTCUz fgUbaw"
+      class="sc-gsTCUz gTmmBS"
     />
     <span
       class="sc-dlfnbm ldcfCB"

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -157,6 +157,7 @@ const Select: SelectComponent = ({
   limit,
   onInputChange,
   minWidth,
+  isDisabled,
   error = false,
   ...rest
 }) => {
@@ -179,11 +180,12 @@ const Select: SelectComponent = ({
     return "見つかりませんでした";
   };
   return (
-    <Styled.Container minWidth={minWidth}>
+    <Styled.Container minWidth={minWidth} isDisabled={isDisabled}>
       <ReactSelect
         isClearable
         placeholder="選択してください"
         noOptionsMessage={getEmptyMessage}
+        isDisabled={isDisabled}
         styles={getOverrideStyles(theme, error)}
         maxMenuHeight={150}
         // MEMO: use palette in Styled.ReactSelectMenuList

--- a/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Select component testing Disable multiple selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ jNedcy"
   >
     <div
       class=" css-14jk2my-container"
@@ -15,7 +15,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
           class=" css-12ms9px-ValueContainer"
         >
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-uybk9d"
@@ -50,7 +50,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
             </div>
           </div>
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-uybk9d"
@@ -163,7 +163,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
 exports[`Select component testing Disable not selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ jNedcy"
   >
     <div
       class=" css-14jk2my-container"
@@ -267,7 +267,7 @@ exports[`Select component testing Disable not selected 1`] = `
 exports[`Select component testing Disable one selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ jNedcy"
   >
     <div
       class=" css-14jk2my-container"
@@ -371,7 +371,7 @@ exports[`Select component testing Disable one selected 1`] = `
 exports[`Select component testing Error multiple selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -383,7 +383,7 @@ exports[`Select component testing Error multiple selected 1`] = `
           class=" css-12ms9px-ValueContainer"
         >
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-18bjtpy"
@@ -418,7 +418,7 @@ exports[`Select component testing Error multiple selected 1`] = `
             </div>
           </div>
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-18bjtpy"
@@ -481,7 +481,7 @@ exports[`Select component testing Error multiple selected 1`] = `
           class=" css-1hb7zxy-IndicatorsContainer"
         >
           <div
-            class="sc-jSgupP lazPgH"
+            class="sc-jSgupP fhHPSN"
           >
             <div
               aria-hidden="true"
@@ -561,7 +561,7 @@ exports[`Select component testing Error multiple selected 1`] = `
 exports[`Select component testing Error not selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -664,7 +664,7 @@ exports[`Select component testing Error not selected 1`] = `
 exports[`Select component testing Error one selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -709,7 +709,7 @@ exports[`Select component testing Error one selected 1`] = `
           class=" css-1hb7zxy-IndicatorsContainer"
         >
           <div
-            class="sc-jSgupP lazPgH"
+            class="sc-jSgupP fhHPSN"
           >
             <div
               aria-hidden="true"
@@ -798,7 +798,7 @@ exports[`Select component testing Error one selected 1`] = `
 exports[`Select component testing Normal multiple selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -810,7 +810,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
           class=" css-12ms9px-ValueContainer"
         >
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-gqt44k"
@@ -845,7 +845,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
             </div>
           </div>
           <div
-            class="css-jahdpg-multiValue"
+            class="css-utwydg-multiValue"
           >
             <div
               class="css-gqt44k"
@@ -908,7 +908,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
           class=" css-1hb7zxy-IndicatorsContainer"
         >
           <div
-            class="sc-jSgupP lazPgH"
+            class="sc-jSgupP fhHPSN"
           >
             <div
               aria-hidden="true"
@@ -988,7 +988,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
 exports[`Select component testing Normal not selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -1091,7 +1091,7 @@ exports[`Select component testing Normal not selected 1`] = `
 exports[`Select component testing Normal one selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ fQdfBQ"
+    class="sc-bdfBwQ eYvPRt"
   >
     <div
       class=" css-2b097c-container"
@@ -1136,7 +1136,7 @@ exports[`Select component testing Normal one selected 1`] = `
           class=" css-1hb7zxy-IndicatorsContainer"
         >
           <div
-            class="sc-jSgupP lazPgH"
+            class="sc-jSgupP fhHPSN"
           >
             <div
               aria-hidden="true"

--- a/src/components/Select/styled.ts
+++ b/src/components/Select/styled.ts
@@ -3,8 +3,12 @@ import styled, { DefaultTheme, StyledComponent } from "styled-components";
 import { components, MenuListComponentProps } from "react-select";
 import { addScrollbarProperties } from "../../utils/scrollbar";
 
-export const Container = styled.div<{ minWidth?: string }>`
+export const Container = styled.div<{
+  minWidth?: string;
+  isDisabled?: boolean;
+}>`
   min-width: ${({ minWidth }) => minWidth || "auto"};
+  cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "auto")};
 `;
 
 // MEMO: Add type annotations cause of Error↓

--- a/src/components/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Spinner component testing Spinner 1`] = `
         cx="50"
         cy="50"
         r="20"
-        stroke="#EFF1F2"
+        stroke="#E2E8EA"
       />
       <circle
         class="sc-dlfnbm sc-hKgILt erQbZM fZCBdO"

--- a/src/components/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Switch component testing Switch 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ cEaTJr"
+    class="sc-bdfBwQ iIovdh"
   >
     <div
       class="sc-gsTCUz khJLZs"

--- a/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextField component testing TextField 1`] = `
       class="sc-gsTCUz cWMhHG"
     >
       <input
-        class="sc-jSgupP iXafGT"
+        class="sc-jSgupP hRvuiY"
       />
     </div>
   </div>
@@ -48,7 +48,7 @@ exports[`TextField component testing TextField passward 1`] = `
         </div>
       </div>
       <input
-        class="sc-jSgupP iXafGT"
+        class="sc-jSgupP hRvuiY"
       />
     </div>
   </div>
@@ -64,7 +64,7 @@ exports[`TextField component testing TextField with icon 1`] = `
       class="sc-gsTCUz cXmLeR"
     >
       <input
-        class="sc-jSgupP iXafGT"
+        class="sc-jSgupP hRvuiY"
         type="password"
       />
       <div

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
     width="56px"
   >
     <label
-      class="sc-dlfnbm gQubrr"
+      class="sc-dlfnbm jRmUcB"
       width="56px"
     >
       <input

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -55,7 +55,7 @@ export const Label = styled.label<LabelProps>`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   width: ${({ width }) => width};
   height: calc(1px * 2 + 22px);
   background-color: ${({ active, disabled, theme }) =>

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -65,7 +65,7 @@ export const colors: { [color: string]: Color } = {
     50: "#FDFEFF",
 
     100: "#F5F7F8",
-    200: "#EFF1F2",
+    200: "#E2E8EA",
     300: "#D1D5DA",
     400: "#B3BAC1",
     500: "#959FA9",


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

ref: https://github.com/voyagegroup/fluct_XDC/issues/110
ref: https://github.com/voyagegroup/fluct_XDC/issues/111
ref: https://github.com/voyagegroup/fluct_XDC/issues/112

Border付きCardのようす
<img width="900" alt="スクリーンショット 2021-02-01 15 58 49" src="https://user-images.githubusercontent.com/11240481/106424954-6e21f500-64a6-11eb-8b31-8c6b07c8bd97.png">


`cursor: not-allowed` を追加したコンポーネント
* Button
* ButtonGroup (Buttonへの追加の影響)
* Checkbox
* DropdownButton (Buttonへの追加の影響)
* Input
* Select
* ToggleButton
* RadioButton