### PR TITLE
閉じるアイコンの形を変更

### DIFF
--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -43,12 +43,14 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
                 <rect
                   fill="#041C33"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(18.364 2) rotate(45)"
                   width="5.142"
                 />
                 <rect
                   fill="#041C33"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(2 5.636) rotate(-45)"
                   width="5.143"
                 />

--- a/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
+++ b/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
@@ -36,12 +36,14 @@ exports[`FloatingTip component testing FloatingTip 1`] = `
               <rect
                 fill="#041C33"
                 height="23.141"
+                rx="2.571"
                 transform="translate(18.364 2) rotate(45)"
                 width="5.142"
               />
               <rect
                 fill="#041C33"
                 height="23.141"
+                rx="2.571"
                 transform="translate(2 5.636) rotate(-45)"
                 width="5.143"
               />

--- a/src/components/Icon/internal/CloseIcon/index.tsx
+++ b/src/components/Icon/internal/CloseIcon/index.tsx
@@ -7,12 +7,14 @@ const CloseIcon: React.FunctionComponent<IconProps> = ({ fill }) => (
       fill={fill}
       width="5.142"
       height="23.141"
+      rx="2.571"
       transform="translate(18.364 2) rotate(45)"
     />
     <rect
       fill={fill}
       width="5.143"
       height="23.141"
+      rx="2.571"
       transform="translate(2 5.636) rotate(-45)"
     />
   </svg>

--- a/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -36,12 +36,14 @@ exports[`Select component testing Disable multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -71,12 +73,14 @@ exports[`Select component testing Disable multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -404,12 +408,14 @@ exports[`Select component testing Error multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -439,12 +445,14 @@ exports[`Select component testing Error multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -498,12 +506,14 @@ exports[`Select component testing Error multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -726,12 +736,14 @@ exports[`Select component testing Error one selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -831,12 +843,14 @@ exports[`Select component testing Normal multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -866,12 +880,14 @@ exports[`Select component testing Normal multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -925,12 +941,14 @@ exports[`Select component testing Normal multiple selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />
@@ -1153,12 +1171,14 @@ exports[`Select component testing Normal one selected 1`] = `
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(18.364 2) rotate(45)"
                     width="5.142"
                   />
                   <rect
                     fill="#041C33"
                     height="23.141"
+                    rx="2.571"
                     transform="translate(2 5.636) rotate(-45)"
                     width="5.143"
                   />

--- a/src/components/Snackbar/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/Snackbar/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -22,12 +22,14 @@ exports[`Snackbar component testing Snackbar 1`] = `
             <rect
               fill="#041C33"
               height="23.141"
+              rx="2.571"
               transform="translate(18.364 2) rotate(45)"
               width="5.142"
             />
             <rect
               fill="#041C33"
               height="23.141"
+              rx="2.571"
               transform="translate(2 5.636) rotate(-45)"
               width="5.143"
             />

--- a/src/components/Toast/DefaultToast/__tests__/__snapshots__/DefaultToast.test.tsx.snap
+++ b/src/components/Toast/DefaultToast/__tests__/__snapshots__/DefaultToast.test.tsx.snap
@@ -63,12 +63,14 @@ exports[`DefaultToast component testing DefaultToast error 1`] = `
               <rect
                 fill="#F96979"
                 height="23.141"
+                rx="2.571"
                 transform="translate(18.364 2) rotate(45)"
                 width="5.142"
               />
               <rect
                 fill="#F96979"
                 height="23.141"
+                rx="2.571"
                 transform="translate(2 5.636) rotate(-45)"
                 width="5.143"
               />
@@ -118,12 +120,14 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
                 <rect
                   fill="#FDFEFF"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(18.364 2) rotate(45)"
                   width="5.142"
                 />
                 <rect
                   fill="#FDFEFF"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(2 5.636) rotate(-45)"
                   width="5.143"
                 />
@@ -152,12 +156,14 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
               <rect
                 fill="#9CDDFD"
                 height="23.141"
+                rx="2.571"
                 transform="translate(18.364 2) rotate(45)"
                 width="5.142"
               />
               <rect
                 fill="#9CDDFD"
                 height="23.141"
+                rx="2.571"
                 transform="translate(2 5.636) rotate(-45)"
                 width="5.143"
               />
@@ -237,12 +243,14 @@ exports[`DefaultToast component testing DefaultToast success 1`] = `
               <rect
                 fill="#B4ED7B"
                 height="23.141"
+                rx="2.571"
                 transform="translate(18.364 2) rotate(45)"
                 width="5.142"
               />
               <rect
                 fill="#B4ED7B"
                 height="23.141"
+                rx="2.571"
                 transform="translate(2 5.636) rotate(-45)"
                 width="5.143"
               />
@@ -292,12 +300,14 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
                 <rect
                   fill="#FDFEFF"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(18.364 2) rotate(45)"
                   width="5.142"
                 />
                 <rect
                   fill="#FDFEFF"
                   height="23.141"
+                  rx="2.571"
                   transform="translate(2 5.636) rotate(-45)"
                   width="5.143"
                 />
@@ -326,12 +336,14 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
               <rect
                 fill="#FDE54E"
                 height="23.141"
+                rx="2.571"
                 transform="translate(18.364 2) rotate(45)"
                 width="5.142"
               />
               <rect
                 fill="#FDE54E"
                 height="23.141"
+                rx="2.571"
                 transform="translate(2 5.636) rotate(-45)"
                 width="5.143"
               />


### PR DESCRIPTION
# やったこと
closeのアイコンの縁を丸くしました。


### before
![image](https://user-images.githubusercontent.com/56141035/112261408-27cf6200-8caf-11eb-9338-d036795dd556.png)


### after
![image](https://user-images.githubusercontent.com/56141035/112261436-3584e780-8caf-11eb-8ad1-dd15b7b21139.png)
(※大きさは変わっていません。)


# ref
xd: https://xd.adobe.com/view/a2977fa3-990f-4e0b-7eb7-1f835cc8c42a-d4a6/screen/ce21ec0d-b58c-4140-a646-af6043cb340f/specs/

<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
