### PR TITLE
Buttonからmin-width除去 & menuContentsにdisabledを追加

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -79,17 +79,14 @@ const getContainerColorStyles = (
   },
 });
 
-const buttonSize: Record<ButtonSize, { minWidth: string; height: string }> = {
+const buttonSize: Record<ButtonSize, { height: string }> = {
   small: {
-    minWidth: "64px",
     height: "32px",
   },
   medium: {
-    minWidth: "130px",
     height: "42px",
   },
   large: {
-    minWidth: "178px",
     height: "48px",
   },
 };
@@ -153,7 +150,6 @@ const Button: React.FunctionComponent<ButtonProps> = ({
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
       height={buttonSize[size].height}
-      minWidth={buttonSize[size].minWidth}
     >
       {children}
     </Styled.ButtonContainer>

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm drHOmF eVHwxU"
+    class="sc-gsTCUz sc-dlfnbm drHOmF dMbzMA"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -9,7 +9,6 @@ export type ContainerProps = ButtonColorStyle & {
   fontWeight: string;
   height: string;
   horizontalPadding: string;
-  minWidth: string;
   href?: string;
   disabled?: boolean;
 };
@@ -21,7 +20,6 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   padding-right: ${({ horizontalPadding }) => horizontalPadding};
   padding-left: ${({ horizontalPadding }) => horizontalPadding};
   width: ${({ inline }) => (inline ? "auto" : "100%")};
-  min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${({ theme }) => theme.radius}px;
   border: ${({ normal, disabled }) => (disabled ? 0 : normal.border)};

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO hSrEyx"
+      class="sc-dlfnbm sc-hKgILt iQdNXO kBCnFt"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO hSrEyx"
+      class="sc-dlfnbm sc-hKgILt iQdNXO kBCnFt"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -11,6 +11,7 @@ export type ContextMenuProps = {
    *   text: string;
    *   onClick: () => void;
    *   divideTop?: boolean;
+   *   disabled?: boolean;
    * }`
    */
   contents: ContentProp[];

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC kOKIon"
+          class="sc-gKsewC eFXhdS"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -68,7 +68,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC kOKIon"
+          class="sc-gKsewC eFXhdS"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -84,7 +84,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC kOKIon"
+          class="sc-gKsewC eFXhdS"
         >
           <p
             class="sc-hKgILt jKKuBF"
@@ -95,7 +95,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC kOKIon"
+          class="sc-gKsewC eFXhdS"
         >
           <p
             class="sc-hKgILt jKKuBF"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF hnouyd sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF iDkGgJ sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -51,7 +51,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -62,7 +62,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -78,7 +78,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -89,7 +89,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -112,7 +112,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF eVHwxU sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF dMbzMA sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -161,7 +161,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -172,7 +172,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -188,7 +188,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -199,7 +199,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -222,7 +222,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF cyQxHy sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF hFvtmK sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -231,7 +231,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF cyQxHy sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF hFvtmK sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -274,7 +274,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -285,7 +285,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -301,7 +301,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -312,7 +312,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -335,7 +335,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF gsbZLr sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF dJCGgL sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -343,7 +343,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF gsbZLr sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF dJCGgL sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -391,7 +391,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -402,7 +402,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -418,7 +418,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           orientation="horizontal"
         />
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"
@@ -429,7 +429,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-pFZIQ kdyKdd"
+          class="sc-pFZIQ gTJVis"
         >
           <p
             class="sc-bdfBwQ gNlqto"

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -20,6 +20,7 @@ export type MenuProps = React.ComponentPropsWithRef<"div"> & {
    *   text: string;
    *   onClick: () => void;
    *   divideTop?: boolean;
+   *   disabled?: boolean;
    * }`
    */
   contents: ContentProp[];

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -18,7 +18,7 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
       contents: [
         { text: "Save", onClick: () => {} },
         { text: "Edit", onClick: () => {} },
-        { text: "Delete", onClick: () => {}, disabled:true },
+        { text: "Delete", onClick: () => {}, disabled: true },
         { text: "Update", onClick: () => {} },
       ],
       maxHeight: "100px",

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -18,7 +18,7 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
       contents: [
         { text: "Save", onClick: () => {} },
         { text: "Edit", onClick: () => {} },
-        { text: "Delete", onClick: () => {} },
+        { text: "Delete", onClick: () => {}, disabled:true },
         { text: "Update", onClick: () => {} },
       ],
       maxHeight: "100px",

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -10,6 +10,7 @@ export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   // TODO: rename "handleClick"
   onClick: () => void;
   divideTop?: boolean;
+  disabled?: boolean;
 };
 
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
@@ -34,8 +35,16 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
               <Divider my={1} mx={2} color={theme.palette.gray.light} />
             )}
             {/* eslint-disable-next-line react/jsx-handler-names */}
-            <Styled.TextContainer onClick={content.onClick}>
-              <Typography size="sm">{content.text}</Typography>
+            <Styled.TextContainer
+              disabled={content.disabled}
+              onClick={content.onClick}
+            >
+              <Typography
+                size="sm"
+                color={content.disabled ? "disabled" : "initial"}
+              >
+                {content.text}
+              </Typography>
             </Styled.TextContainer>
           </React.Fragment>
         ))}

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz jkzjCh"
+      class="sc-gsTCUz gFfxhE"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -22,7 +22,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz jkzjCh"
+      class="sc-gsTCUz gFfxhE"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -38,7 +38,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz jkzjCh"
+      class="sc-gsTCUz gFfxhE"
     >
       <p
         class="sc-hKgILt jKKuBF"
@@ -49,7 +49,7 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz jkzjCh"
+      class="sc-gsTCUz gFfxhE"
     >
       <p
         class="sc-hKgILt jKKuBF"

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -15,18 +15,22 @@ export const Container = styled.div<ContainerProps>`
   ${({ maxHeight }) => addScrollbarProperties({ maxHeight })}
 `;
 
-export const TextContainer = styled.div`
-  cursor: pointer;
+export const TextContainer = styled.div<{ disabled?: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   display: flex;
   align-items: center;
+  color: ${({ disabled, theme }) =>
+    disabled ? theme.palette.text.disabled : "auto"};
   height: 32px;
   margin: 0 ${({ theme }) => theme.spacing}px;
   padding: 0 ${({ theme }) => theme.spacing}px;
   border-radius: ${({ theme }) => theme.radius}px;
   &:hover {
-    background-color: ${({ theme }) => theme.palette.gray.light};
+    background-color: ${({ disabled, theme }) =>
+      disabled ? "auto" : theme.palette.gray.light};
   }
   &:active {
-    background-color: ${({ theme }) => theme.palette.gray.main};
+    background-color: ${({ disabled, theme }) =>
+      disabled ? "auto" : theme.palette.gray.main};
   }
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

* Buttonからmin-width除去
<img width="148" alt="スクリーンショット 2021-03-10 12 00 59" src="https://user-images.githubusercontent.com/11240481/110569834-65ed6180-8198-11eb-98fa-850582a8672d.png">

* menuContentsにdisabledを追加
<img width="132" alt="スクリーンショット 2021-03-10 12 00 43" src="https://user-images.githubusercontent.com/11240481/110569844-684fbb80-8198-11eb-8612-593f6700add5.png">
