### PR TITLE
トグルボタンのノブに指定しているz-indexを削除する

### DIFF
--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -33,7 +33,6 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
           disabled={disabled}
           onChange={onChange}
         />
-        <Styled.ToggleButton active={active} disabled={disabled} />
         <Styled.ActiveLabelText>
           <Typography
             component="div"
@@ -56,6 +55,7 @@ const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({
             {inActiveText}
           </Typography>
         </Styled.InActiveLabelText>
+        <Styled.ToggleButton active={active} disabled={disabled} />
       </Styled.Label>
     </Styled.Container>
   );

--- a/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/ToggleButton/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -15,9 +15,6 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
         readonly=""
         type="checkbox"
       />
-      <span
-        class="sc-gsTCUz bqUFVN"
-      />
       <div
         class="sc-dlfnbm sc-hKgILt knXVJq xtjCQ"
       >
@@ -40,6 +37,9 @@ exports[`ToggleButton component testing ToggleButton 1`] = `
           OFF
         </div>
       </div>
+      <span
+        class="sc-gsTCUz gVssdf"
+      />
     </label>
   </div>
 </DocumentFragment>

--- a/src/components/ToggleButton/styled.ts
+++ b/src/components/ToggleButton/styled.ts
@@ -13,7 +13,6 @@ export const ToggleButton = styled.span<{ active: boolean; disabled: boolean }>`
   position: absolute;
   top: 50%;
   left: 4px;
-  z-index: 9999;
   transform: translateY(-50%);
   width: 14px;
   height: 14px;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## 概要
トグルボタンのノブに`z-index: 9999;`を指定していることで、他コンポーネントが重なった際にノブだけが出っ張ってくるので、z-indexを削除した実装に変更する。

## やったこと
- `ToggleButton`（Knob）を`ActiveLabelText`と`InActiveLabelText`の後ろに置いた
  - DOMの順番的に`z-index`なしで`ToggleButton`を`LabelText`の上に配置することができる。

## 問題の画像（CodeRecipes/Form/Overviewで検証）
### Before（OFF時も同様）
【デフォルト】

![image](https://user-images.githubusercontent.com/50824354/112809738-48cff280-90b5-11eb-8812-82cbb0985864.png)

【Selectの選択ウインドウを開いた時】

![image](https://user-images.githubusercontent.com/50824354/112809766-52595a80-90b5-11eb-80b3-792b326be6e6.png)

### After（OFF時も同様）
![image](https://user-images.githubusercontent.com/50824354/112808929-77999900-90b4-11eb-8aef-112971d49eb1.png)
