### PR TITLE
ボタンに日本語を入れた際のレイアウト（横幅）崩れを修正

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -118,18 +118,6 @@ const paddingAtActive: Record<
   },
 };
 
-const buttonSize: Record<ButtonSize, { minWidth: string }> = {
-  small: {
-    minWidth: "64px",
-  },
-  medium: {
-    minWidth: "130px",
-  },
-  large: {
-    minWidth: "178px",
-  },
-};
-
 export type ButtonProps = Omit<BaseButtonProps, "color"> & {
   /**
    * The component used for the root node.
@@ -191,7 +179,6 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       fontSize={
         size === "small" ? `${fontSize["xs"]}px` : `${fontSize["md"]}px`
       }
-      minWidth={buttonSize[size].minWidth}
     >
       {children}
     </Styled.ButtonContainer>

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button component testing Button 1`] = `
 <DocumentFragment>
   <button
-    class="sc-gsTCUz sc-dlfnbm idRKex dGqrhc"
+    class="sc-gsTCUz sc-dlfnbm idRKex cuSjWD"
     font-size="14px"
     font-weight="bold"
   />

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -13,7 +13,6 @@ export type ContainerProps = ButtonColorStyle & {
   horizontalPadding: string;
   paddingTopAtActive: string;
   paddingBottomAtActive: string;
-  minWidth: string;
   href?: string;
   disabled?: boolean;
 };
@@ -25,7 +24,6 @@ export const ButtonContainer = styled(BaseButton)<ContainerProps>`
   padding: ${({ verticalPadding, horizontalPadding }) =>
     `${verticalPadding} ${horizontalPadding}`};
   width: ${({ inline }) => (inline ? "auto" : "100%")};
-  min-width: ${({ minWidth }) => minWidth};
   border-radius: ${({ theme }) => theme.radius}px;
   border: ${({ normal, disabled, theme }) =>
     disabled ? `1px solid ${theme.palette.divider}` : normal.border};

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`Button component testing ButtonGroup 1`] = `
     class="sc-bdfBwQ kogCJu"
   >
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG izJahf"
+      class="sc-dlfnbm sc-hKgILt bqGKDG ggeGGI"
       font-size="14px"
       font-weight="normal"
     >
       Edit
     </button>
     <button
-      class="sc-dlfnbm sc-hKgILt bqGKDG izJahf"
+      class="sc-dlfnbm sc-hKgILt bqGKDG ggeGGI"
       font-size="14px"
       font-weight="normal"
     >

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -172,15 +172,15 @@ const ConfirmModal: React.FunctionComponent<ConfirmModalProps> = ({
             {showFooter && (
               <Styled.ModalFooter fullSize={fullSize}>
                 <Flex display="flex" alignItems="center">
-                  <Spacer pr={2}>
-                    <Button
-                      type="button"
-                      color="secondary"
-                      onClick={handleClose("clickCancelButton")}
-                    >
-                      {cancelText}
-                    </Button>
-                  </Spacer>
+                  <Button
+                    type="button"
+                    color="secondary"
+                    inline={true}
+                    onClick={handleClose("clickCancelButton")}
+                  >
+                    {cancelText}
+                  </Button>
+                  <Spacer pr={2} />
                   <Button
                     type="submit"
                     color={buttonColor}

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -181,7 +181,12 @@ const ConfirmModal: React.FunctionComponent<ConfirmModalProps> = ({
                       {cancelText}
                     </Button>
                   </Spacer>
-                  <Button type="submit" color={buttonColor} disabled={disabled}>
+                  <Button
+                    type="submit"
+                    color={buttonColor}
+                    disabled={disabled}
+                    inline={true}
+                  >
                     {confirmText}
                   </Button>
                 </Flex>

--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
       class="sc-bkzZxe fuFIfA sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
     />
     <div
-      class="sc-gsTCUz sc-hKgILt jsbffe hUZwiX sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
+      class="sc-gsTCUz sc-hKgILt jsbffe iURdPL sc-idOhPF hnQDfL fade-transition-appear fade-transition-appear-active"
     >
       <form>
         <div

--- a/src/components/ConfirmModal/styled.ts
+++ b/src/components/ConfirmModal/styled.ts
@@ -2,13 +2,13 @@ import styled, { keyframes, css } from "styled-components";
 import { addScrollbarProperties } from "../../utils/scrollbar";
 import Card from "../Card";
 
-const fadeIn = keyframes`	
-  0% {	
-    opacity: 0;	
-  }	
-  100% {	
-    opacity: 1;	
-  }	
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 `;
 export const ModalBackground = styled.div`
   position: absolute;
@@ -21,13 +21,13 @@ export const ModalBackground = styled.div`
   animation: ${fadeIn} 0.4s;
 `;
 
-const slideIn = keyframes`	
-  0% {	
-    transform: translate(-50%, calc(-50% + 8px));	
-  }	
-  100% {	
-    transform: translate(-50%, -50%);	
-  }	
+const slideIn = keyframes`
+  0% {
+    transform: translate(-50%, calc(-50% + 8px));
+  }
+  100% {
+    transform: translate(-50%, -50%);
+  }
 `;
 
 const FullSizeSlideIn = keyframes`
@@ -108,6 +108,7 @@ export const ModalFooter = styled.div<{ fullSize: boolean }>`
   border-radius: ${({ fullSize, theme }) =>
     fullSize ? 0 : `0 0 ${theme.radius}px ${theme.radius}px`};
   margin-bottom: ${({ fullSize }) => (fullSize ? "1.8vh" : "auto")};
+  word-break: break-word;
 `;
 
 export const IconContainer = styled.div`

--- a/src/components/ConfirmModal/styled.ts
+++ b/src/components/ConfirmModal/styled.ts
@@ -108,7 +108,6 @@ export const ModalFooter = styled.div<{ fullSize: boolean }>`
   border-radius: ${({ fullSize, theme }) =>
     fullSize ? 0 : `0 0 ${theme.radius}px ${theme.radius}px`};
   margin-bottom: ${({ fullSize }) => (fullSize ? "1.8vh" : "auto")};
-  word-break: break-word;
 `;
 
 export const IconContainer = styled.div`

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ijETIn sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex oSzyM sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -111,7 +111,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex dGqrhc sc-gKsewC ijcSYt"
+      class="sc-gsTCUz sc-dlfnbm idRKex cuSjWD sc-gKsewC ijcSYt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"
@@ -220,7 +220,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ewRgLw sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex ffFyTf sc-eCssSg eZdWdg"
       disabled=""
       font-size="14px"
       font-weight="bold"
@@ -228,7 +228,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex ewRgLw sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex ffFyTf sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       disabled=""
       font-size="14px"
@@ -331,14 +331,14 @@ exports[`DropdownButton component testing splited enable 1`] = `
     role="button"
   >
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex iSfkoj sc-eCssSg eZdWdg"
+      class="sc-gsTCUz sc-dlfnbm idRKex eCLzwk sc-eCssSg eZdWdg"
       font-size="14px"
       font-weight="bold"
     >
       Save
     </button>
     <button
-      class="sc-gsTCUz sc-dlfnbm idRKex iSfkoj sc-jSgupP fKddXt"
+      class="sc-gsTCUz sc-dlfnbm idRKex eCLzwk sc-jSgupP fKddXt"
       data-testid="menu-toggle"
       font-size="14px"
       font-weight="bold"


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
## 概要
ボタンに日本語を入れた際にレイアウト（横幅）が崩れるので、その修正PR

## やったこと
- min-widthの削除
- Buttonのpropsに`inline={true}`を渡すことによって、Buttonに`width: auto;`を指定し、Button(flex-item)の横幅がボタンテキストの長さに応じて可変するようにした

## 問題のスクショ
### Before
![image](https://user-images.githubusercontent.com/50824354/112243818-956c9580-8c91-11eb-9fa6-ab58033e2f8e.png)

### After
![image](https://user-images.githubusercontent.com/50824354/112266488-6832de00-8cb7-11eb-8ec8-7d474c9ca2c0.png)
