### PR TITLE
select paddingの修正: 左右10px -> 8px

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -135,7 +135,7 @@ const getOverrideStyles = (theme: Theme, error: boolean) => {
     }),
     valueContainer: (base) => ({
       ...base,
-      padding: "10px",
+      padding: "10px 8px",
     }),
   };
   return overrideStyles;

--- a/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
         class=" css-7n5mtx-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class="css-utwydg-multiValue"
@@ -177,7 +177,7 @@ exports[`Select component testing Disable not selected 1`] = `
         class=" css-7n5mtx-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-dcdqlp-placeholder"
@@ -282,7 +282,7 @@ exports[`Select component testing Disable one selected 1`] = `
         class=" css-7n5mtx-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-10spk3r-singleValue"
@@ -387,7 +387,7 @@ exports[`Select component testing Error multiple selected 1`] = `
         class=" css-15ys67v-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class="css-utwydg-multiValue"
@@ -584,7 +584,7 @@ exports[`Select component testing Error not selected 1`] = `
         class=" css-15ys67v-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-2rfliy-placeholder"
@@ -688,7 +688,7 @@ exports[`Select component testing Error one selected 1`] = `
         class=" css-15ys67v-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-etdf8s-singleValue"
@@ -825,7 +825,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
         class=" css-1ukuozi-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class="css-utwydg-multiValue"
@@ -1022,7 +1022,7 @@ exports[`Select component testing Normal not selected 1`] = `
         class=" css-1ukuozi-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-b1k5wd-placeholder"
@@ -1126,7 +1126,7 @@ exports[`Select component testing Normal one selected 1`] = `
         class=" css-1ukuozi-control"
       >
         <div
-          class=" css-6wqz8z-ValueContainer"
+          class=" css-18ormyf-ValueContainer"
         >
           <div
             class=" css-105lwrm-singleValue"


### PR DESCRIPTION
# やったこと
Selectコンポーネントのシングルにおいて、選択時の内容物のpaddingの左右を10pxから8pxに変更

# 確認方法
```
yarn install
yarn storybook
```

# ref
こちらで上下左右を8px -> 10pxにしている
#274 

<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
