### PR TITLE
デフォルトでMenuが閉じるように変更

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -35,11 +35,7 @@ export const Example = () => {
   return (
     <div style={{ height: "200px" }}>
       <div>selected: {selected}</div>
-      <Select
-        options={options}
-        closeMenuOnSelect={true}
-        onChange={handleChange}
-      />
+      <Select options={options} onChange={handleChange} />
     </div>
   );
 };
@@ -108,7 +104,6 @@ export const WithAsyncSearch: Story = () => {
         placeholder="Search with some text..."
         isLoading={loading}
         options={options}
-        closeMenuOnSelect={true}
         onInputChange={handleInputChange}
         onChange={handleSelect}
       />
@@ -147,29 +142,19 @@ export const DesignSamples = () => {
         <div>
           <Typography weight="bold">Normal</Typography>
           <Spacer pt={2} />
-          <Select closeMenuOnSelect={true} minWidth="200px" options={options} />
+          <Select minWidth="200px" options={options} />
         </div>
         <Spacer pl={3} />
         <div>
           <Typography weight="bold">Disabled</Typography>
           <Spacer pt={2} />
-          <Select
-            closeMenuOnSelect={true}
-            minWidth="200px"
-            options={options}
-            isDisabled={true}
-          />
+          <Select minWidth="200px" options={options} isDisabled={true} />
         </div>
         <Spacer pl={3} />
         <div>
           <Typography weight="bold">Error</Typography>
           <Spacer pt={2} />
-          <Select
-            closeMenuOnSelect={true}
-            minWidth="200px"
-            options={options}
-            error={true}
-          />
+          <Select minWidth="200px" options={options} error={true} />
         </div>
       </Flex>
       <Spacer pt={3} />

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -159,7 +159,7 @@ const Select: SelectComponent = ({
   minWidth,
   isDisabled,
   error = false,
-  closeMenuOnSelect = false,
+  closeMenuOnSelect = true,
   ...rest
 }) => {
   const theme = useTheme();


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

 ## 概要
元が閉じる設計だったこともあり、`closeMenuOnSelct`が 指定されていなかったら = デフォルト = 今まで通りな設計に変更する。

## やったこと
[前回](https://github.com/voyagegroup/ingred-ui/pull/270)のissueでデフォルトでMenuは閉じない (`closeMenuOnSelect=false`) ように設定していたが、デフォルトで閉じる (`closeMenuOnSelect=true`) ように修正した。