### PR TITLE
ボタンのデザインを変更

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,8 +33,11 @@ const getContainerColorStyles = (
     normal: {
       background: theme.palette.primary.main,
       color: theme.palette.white,
-      boxShadow: `0px 0px 16px ${hexToRgba(theme.palette.primary.main, 0.4)}`,
-      border: "none",
+      boxShadow: `0px -2px ${hexToRgba(
+        theme.palette.black,
+        0.16,
+      )} inset, 0px 2px ${hexToRgba(theme.palette.black, 0.08)}`,
+      border: `1px solid ${theme.palette.primary.dark}`,
     },
     hover: {
       background: theme.palette.primary.dark,
@@ -49,7 +52,10 @@ const getContainerColorStyles = (
     normal: {
       background: theme.palette.white,
       color: theme.palette.black,
-      boxShadow: "none",
+      boxShadow: `0px -2px ${hexToRgba(
+        theme.palette.black,
+        0.16,
+      )} inset, 0px 2px ${hexToRgba(theme.palette.black, 0.08)}`,
       border: `1px solid ${theme.palette.divider}`,
     },
     hover: {
@@ -65,8 +71,11 @@ const getContainerColorStyles = (
     normal: {
       background: theme.palette.danger.main,
       color: theme.palette.white,
-      boxShadow: `0px 0px 16px ${hexToRgba(theme.palette.danger.main, 0.4)}`,
-      border: "none",
+      boxShadow: `0px -2px ${hexToRgba(
+        theme.palette.danger.main,
+        0.16,
+      )} inset, 0px 2px ${hexToRgba(theme.palette.danger.dark, 0.08)}`,
+      border: `1px solid ${theme.palette.danger.deepDark}`,
     },
     hover: {
       background: theme.palette.danger.dark,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,7 +44,7 @@ const getContainerColorStyles = (
       border: "none",
     },
     active: {
-      background: theme.palette.primary.deepDark,
+      background: theme.palette.primary.dark,
       border: "none",
     },
   },
@@ -63,7 +63,7 @@ const getContainerColorStyles = (
       border: `1px solid ${theme.palette.divider}`,
     },
     active: {
-      background: theme.palette.gray.light,
+      background: theme.palette.gray.highlight,
       border: `1px solid ${theme.palette.divider}`,
     },
   },
@@ -82,7 +82,7 @@ const getContainerColorStyles = (
       border: "none",
     },
     active: {
-      background: theme.palette.danger.deepDark,
+      background: theme.palette.danger.dark,
       border: "none",
     },
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -100,6 +100,24 @@ const verticalPadding: Record<ButtonSize, { padding: string }> = {
   },
 };
 
+const paddingAtActive: Record<
+  ButtonSize,
+  { paddingTop: string; paddingBottom: string }
+> = {
+  small: {
+    paddingTop: "7px",
+    paddingBottom: "5px",
+  },
+  medium: {
+    paddingTop: "11px",
+    paddingBottom: "9px",
+  },
+  large: {
+    paddingTop: "14px",
+    paddingBottom: "12px",
+  },
+};
+
 export type ButtonProps = Omit<BaseButtonProps, "color"> & {
   /**
    * The component used for the root node.
@@ -149,10 +167,11 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       {...rest}
       as={component || "button"}
       {...anchorProps}
-      size={size}
       inline={inline}
       verticalPadding={verticalPadding[size].padding}
       horizontalPadding={horizontalPadding}
+      paddingTopAtActive={paddingAtActive[size].paddingTop}
+      paddingBottomAtActive={paddingAtActive[size].paddingBottom}
       normal={{ ...colorStyle.normal }}
       hover={{ ...colorStyle.hover }}
       active={{ ...colorStyle.active }}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -32,7 +32,7 @@ const getContainerColorStyles = (
   primary: {
     normal: {
       background: theme.palette.primary.main,
-      color: theme.palette.white,
+      color: theme.palette.text.white,
       boxShadow: `0px -2px ${hexToRgba(
         theme.palette.black,
         0.16,
@@ -50,7 +50,7 @@ const getContainerColorStyles = (
   },
   secondary: {
     normal: {
-      background: theme.palette.white,
+      background: theme.palette.background.default,
       color: theme.palette.black,
       boxShadow: `0px -2px ${hexToRgba(
         theme.palette.black,
@@ -59,23 +59,23 @@ const getContainerColorStyles = (
       border: `1px solid ${theme.palette.divider}`,
     },
     hover: {
-      background: theme.palette.gray.light,
+      background: theme.palette.gray.highlight,
       border: `1px solid ${theme.palette.divider}`,
     },
     active: {
-      background: theme.palette.gray.main,
+      background: theme.palette.gray.light,
       border: `1px solid ${theme.palette.divider}`,
     },
   },
   danger: {
     normal: {
       background: theme.palette.danger.main,
-      color: theme.palette.white,
+      color: theme.palette.text.white,
       boxShadow: `0px -2px ${hexToRgba(
-        theme.palette.danger.main,
+        theme.palette.black,
         0.16,
-      )} inset, 0px 2px ${hexToRgba(theme.palette.danger.dark, 0.08)}`,
-      border: `1px solid ${theme.palette.danger.deepDark}`,
+      )} inset, 0px 2px ${hexToRgba(theme.palette.black, 0.08)}`,
+      border: `1px solid ${theme.palette.danger.dark}`,
     },
     hover: {
       background: theme.palette.danger.dark,
@@ -88,15 +88,15 @@ const getContainerColorStyles = (
   },
 });
 
-const buttonSize: Record<ButtonSize, { height: string }> = {
+const verticalPadding: Record<ButtonSize, { padding: string }> = {
   small: {
-    height: "32px",
+    padding: "6px",
   },
   medium: {
-    height: "42px",
+    padding: "10px",
   },
   large: {
-    height: "48px",
+    padding: "13px",
   },
 };
 
@@ -149,7 +149,9 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       {...rest}
       as={component || "button"}
       {...anchorProps}
+      size={size}
       inline={inline}
+      verticalPadding={verticalPadding[size].padding}
       horizontalPadding={horizontalPadding}
       normal={{ ...colorStyle.normal }}
       hover={{ ...colorStyle.hover }}
@@ -158,7 +160,6 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       fontSize={
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
-      height={buttonSize[size].height}
     >
       {children}
     </Styled.ButtonContainer>

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm hekyXD fnQtw"
+    class="sc-gsTCUz sc-dlfnbm hekyXD dvRQZw"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm hekyXD dvRQZw"
+    class="sc-gsTCUz sc-dlfnbm idRKex dvRQZw"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm hekyXD hvhNAv"
+    class="sc-gsTCUz sc-dlfnbm hekyXD fnQtw"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,10 +3,9 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm drHOmF jLGulE"
+    class="sc-gsTCUz sc-dlfnbm hekyXD hvhNAv"
     font-size="14px"
     font-weight="bold"
-    height="42px"
   />
 </DocumentFragment>
 `;

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm drHOmF dtyYRP"
+    class="sc-gsTCUz sc-dlfnbm drHOmF jLGulE"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm drHOmF dMbzMA"
+    class="sc-gsTCUz sc-dlfnbm drHOmF dtyYRP"
     font-size="14px"
     font-weight="bold"
     height="42px"

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm idRKex hRnnYH"
+    class="sc-gsTCUz sc-dlfnbm idRKex bHISMI"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm idRKex dvRQZw"
+    class="sc-gsTCUz sc-dlfnbm idRKex hRnnYH"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/internal/BaseButton.tsx
+++ b/src/components/Button/internal/BaseButton.tsx
@@ -4,7 +4,7 @@ export type Props = React.ComponentPropsWithRef<"button">;
 
 export const BaseButton = styled.button`
   margin: 0;
-  padding: 0;
+  padding: 10px 16px;
   border: 0;
   background-color: transparent;
   text-decoration: none;
@@ -16,8 +16,6 @@ export const BaseButton = styled.button`
   outline: none;
 
   &:disabled {
-    box-shadow: none;
-    text-shadow: none;
     cursor: not-allowed;
   }
 `;

--- a/src/components/Button/internal/BaseButton.tsx
+++ b/src/components/Button/internal/BaseButton.tsx
@@ -4,7 +4,7 @@ export type Props = React.ComponentPropsWithRef<"button">;
 
 export const BaseButton = styled.button`
   margin: 0;
-  padding: 10px 16px;
+  padding: 0;
   border: 0;
   background-color: transparent;
   text-decoration: none;

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -17,24 +17,28 @@ export type ContainerProps = ButtonColorStyle & {
   disabled?: boolean;
 };
 
-function computePaddingBySize(size: ButtonSize) {
-  if (size === "small") {
-    return css`
-      padding-top: 7px;
-      padding-bottom: 5px;
-    `;
-  } else if (size === "medium") {
-    return css`
-      padding-top: 11px;
-      padding-bottom: 9px;
-    `;
-  } else {
-    return css`
-      padding-top: 14px;
-      padding-bottom: 12px;
-    `;
+const computePaddingBySize = (size?: ButtonSize) => {
+  switch (size) {
+    case "small":
+      return css`
+        padding-top: 7px;
+        padding-bottom: 5px;
+      `;
+      break;
+    case "large":
+      return css`
+        padding-top: 14px;
+        padding-bottom: 12px;
+      `;
+      break;
+    default:
+      return css`
+        padding-top: 11px;
+        padding-bottom: 9px;
+      `;
+      break;
   }
-}
+};
 
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   display: ${({ inline }) => (inline ? "inline-flex" : "flex")};

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -1,44 +1,76 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { BaseButton } from "./internal/BaseButton";
-import { ButtonColorStyle } from "./Button";
+import { ButtonColorStyle, ButtonSize } from "./Button";
+
+import { hexToRgba } from "../../utils/hexToRgba";
 
 export type ContainerProps = ButtonColorStyle & {
   inline: boolean;
+  size: ButtonSize;
   fontSize: string;
   fontWeight: string;
   height: string;
+  verticalPadding: string;
   horizontalPadding: string;
   href?: string;
   disabled?: boolean;
 };
 
+function computePaddingBySize(size: ButtonSize) {
+  if (size === "small") {
+    return css`
+      padding-top: 7px;
+      padding-bottom: 5px;
+    `;
+  } else if (size === "medium") {
+    return css`
+      padding-top: 11px;
+      padding-bottom: 9px;
+    `;
+  } else {
+    return css`
+      padding-top: 14px;
+      padding-bottom: 12px;
+    `;
+  }
+}
+
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   display: ${({ inline }) => (inline ? "inline-flex" : "flex")};
   justify-content: center;
   align-items: center;
-  padding-right: ${({ horizontalPadding }) => horizontalPadding};
-  padding-left: ${({ horizontalPadding }) => horizontalPadding};
+  padding: ${({ verticalPadding, horizontalPadding }) =>
+    `${verticalPadding} ${horizontalPadding}`};
   width: ${({ inline }) => (inline ? "auto" : "100%")};
   height: ${({ height }) => height};
   border-radius: ${({ theme }) => theme.radius}px;
-  border: ${({ normal, disabled }) => (disabled ? 0 : normal.border)};
+  border: ${({ normal, disabled, theme }) =>
+    disabled ? `1px solid ${theme.palette.divider}` : normal.border};
   background: ${({ normal, disabled, theme }) =>
-    disabled ? theme.palette.gray.highlight : normal.background};
+    disabled ? theme.palette.gray.light : normal.background};
   color: ${({ normal, disabled, theme }) =>
     disabled ? theme.palette.text.disabled : normal.color};
   text-align: center;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-size: ${({ fontSize }) => fontSize};
-  box-shadow: ${({ normal, disabled }) =>
-    disabled ? "none" : normal.boxShadow};
-  transition: all 0.3s;
+  box-shadow: ${({ normal, disabled, theme }) =>
+    disabled
+      ? `0px -2px ${hexToRgba(
+          theme.palette.black,
+          0.16,
+        )} inset, 0px 2px ${hexToRgba(theme.palette.black, 0.08)}`
+      : normal.boxShadow};
+  transition: background 0.3s;
 
   &:hover:not([disabled]) {
     background: ${({ hover }) => hover.background};
   }
 
-  &:active {
+  &:active:not([disabled]) {
     background: ${({ active }) => active.background};
+    ${({ size }) => computePaddingBySize(size)}
+    box-shadow: ${({ theme }) =>
+      `inset 0 2px ${hexToRgba(theme.palette.black, 0.16)}`};
   }
 `;

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -1,43 +1,21 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import { BaseButton } from "./internal/BaseButton";
-import { ButtonColorStyle, ButtonSize } from "./Button";
+import { ButtonColorStyle } from "./Button";
 
 import { hexToRgba } from "../../utils/hexToRgba";
 
 export type ContainerProps = ButtonColorStyle & {
   inline: boolean;
-  size: ButtonSize;
   fontSize: string;
   fontWeight: string;
   height: string;
   verticalPadding: string;
   horizontalPadding: string;
+  paddingTopAtActive: string;
+  paddingBottomAtActive: string;
   href?: string;
   disabled?: boolean;
-};
-
-const computePaddingBySize = (size?: ButtonSize) => {
-  switch (size) {
-    case "small":
-      return css`
-        padding-top: 7px;
-        padding-bottom: 5px;
-      `;
-      break;
-    case "large":
-      return css`
-        padding-top: 14px;
-        padding-bottom: 12px;
-      `;
-      break;
-    default:
-      return css`
-        padding-top: 11px;
-        padding-bottom: 9px;
-      `;
-      break;
-  }
 };
 
 export const ButtonContainer = styled(BaseButton)<ContainerProps>`
@@ -72,7 +50,8 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   }
 
   &:active:not([disabled]) {
-    ${({ size }) => computePaddingBySize(size)}
+    padding-top: ${({ paddingTopAtActive }) => paddingTopAtActive};
+    padding-bottom: ${({ paddingBottomAtActive }) => paddingBottomAtActive};
     background: ${({ active }) => active.background};
     box-shadow: ${({ theme }) =>
       `inset 0 2px ${hexToRgba(theme.palette.black, 0.16)}`};

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -72,8 +72,8 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   }
 
   &:active:not([disabled]) {
-    background: ${({ active }) => active.background};
     ${({ size }) => computePaddingBySize(size)}
+    background: ${({ active }) => active.background};
     box-shadow: ${({ theme }) =>
       `inset 0 2px ${hexToRgba(theme.palette.black, 0.16)}`};
   }

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -40,6 +40,5 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
 
   &:active {
     background: ${({ active }) => active.background};
-    box-shadow: none;
   }
 `;

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -11,17 +11,12 @@ export type ButtonGroupProps = {
   disabled?: boolean;
 };
 
-const buttonSize: Record<
-  GroupButtonSize,
-  { minWidth: string; height: string }
-> = {
+const buttonSize: Record<GroupButtonSize, { minWidth: string }> = {
   small: {
     minWidth: "63px",
-    height: "32px",
   },
   medium: {
     minWidth: "71px",
-    height: "42px",
   },
 };
 
@@ -52,7 +47,6 @@ const ButtonGroup: React.FunctionComponent<ButtonGroupProps> = ({
 
   return (
     <Styled.ButtonGroupContainer
-      height={buttonSize[size].height}
       minWidth={buttonSize[size].minWidth}
       horizontalPadding={horizontalPadding}
     >

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -34,7 +34,6 @@ const ButtonGroup: React.FunctionComponent<ButtonGroupProps> = ({
   const horizontalPadding =
     size === "small" ? `${theme.spacing}px` : `${theme.spacing * 2}px`;
 
-  let isLeftButtonDisabled = false;
   const childrenWithProps = React.Children.map(
     children,
     (child: React.ReactElement) => {
@@ -44,14 +43,9 @@ const ButtonGroup: React.FunctionComponent<ButtonGroupProps> = ({
         size: size,
         color: "secondary",
         style: {
-          borderLeft:
-            isLeftButtonDisabled &&
-            !child.props.disabled &&
-            `1px solid ${theme.palette.divider}`,
           ...child.props.style,
         },
       });
-      isLeftButtonDisabled = child.props.disabled;
       return Button;
     },
   );

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -3,18 +3,17 @@
 exports[`Button component testing ButtonGroup 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ dsjYGL"
-    height="42px"
+    class="sc-bdfBwQ kogCJu"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG hXFYVy"
+      class="sc-dlfnbm sc-hKgILt bqGKDG bAUIQU"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG hXFYVy"
+      class="sc-dlfnbm sc-hKgILt bqGKDG bAUIQU"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO gEAWww"
+      class="sc-dlfnbm sc-hKgILt iQdNXO kgGiDT"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO gEAWww"
+      class="sc-dlfnbm sc-hKgILt iQdNXO kgGiDT"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE kKYuKr"
+      class="sc-dlfnbm sc-hKgILt eHpxDE ivZeNy"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE kKYuKr"
+      class="sc-dlfnbm sc-hKgILt eHpxDE ivZeNy"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO kBCnFt"
+      class="sc-dlfnbm sc-hKgILt iQdNXO gEAWww"
       font-size="14px"
       font-weight="normal"
       height="42px"
@@ -15,7 +15,7 @@ exports[`Button component testing ButtonGroup 1`] = `
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO kBCnFt"
+      class="sc-dlfnbm sc-hKgILt iQdNXO gEAWww"
       font-size="14px"
       font-weight="normal"
       height="42px"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`Button component testing ButtonGroup 1`] = `
     class="sc-bdfBwQ kogCJu"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG bAUIQU"
+      class="sc-dlfnbm sc-hKgILt bqGKDG UcvjX"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG bAUIQU"
+      class="sc-dlfnbm sc-hKgILt bqGKDG UcvjX"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE ivZeNy"
+      class="sc-dlfnbm sc-hKgILt eHpxDE hXFYVy"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE ivZeNy"
+      class="sc-dlfnbm sc-hKgILt eHpxDE hXFYVy"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE hXFYVy"
+      class="sc-dlfnbm sc-hKgILt bqGKDG hXFYVy"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt eHpxDE hXFYVy"
+      class="sc-dlfnbm sc-hKgILt bqGKDG hXFYVy"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -7,18 +7,16 @@ exports[`Button component testing ButtonGroup 1`] = `
     height="42px"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO kgGiDT"
+      class="sc-dlfnbm sc-hKgILt eHpxDE kKYuKr"
       font-size="14px"
       font-weight="normal"
-      height="42px"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt iQdNXO kgGiDT"
+      class="sc-dlfnbm sc-hKgILt eHpxDE kKYuKr"
       font-size="14px"
       font-weight="normal"
-      height="42px"
     >
       Save
     </button>

--- a/src/components/ButtonGroup/styled.ts
+++ b/src/components/ButtonGroup/styled.ts
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export type ContainerProps = {
-  height: string;
   minWidth: string;
   horizontalPadding: string;
 };
@@ -12,7 +11,6 @@ export const ButtonGroupContainer = styled.div<ContainerProps>`
   & > * {
     min-width: ${({ minWidth }) => minWidth};
     width: auto;
-    height: ${({ height }) => height};
     padding-right: ${({ horizontalPadding }) => horizontalPadding};
     padding-left: ${({ horizontalPadding }) => horizontalPadding};
   }

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD kBzluP sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD eplhFT sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD fnQtw sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD dvRQZw sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD hEmsQU sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD lmCrlk sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD hEmsQU sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD lmCrlk sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD faYQAf sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD ibhWEv sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD faYQAf sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD ibhWEv sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex eplhFT sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex hqXYsA sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex dvRQZw sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex hRnnYH sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex lmCrlk sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex ccbNxb sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex lmCrlk sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex ccbNxb sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ibhWEv sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex gumtzI sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ibhWEv sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex gumtzI sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex hqXYsA sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex utbqr sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex hRnnYH sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex bHISMI sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ccbNxb sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex kVUASo sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ccbNxb sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex kVUASo sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex gumtzI sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex jIElxj sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex gumtzI sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex jIElxj sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,12 +7,11 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF idonPG sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD atvXa sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
       <div
@@ -112,11 +111,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF jLGulE sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD hvhNAv sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
       <div
@@ -222,21 +220,19 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF fVGGBF sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD jMETiR sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF fVGGBF sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD jMETiR sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"
@@ -335,19 +331,17 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kMaUzX sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD gCeTyI sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kMaUzX sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD gCeTyI sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF dMbzMA sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF dtyYRP sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -335,7 +335,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF dJCGgL sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF kBVvDg sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -343,7 +343,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF dJCGgL sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF kBVvDg sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD atvXa sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD kBzluP sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD hvhNAv sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm hekyXD fnQtw sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD jMETiR sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD hEmsQU sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD jMETiR sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD hEmsQU sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD gCeTyI sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm hekyXD faYQAf sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD gCeTyI sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm hekyXD faYQAf sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF iDkGgJ sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF idonPG sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -112,7 +112,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF dtyYRP sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm drHOmF jLGulE sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -222,7 +222,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF hFvtmK sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF fVGGBF sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -231,7 +231,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF hFvtmK sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF fVGGBF sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -335,7 +335,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kBVvDg sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm drHOmF kMaUzX sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
       height="42px"
@@ -343,7 +343,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm drHOmF kBVvDg sc-jSgupP pjuOx"
+      class="sc-gsTCUz sc-dlfnbm drHOmF kMaUzX sc-jSgupP pjuOx"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD eplhFT sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex eplhFT sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD dvRQZw sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex dvRQZw sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD lmCrlk sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex lmCrlk sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD lmCrlk sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex lmCrlk sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD ibhWEv sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex ibhWEv sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm hekyXD ibhWEv sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex ibhWEv sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"

--- a/src/components/DropdownButton/styled.ts
+++ b/src/components/DropdownButton/styled.ts
@@ -21,6 +21,12 @@ export const SplitToggle = styled(Button)`
         : theme.palette.divider};
   padding: 0 ${({ theme, size }) => (size === "small" ? 0 : theme.spacing)}px;
   min-width: auto;
+
+  &:active:not([disabled]) {
+    padding-bottom: 0;
+    padding-top: 2px;
+  }
+
   &:disabled {
     border-left: 1px solid ${({ theme }) => theme.palette.divider};
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## ref
[#118](https://github.com/voyagegroup/fluct_XDC/issues/118)

## やったこと
- ボタンのデザインを変更
  - ふんわりしたドロップシャドウのデザインから、カッチリした立体感のあるデザインに変更。

## 変更点
### Before
<img width="1201" alt="スクリーンショット 2021-03-12 16 20 46" src="https://user-images.githubusercontent.com/50824354/110906157-e81f8680-834e-11eb-847b-47138ac344b3.png">


### After
<img width="1200" alt="スクリーンショット 2021-03-12 16 19 52" src="https://user-images.githubusercontent.com/50824354/110906067-c920f480-834e-11eb-89e5-1429600073a8.png">
