### PR TITLE
see you xs size

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -68,10 +68,6 @@ export const Overview = () => (
       size: sm (12px)
     </Typography>
     {renderIcons({ size: "sm" })}
-    <Typography weight="bold" size="xxl">
-      size: xs (10px)
-    </Typography>
-    {renderIcons({ size: "xs" })}
   </Container>
 );
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -133,9 +133,8 @@ export type IconName =
 
 type IconType = "fill" | "line";
 type IconColor = IconType | "active" | string;
-type IconSize = "xs" | "sm" | "md" | "lg";
+type IconSize = "sm" | "md" | "lg";
 export const iconSize: { [key in IconSize]: number } = {
-  xs: 10,
   sm: 12,
   md: 18,
   lg: 24,


### PR DESCRIPTION
# やったこと
iconサイズからxsを削除

# なぜやったか
https://github.com/voyagegroup/ingred-ui/pull/265 でxsを追加したが、その後そもそもxsが必要だった事情がなくなった。
lg, md, smに対して, xsは10pxと微妙な値であったため必要ないと判断したため。

<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->
