### PR TITLE
トグルボタンのデザインを変更

### DIFF
--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -23,7 +23,7 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
 }) => {
   const textColor = active ? "primary" : "secondary";
   return (
-    <Styled.Container active={active} disabled={disabled} width={width}>
+    <Styled.Container width={width}>
       <Styled.Label active={active} disabled={disabled} width={width}>
         <Styled.HiddenInput
           ref={inputRef}
@@ -35,16 +35,28 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
           onChange={onChange}
         />
         <Styled.ToggleButton active={active} disabled={disabled} />
-        <Styled.LabelText position={active ? "left" : "right"}>
+        <Styled.ActiveLabelText position={active ? "right" : "left"}>
           <Typography
             component="div"
             color={disabled ? "disabled" : textColor}
+            align="center"
             size="xs"
             weight="bold"
           >
-            {active ? activeText : inActiveText}
+            {activeText}
           </Typography>
-        </Styled.LabelText>
+        </Styled.ActiveLabelText>
+        <Styled.InActiveLabelText position={active ? "right" : "left"}>
+          <Typography
+            component="div"
+            color={disabled ? "disabled" : textColor}
+            align="center"
+            size="xs"
+            weight="bold"
+          >
+            {inActiveText}
+          </Typography>
+        </Styled.InActiveLabelText>
       </Styled.Label>
     </Styled.Container>
   );

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -21,7 +21,6 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
   inActiveText = "OFF",
   inputRef,
 }) => {
-  const textColor = active ? "primary" : "secondary";
   return (
     <Styled.Container width={width}>
       <Styled.Label active={active} disabled={disabled} width={width}>
@@ -35,10 +34,10 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
           onChange={onChange}
         />
         <Styled.ToggleButton active={active} disabled={disabled} />
-        <Styled.ActiveLabelText position={active ? "right" : "left"}>
+        <Styled.ActiveLabelText>
           <Typography
             component="div"
-            color={disabled ? "disabled" : textColor}
+            color={disabled ? "disabled" : "primary"}
             align="center"
             size="xs"
             weight="bold"
@@ -46,10 +45,10 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
             {activeText}
           </Typography>
         </Styled.ActiveLabelText>
-        <Styled.InActiveLabelText position={active ? "right" : "left"}>
+        <Styled.InActiveLabelText>
           <Typography
             component="div"
-            color={disabled ? "disabled" : textColor}
+            color={disabled ? "disabled" : "secondary"}
             align="center"
             size="xs"
             weight="bold"

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -17,8 +17,8 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
   disabled = false,
   onChange,
   width = "56px",
-  activeText = "ONNNNNNNNNNNNNNNNN",
-  inActiveText = "OFFFFFFFFFFFFFFFFFFFFFF",
+  activeText = "ON",
+  inActiveText = "OFF",
   inputRef,
 }) => {
   return (

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -17,8 +17,8 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
   disabled = false,
   onChange,
   width = "56px",
-  activeText = "ON",
-  inActiveText = "OFF",
+  activeText = "ONNNNNNNNNNNNNNNNN",
+  inActiveText = "OFFFFFFFFFFFFFFFFFFFFFF",
   inputRef,
 }) => {
   return (

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -19,25 +19,25 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
         class="sc-gsTCUz bqUFVN"
       />
       <div
-        class="sc-dlfnbm sc-hKgILt bYFWIa iPmpMo"
+        class="sc-dlfnbm sc-hKgILt knXVJq xtjCQ"
       >
         <div
           class="sc-iBPRYJ dJqPht"
           color="#0B82F4"
           font-size="12px"
         >
-          ON
+          ONNNNNNNNNNNNNNNNN
         </div>
       </div>
       <div
-        class="sc-dlfnbm sc-eCssSg bYFWIa dxsAVF"
+        class="sc-dlfnbm sc-eCssSg knXVJq hvwnZm"
       >
         <div
           class="sc-iBPRYJ iZXNbL"
           color="#596978"
           font-size="12px"
         >
-          OFF
+          OFFFFFFFFFFFFFFFFFFFFFF
         </div>
       </div>
     </label>

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
     width="56px"
   >
     <label
-      class="sc-jSgupP jDuWXm"
+      class="sc-jSgupP eTVUCj"
       width="56px"
     >
       <input
@@ -16,21 +16,21 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
         type="checkbox"
       />
       <span
-        class="sc-gsTCUz fxdyjT"
+        class="sc-gsTCUz bqUFVN"
       />
       <div
-        class="sc-dlfnbm sc-hKgILt eWKzWA etPkmZ"
+        class="sc-dlfnbm sc-hKgILt bYFWIa iPmpMo"
       >
         <div
-          class="sc-iBPRYJ iZXNbL"
-          color="#596978"
+          class="sc-iBPRYJ dJqPht"
+          color="#0B82F4"
           font-size="12px"
         >
           ON
         </div>
       </div>
       <div
-        class="sc-dlfnbm sc-eCssSg eWKzWA iJJxuL"
+        class="sc-dlfnbm sc-eCssSg bYFWIa dxsAVF"
       >
         <div
           class="sc-iBPRYJ iZXNbL"

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -7,22 +7,33 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
     width="56px"
   >
     <label
-      class="sc-dlfnbm kSSUTB"
+      class="sc-jSgupP jDuWXm"
       width="56px"
     >
       <input
-        class="sc-hKgILt gtKLDR"
+        class="sc-gKsewC iTZwRO"
         readonly=""
         type="checkbox"
       />
       <span
-        class="sc-gsTCUz eMKoBC"
+        class="sc-gsTCUz hqweVm"
       />
       <div
-        class="sc-eCssSg boVAbf"
+        class="sc-dlfnbm sc-hKgILt eWKzWA etPkmZ"
       >
         <div
-          class="sc-jSgupP iQubmi"
+          class="sc-iBPRYJ iZXNbL"
+          color="#596978"
+          font-size="12px"
+        >
+          ON
+        </div>
+      </div>
+      <div
+        class="sc-dlfnbm sc-eCssSg eWKzWA iJJxuL"
+      >
+        <div
+          class="sc-iBPRYJ iZXNbL"
           color="#596978"
           font-size="12px"
         >

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
     width="56px"
   >
     <label
-      class="sc-dlfnbm ioGuzp"
+      class="sc-dlfnbm kSSUTB"
       width="56px"
     >
       <input

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
           color="#0B82F4"
           font-size="12px"
         >
-          ONNNNNNNNNNNNNNNNN
+          ON
         </div>
       </div>
       <div
@@ -37,7 +37,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
           color="#596978"
           font-size="12px"
         >
-          OFFFFFFFFFFFFFFFFFFFFFF
+          OFF
         </div>
       </div>
     </label>

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
     width="56px"
   >
     <label
-      class="sc-dlfnbm jRmUcB"
+      class="sc-dlfnbm ioGuzp"
       width="56px"
     >
       <input
@@ -16,7 +16,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
         type="checkbox"
       />
       <span
-        class="sc-gsTCUz bYFmhz"
+        class="sc-gsTCUz eMKoBC"
       />
       <div
         class="sc-eCssSg boVAbf"

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
         type="checkbox"
       />
       <span
-        class="sc-gsTCUz hqweVm"
+        class="sc-gsTCUz fxdyjT"
       />
       <div
         class="sc-dlfnbm sc-hKgILt eWKzWA etPkmZ"

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -65,8 +65,15 @@ export const Label = styled.label<LabelProps>`
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   width: ${({ width }) => width};
   height: calc(1px * 2 + 22px);
-  background-color: ${({ disabled, theme }) =>
-    !disabled ? theme.palette.background.default : theme.palette.gray.light};
+  background-color: ${({ active, disabled, theme }) => {
+    let backgroundColor = theme.palette.gray.highlight;
+    if (disabled) {
+      backgroundColor = theme.palette.gray.light;
+    } else if (active) {
+      backgroundColor = theme.palette.background.hint;
+    }
+    return backgroundColor;
+  }};
   border: 1px solid
     ${({ active, disabled, theme }) =>
       active && !disabled ? theme.palette.primary.main : theme.palette.divider};

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -29,24 +29,26 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
   }};
   border: 1px solid
     ${({ active, disabled, theme }) =>
-      active && !disabled ? theme.palette.primary.main : theme.palette.divider};
+      active && !disabled ? theme.palette.primary.dark : theme.palette.divider};
   box-shadow: ${({ theme }) =>
-    `0 -2px ${hexToRgba(theme.palette.black, 0.16)} inset, 0px 2px ${hexToRgba(
+    `0 -2px ${hexToRgba(theme.palette.black, 0.16)} inset, 0px 1px ${hexToRgba(
       theme.palette.black,
       0.08,
     )}`};
-  transition: all 0.2s cubic-bezier(0.47, 0, 0.75, 0.72);
+  transition: all 0.3s cubic-bezier(0.47, 0, 0.75, 0.72);
 `;
 
-export const LabelText = styled.div<{ position: "right" | "left" }>`
+export const LabelText = styled.div`
   position: absolute;
-  ${({ position }) => `${position}: 6px`};
   width: 100%;
+  transition: all 0s 0.3s cubic-bezier(0.47, 0, 0.75, 0.72);
 `;
 export const ActiveLabelText = styled(LabelText)`
+  right: 6px;
   opacity: 0;
 `;
 export const InActiveLabelText = styled(LabelText)`
+  left: 6px;
   opacity: 1;
 `;
 
@@ -81,7 +83,7 @@ export const Label = styled.label<LabelProps>`
   border-radius: 56px;
   box-shadow: ${({ theme }) =>
     `0 2px ${hexToRgba(theme.palette.black, 0.08)} inset`};
-  transition: all 0.3s ease;
+  transition: all 0.3s ease, border-color 0.3s cubic-bezier(0.47, 0, 0.75, 0.72);
 
   ${({ active }) =>
     active &&

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -2,8 +2,6 @@ import styled, { css } from "styled-components";
 import { hexToRgba } from "../../utils/hexToRgba";
 
 export const Container = styled.div<{
-  active: boolean;
-  disabled: boolean;
   width: string;
 }>`
   position: relative;
@@ -12,15 +10,14 @@ export const Container = styled.div<{
 `;
 
 export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
-  content: "";
   position: absolute;
   top: 50%;
-  transform: translateY(-50%);
   left: 4px;
+  z-index: 99999;
+  transform: translateY(-50%);
   width: 14px;
   height: 14px;
   border-radius: 14px;
-  transition: all 0.3s;
   background-color: ${({ active, disabled, theme }) => {
     let backgroundColor = theme.palette.background.default;
     if (disabled) {
@@ -38,15 +35,19 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
       theme.palette.black,
       0.08,
     )}`};
+  transition: all 0.2s cubic-bezier(0.47, 0, 0.75, 0.72);
+`;
 
-  ${({ active }) =>
-    active &&
-    css`
-      & {
-        left: calc(100% - 4px);
-        transform: translate(-100%, -50%);
-      }
-    `}
+export const LabelText = styled.div<{ position: "right" | "left" }>`
+  position: absolute;
+  ${({ position }) => `${position}: 6px`};
+  width: 100%;
+`;
+export const ActiveLabelText = styled(LabelText)`
+  opacity: 0;
+`;
+export const InActiveLabelText = styled(LabelText)`
+  opacity: 1;
 `;
 
 type LabelProps = {
@@ -80,25 +81,25 @@ export const Label = styled.label<LabelProps>`
   border-radius: 56px;
   box-shadow: ${({ theme }) =>
     `0 2px ${hexToRgba(theme.palette.black, 0.08)} inset`};
-  transition: background-color 0.3s ease, border-color 0.3s ease;
+  transition: all 0.3s ease;
 
-  &:active > ${ToggleButton} {
-    width: 22px;
-  }
+  ${({ active }) =>
+    active &&
+    css`
+      & > ${ToggleButton} {
+        left: calc(100% - 14px - 4px);
+      }
+      & > ${ActiveLabelText} {
+        opacity: 1;
+      }
+      & > ${InActiveLabelText} {
+        opacity: 0;
+      }
+    `}
 `;
 
 export const HiddenInput = styled.input`
   width: 0;
   height: 0;
   visibility: hidden;
-`;
-
-export const LabelText = styled.div<{ position: "right" | "left" }>`
-  position: absolute;
-  top: 50%;
-  ${({ position }) => `${position}: calc(50% - 7px)`};
-  transform: translate(
-    ${({ position }) => (position === "right" ? "" : "-")}50%,
-    -50%
-  );
 `;

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -45,10 +45,12 @@ export const LabelText = styled.div`
   white-space: nowrap;
   transition: all 0s 0.3s cubic-bezier(0.47, 0, 0.75, 0.72);
 `;
+
 export const ActiveLabelText = styled(LabelText)`
   padding-right: 6px;
   opacity: 0;
 `;
+
 export const InActiveLabelText = styled(LabelText)`
   margin-left: 6px;
   opacity: 1;

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -41,14 +41,16 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
 export const LabelText = styled.div`
   position: absolute;
   width: 100%;
+  word-break: break-all;
+  white-space: nowrap;
   transition: all 0s 0.3s cubic-bezier(0.47, 0, 0.75, 0.72);
 `;
 export const ActiveLabelText = styled(LabelText)`
-  right: 6px;
+  padding-right: 6px;
   opacity: 0;
 `;
 export const InActiveLabelText = styled(LabelText)`
-  left: 6px;
+  margin-left: 6px;
   opacity: 1;
 `;
 

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { hexToRgba } from "../../utils/hexToRgba";
 
 export const Container = styled.div<{
   active: boolean;
@@ -13,12 +14,13 @@ export const Container = styled.div<{
 export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
   content: "";
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 18px;
-  transition: 0.2s;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 14px;
+  transition: all 0.3s;
   background-color: ${({ active, disabled, theme }) => {
     let backgroundColor = theme.palette.background.default;
     if (disabled) {
@@ -31,13 +33,18 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
   border: 1px solid
     ${({ active, disabled, theme }) =>
       active && !disabled ? theme.palette.primary.main : theme.palette.divider};
+  box-shadow: ${({ theme }) =>
+    `0 -2px ${hexToRgba(theme.palette.black, 0.16)} inset, 0px 2px ${hexToRgba(
+      theme.palette.black,
+      0.08,
+    )}`};
 
   ${({ active }) =>
     active &&
     css`
       & {
-        left: calc(100% - 2px);
-        transform: translateX(-100%);
+        left: calc(100% - 4px);
+        transform: translate(-100%, -50%);
       }
     `}
 `;
@@ -58,15 +65,15 @@ export const Label = styled.label<LabelProps>`
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   width: ${({ width }) => width};
   height: calc(1px * 2 + 22px);
-  background-color: ${({ active, disabled, theme }) =>
-    active && !disabled
-      ? theme.palette.background.hint
-      : theme.palette.gray.light};
+  background-color: ${({ disabled, theme }) =>
+    !disabled ? theme.palette.background.default : theme.palette.gray.light};
   border: 1px solid
     ${({ active, disabled, theme }) =>
       active && !disabled ? theme.palette.primary.main : theme.palette.divider};
   border-radius: 56px;
-  transition: background-color 0.2s, border-color 0.2s;
+  box-shadow: ${({ theme }) =>
+    `0 2px ${hexToRgba(theme.palette.black, 0.08)} inset`};
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 
   &:active > ${ToggleButton} {
     width: 22px;

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -13,7 +13,7 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
   position: absolute;
   top: 50%;
   left: 4px;
-  z-index: 99999;
+  z-index: 9999;
   transform: translateY(-50%);
   width: 14px;
   height: 14px;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## Ref
[#121](https://github.com/voyagegroup/fluct_XDC/issues/121)

## やったこと
- ノブに立体感を出した
- 本体を少し凹ませた表現にするためインナーシャドウを加えた
- トグルボタンがテキストの下側に埋もれていたため、z-indexを変更した

## スクショ
### Before
![image](https://user-images.githubusercontent.com/50824354/111561622-1a5e3780-87d8-11eb-9be1-52c451a5eec8.png)


### After
![image](https://user-images.githubusercontent.com/50824354/111561468-d8cd8c80-87d7-11eb-8b66-1e369480d43b.png)