### PR TITLE
Revert "Buttonからmin-widthを除去"

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -118,18 +118,15 @@ const paddingAtActive: Record<
   },
 };
 
-const buttonSize: Record<ButtonSize, { minWidth: string; height: string }> = {
+const buttonSize: Record<ButtonSize, { minWidth: string }> = {
   small: {
     minWidth: "64px",
-    height: "32px",
   },
   medium: {
     minWidth: "130px",
-    height: "42px",
   },
   large: {
     minWidth: "178px",
-    height: "48px",
   },
 };
 
@@ -194,7 +191,6 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       fontSize={
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
-      height={buttonSize[size].height}
       minWidth={buttonSize[size].minWidth}
     >
       {children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -118,6 +118,21 @@ const paddingAtActive: Record<
   },
 };
 
+const buttonSize: Record<ButtonSize, { minWidth: string; height: string }> = {
+  small: {
+    minWidth: "64px",
+    height: "32px",
+  },
+  medium: {
+    minWidth: "130px",
+    height: "42px",
+  },
+  large: {
+    minWidth: "178px",
+    height: "48px",
+  },
+};
+
 export type ButtonProps = Omit<BaseButtonProps, "color"> & {
   /**
    * The component used for the root node.
@@ -179,6 +194,8 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       fontSize={
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
+      height={buttonSize[size].height}
+      minWidth={buttonSize[size].minWidth}
     >
       {children}
     </Styled.ButtonContainer>

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,9 +3,10 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm idRKex bHISMI"
+    class="sc-gsTCUz sc-dlfnbm idRKex jgCuyd"
     font-size="14px"
     font-weight="bold"
+    height="42px"
   />
 </DocumentFragment>
 `;

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,10 +3,9 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm idRKex jgCuyd"
+    class="sc-gsTCUz sc-dlfnbm idRKex dGqrhc"
     font-size="14px"
     font-weight="bold"
-    height="42px"
   />
 </DocumentFragment>
 `;

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -14,6 +14,7 @@ export type ContainerProps = ButtonColorStyle & {
   horizontalPadding: string;
   paddingTopAtActive: string;
   paddingBottomAtActive: string;
+  minWidth: string;
   href?: string;
   disabled?: boolean;
 };
@@ -25,6 +26,7 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   padding: ${({ verticalPadding, horizontalPadding }) =>
     `${verticalPadding} ${horizontalPadding}`};
   width: ${({ inline }) => (inline ? "auto" : "100%")};
+  min-width: ${({ minWidth }) => minWidth};
   height: ${({ height }) => height};
   border-radius: ${({ theme }) => theme.radius}px;
   border: ${({ normal, disabled, theme }) =>

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -9,7 +9,6 @@ export type ContainerProps = ButtonColorStyle & {
   inline: boolean;
   fontSize: string;
   fontWeight: string;
-  height: string;
   verticalPadding: string;
   horizontalPadding: string;
   paddingTopAtActive: string;
@@ -27,7 +26,6 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
     `${verticalPadding} ${horizontalPadding}`};
   width: ${({ inline }) => (inline ? "auto" : "100%")};
   min-width: ${({ minWidth }) => minWidth};
-  height: ${({ height }) => height};
   border-radius: ${({ theme }) => theme.radius}px;
   border: ${({ normal, disabled, theme }) =>
     disabled ? `1px solid ${theme.palette.divider}` : normal.border};

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -6,16 +6,18 @@ exports[`Button component testing ButtonGroup 1`] = `
     class="sc-bdfBwQ kogCJu"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG UcvjX"
+      class="sc-dlfnbm sc-hKgILt bqGKDG LUa-dq"
       font-size="14px"
       font-weight="normal"
+      height="42px"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG UcvjX"
+      class="sc-dlfnbm sc-hKgILt bqGKDG LUa-dq"
       font-size="14px"
       font-weight="normal"
+      height="42px"
     >
       Save
     </button>

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -6,18 +6,16 @@ exports[`Button component testing ButtonGroup 1`] = `
     class="sc-bdfBwQ kogCJu"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG LUa-dq"
+      class="sc-dlfnbm sc-hKgILt bqGKDG izJahf"
       font-size="14px"
       font-weight="normal"
-      height="42px"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG LUa-dq"
+      class="sc-dlfnbm sc-hKgILt bqGKDG izJahf"
       font-size="14px"
       font-weight="normal"
-      height="42px"
     >
       Save
     </button>

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,12 +7,11 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex cOohKy sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex ijETIn sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
       <div
@@ -112,11 +111,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex jgCuyd sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex dGqrhc sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
       <div
@@ -222,21 +220,19 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex CMyFB sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex ewRgLw sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex CMyFB sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex ewRgLw sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"
@@ -335,19 +331,17 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex cBNUla sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex iSfkoj sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex cBNUla sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex iSfkoj sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
-      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,11 +7,12 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex utbqr sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex cOohKy sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       Save
       <div
@@ -111,10 +112,11 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex bHISMI sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex jgCuyd sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       Save
       <div
@@ -220,19 +222,21 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex kVUASo sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex CMyFB sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex kVUASo sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex CMyFB sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"
@@ -331,17 +335,19 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex jIElxj sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex cBNUla sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex jIElxj sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex cBNUla sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
+      height="42px"
     >
       <div
         class="sc-iBPRYJ gvzchn"


### PR DESCRIPTION
This reverts commit c83eaf86bbf053610b1a7ce6537ff78dd01ae616.

<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## やったこと
min-widthを削除したことによって、ボタンテキストが日本語の際にボタンの横幅がおかしくなるので、min-widthを削除したコミットをrevertした。

## 問題のスクショ
### Before
![image](https://user-images.githubusercontent.com/50824354/112121014-1aa86980-8c02-11eb-9ccc-196a57b726cc.png)

### After
![image](https://user-images.githubusercontent.com/50824354/112121545-b508ad00-8c02-11eb-9164-d29beb35a491.png)
