### PR TITLE
Multiple Selectで複数選択する際に都度閉じないように修正

### DIFF
--- a/.storybook/documents/Information/CodeRecipes/FormRecipe.stories.tsx
+++ b/.storybook/documents/Information/CodeRecipes/FormRecipe.stories.tsx
@@ -142,6 +142,7 @@ export const Overview: React.FC = () => {
         control={control}
         render={(props) => (
           <Select
+            closeMenuOnSelect={true}
             options={["1", "2", "3"].map((val) => ({ label: val, value: val }))}
             onChange={(value) => props.onChange(value)}
           />

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -49,6 +49,10 @@ export const MultipleSelect = () => {
     { label: "Three", value: 3 },
   ];
   const handleChange = (options: any) => {
+    if (options == null) {
+      setSelected([]);
+      return;
+    }
     setSelected(options.map((ops: OptionType<number>) => ops.label));
   };
   return (

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Flex, Spacer, Typography } from "..";
 import { Story } from "@storybook/react/types-6-0";
 import Select, { OptionType } from "./Select";
-import { ValueType } from "react-select";
 
 export default {
   title: "Components/Inputs/Select",
@@ -36,7 +35,11 @@ export const Example = () => {
   return (
     <div style={{ height: "200px" }}>
       <div>selected: {selected}</div>
-      <Select options={options} onChange={handleChange} />
+      <Select
+        options={options}
+        closeMenuOnSelect={true}
+        onChange={handleChange}
+      />
     </div>
   );
 };
@@ -105,6 +108,7 @@ export const WithAsyncSearch: Story = () => {
         placeholder="Search with some text..."
         isLoading={loading}
         options={options}
+        closeMenuOnSelect={true}
         onInputChange={handleInputChange}
         onChange={handleSelect}
       />
@@ -143,19 +147,29 @@ export const DesignSamples = () => {
         <div>
           <Typography weight="bold">Normal</Typography>
           <Spacer pt={2} />
-          <Select minWidth="200px" options={options} />
+          <Select closeMenuOnSelect={true} minWidth="200px" options={options} />
         </div>
         <Spacer pl={3} />
         <div>
           <Typography weight="bold">Disabled</Typography>
           <Spacer pt={2} />
-          <Select minWidth="200px" options={options} isDisabled={true} />
+          <Select
+            closeMenuOnSelect={true}
+            minWidth="200px"
+            options={options}
+            isDisabled={true}
+          />
         </div>
         <Spacer pl={3} />
         <div>
           <Typography weight="bold">Error</Typography>
           <Spacer pt={2} />
-          <Select minWidth="200px" options={options} error={true} />
+          <Select
+            closeMenuOnSelect={true}
+            minWidth="200px"
+            options={options}
+            error={true}
+          />
         </div>
       </Flex>
       <Spacer pt={3} />

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -159,6 +159,7 @@ const Select: SelectComponent = ({
   minWidth,
   isDisabled,
   error = false,
+  closeMenuOnSelect = false,
   ...rest
 }) => {
   const theme = useTheme();
@@ -183,7 +184,7 @@ const Select: SelectComponent = ({
     <Styled.Container minWidth={minWidth} isDisabled={isDisabled}>
       <ReactSelect
         isClearable
-        closeMenuOnSelect={false}
+        closeMenuOnSelect={closeMenuOnSelect}
         noOptionsMessage={getEmptyMessage}
         isDisabled={isDisabled}
         styles={getOverrideStyles(theme, error)}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -183,6 +183,7 @@ const Select: SelectComponent = ({
     <Styled.Container minWidth={minWidth} isDisabled={isDisabled}>
       <ReactSelect
         isClearable
+        closeMenuOnSelect={false}
         noOptionsMessage={getEmptyMessage}
         isDisabled={isDisabled}
         styles={getOverrideStyles(theme, error)}


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
## Ref
close voyagegroup/fluct_XDC#124

## やったこと
- `closeMenuOnSelect={false}`を追加して選択時に閉じないように修正
- StorybookのMultiple Select コンポーネントで最後（最初）の一つを削除した際に、エラーを吐いていたので修正

## スクショ
## Before
![fb70f820a253a98ba0123563bf2c1b1b](https://user-images.githubusercontent.com/50824354/112791972-83c62c00-909d-11eb-9964-dcf16c6bd426.gif)

## After
![15be6db4d3bd4b1c3796fcd9add99e9c](https://user-images.githubusercontent.com/50824354/112791958-7e68e180-909d-11eb-929a-22bdda55c4a1.gif)
