### PR TITLE
ConfirmModal(fullSize)の修正

### DIFF
--- a/src/components/ConfirmModal/styled.ts
+++ b/src/components/ConfirmModal/styled.ts
@@ -107,6 +107,7 @@ export const ModalFooter = styled.div<{ fullSize: boolean }>`
   background-color: ${({ theme }) => theme.palette.gray.light};
   border-radius: ${({ fullSize, theme }) =>
     fullSize ? 0 : `0 0 ${theme.radius}px ${theme.radius}px`};
+  margin-bottom: ${({ fullSize }) => (fullSize ? "1.8vh" : "auto")};
 `;
 
 export const IconContainer = styled.div`


### PR DESCRIPTION
# やったこと
`ConfirmModal`のフッターが隠れてしまっていたので、修正

# ref
- #234
- https://cartaholdings.slack.com/archives/C018N87TM70/p1614850726126900 

# 確認方法
`yarn storybook` 

### before
![スクリーンショット 2021-03-08 11 02 21](https://user-images.githubusercontent.com/56141035/110265275-8ed9ef00-7ffe-11eb-9a48-fe33a9dc2a27.png)

### after
![スクリーンショット 2021-03-08 11 02 04](https://user-images.githubusercontent.com/56141035/110265288-939ea300-7ffe-11eb-9372-d16318156a64.png)
