### PR TITLE
アイコンサイズにxsを追加

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -68,6 +68,10 @@ export const Overview = () => (
       size: sm (12px)
     </Typography>
     {renderIcons({ size: "sm" })}
+    <Typography weight="bold" size="xxl">
+      size: xs (10px)
+    </Typography>
+    {renderIcons({ size: "xs" })}
   </Container>
 );
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -129,8 +129,9 @@ export type IconName =
 
 type IconType = "fill" | "line";
 type IconColor = IconType | "active" | string;
-type IconSize = "sm" | "md" | "lg";
+type IconSize = "xs" | "sm" | "md" | "lg";
 export const iconSize: { [key in IconSize]: number } = {
+  xs: 10,
   sm: 12,
   md: 18,
   lg: 24,


### PR DESCRIPTION
## なぜやったか

12pxよりも小さいアイコンが必要になったが、現状サイズが3種類しかない。
https://github.com/voyagegroup/ingred-ui/blob/862abb5b0ac9a37a20835806e115b61a47a8737a/src/components/Icon/Icon.tsx#L133-L137

## やったこと

自由にサイズをできてしまうと、デザインシステムのアーキテクチャ上問題があるという考えから、下限のサイズ (xs: 10px) を追加した。

## 確認方法
```
yarn install
yarn storybook
```

<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
