### PR TITLE
MenuにWarnTextを追加

### DIFF
--- a/src/components/ContextMenu/ContextMenu.stories.mdx
+++ b/src/components/ContextMenu/ContextMenu.stories.mdx
@@ -4,7 +4,7 @@ import ContextMenu from "./ContextMenu";
 <Meta
   title="Components/Navigation/ContextMenu"
   component={ContextMenu}
-  argTypes={{ onClick: { action: "clicked" } }}
+  argTypes={{ handleClick: { action: "clicked" } }}
 />
 
 # ContextMenu
@@ -20,11 +20,13 @@ import ContextMenu from "./ContextMenu";
       contents: [
         {
           text: "Edit",
-          onClick: () => {},
+          handleClick: () => {},
+          type: "default",
         },
         {
           text: "Save",
-          onClick: () => {},
+          handleClick: () => {},
+          type: "default",
         },
       ],
     }}

--- a/src/components/ContextMenu/ContextMenu.stories.mdx
+++ b/src/components/ContextMenu/ContextMenu.stories.mdx
@@ -4,7 +4,7 @@ import ContextMenu from "./ContextMenu";
 <Meta
   title="Components/Navigation/ContextMenu"
   component={ContextMenu}
-  argTypes={{ handleClick: { action: "clicked" } }}
+  argTypes={{ onClick: { action: "clicked" } }}
 />
 
 # ContextMenu
@@ -20,12 +20,12 @@ import ContextMenu from "./ContextMenu";
       contents: [
         {
           text: "Edit",
-          handleClick: () => {},
+          onClick: () => {},
           type: "default",
         },
         {
           text: "Save",
-          handleClick: () => {},
+          onClick: () => {},
           type: "default",
         },
       ],

--- a/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
+++ b/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { cleanup, fireEvent, act } from "@testing-library/react";
 import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
 import ContextMenu from "../ContextMenu";
+import { ContentProp } from "../../MenuList/MenuList";
 
 jest.mock("react-dom", () => {
   const original = jest.requireActual("react-dom");
@@ -12,24 +13,28 @@ jest.mock("react-dom", () => {
   };
 });
 
-const contents = [
+const contents: ContentProp[] = [
   {
     text: "Save",
-    onClick: () => {},
-    divideTop: true,
+    handleClick: () => {},
+    type: "default",
   },
   {
     text: "Save and execute",
-    onClick: () => {},
+    handleClick: () => {},
+    divideTop: true,
+    type: "default",
   },
   {
     text: "Save as draft",
-    onClick: () => {},
-    divideTop: true,
+    handleClick: () => {},
+    type: "default",
   },
   {
-    text: "Cancel",
-    onClick: () => {},
+    text: "Delete",
+    handleClick: () => {},
+    divideTop: true,
+    type: "default",
   },
 ];
 

--- a/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
+++ b/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
@@ -16,23 +16,23 @@ jest.mock("react-dom", () => {
 const contents: ContentProp[] = [
   {
     text: "Save",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Save and execute",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },
   {
     text: "Save as draft",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Delete",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -51,11 +51,6 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
       <div
         class="sc-jSgupP hzoSSJ"
       >
-        <hr
-          class="sc-fubCfw gdSgwf"
-          color="#E2E8EA"
-          orientation="horizontal"
-        />
         <div
           class="sc-iBPRYJ eNbA-Dk"
         >
@@ -67,6 +62,11 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
             Save
           </p>
         </div>
+        <hr
+          class="sc-fubCfw gdSgwf"
+          color="#E2E8EA"
+          orientation="horizontal"
+        />
         <div
           class="sc-iBPRYJ eNbA-Dk"
         >
@@ -76,6 +76,17 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
             font-size="13px"
           >
             Save and execute
+          </p>
+        </div>
+        <div
+          class="sc-iBPRYJ eNbA-Dk"
+        >
+          <p
+            class="sc-hKgILt jKKuBF sc-gKsewC"
+            color="#041C33"
+            font-size="13px"
+          >
+            Save as draft
           </p>
         </div>
         <hr
@@ -91,18 +102,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
             color="#041C33"
             font-size="13px"
           >
-            Save as draft
-          </p>
-        </div>
-        <div
-          class="sc-iBPRYJ eNbA-Dk"
-        >
-          <p
-            class="sc-hKgILt jKKuBF sc-gKsewC"
-            color="#041C33"
-            font-size="13px"
-          >
-            Cancel
+            Delete
           </p>
         </div>
       </div>

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -36,13 +36,13 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     />
   </button>
   <div
-    class="sc-pFZIQ ksFCbI"
+    class="sc-jrAGrp hiCsBc"
   >
     <div
-      class="sc-jrAGrp dWAcrB sc-kEjbxe coOSJc fade-transition-enter fade-transition-enter-active"
+      class="sc-kEjbxe gDEJEG sc-iqHYGH jmmggR fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-fubCfw bhqupj"
+      class="sc-pFZIQ horHys"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -52,15 +52,15 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
         class="sc-jSgupP hzoSSJ"
       >
         <hr
-          class="sc-iBPRYJ kWqbvW"
+          class="sc-fubCfw gdSgwf"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC eFXhdS"
+          class="sc-iBPRYJ eNbA-Dk"
         >
           <p
-            class="sc-hKgILt jKKuBF"
+            class="sc-hKgILt jKKuBF sc-gKsewC"
             color="#041C33"
             font-size="13px"
           >
@@ -68,10 +68,10 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC eFXhdS"
+          class="sc-iBPRYJ eNbA-Dk"
         >
           <p
-            class="sc-hKgILt jKKuBF"
+            class="sc-hKgILt jKKuBF sc-gKsewC"
             color="#041C33"
             font-size="13px"
           >
@@ -79,15 +79,15 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iBPRYJ kWqbvW"
+          class="sc-fubCfw gdSgwf"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-gKsewC eFXhdS"
+          class="sc-iBPRYJ eNbA-Dk"
         >
           <p
-            class="sc-hKgILt jKKuBF"
+            class="sc-hKgILt jKKuBF sc-gKsewC"
             color="#041C33"
             font-size="13px"
           >
@@ -95,10 +95,10 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-gKsewC eFXhdS"
+          class="sc-iBPRYJ eNbA-Dk"
         >
           <p
-            class="sc-hKgILt jKKuBF"
+            class="sc-hKgILt jKKuBF sc-gKsewC"
             color="#041C33"
             font-size="13px"
           >

--- a/src/components/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/DropdownButton/DropdownButton.stories.tsx
@@ -2,30 +2,35 @@ import * as React from "react";
 import DropdownButton, { DropdownButtonProps } from "./";
 import { Story } from "@storybook/react/types-6-0";
 import { Flex, Spacer, Typography } from "..";
+import { ContentProp } from "../MenuList/MenuList";
 
 export default {
   title: "Components/Inputs/DropdownButton",
   component: DropdownButton,
 };
 
-const contents = [
+const contents: ContentProp[] = [
   {
     text: "Save",
-    onClick: () => {},
+    handleClick: () => {},
+    type: "default",
   },
   {
     text: "Save and execute",
-    onClick: () => {},
+    handleClick: () => {},
     divideTop: true,
+    type: "default",
   },
   {
     text: "Save as draft",
-    onClick: () => {},
+    handleClick: () => {},
+    type: "default",
   },
   {
     text: "Delete",
-    onClick: () => {},
+    handleClick: () => {},
     divideTop: true,
+    type: "default",
   },
 ];
 

--- a/src/components/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/DropdownButton/DropdownButton.stories.tsx
@@ -12,23 +12,23 @@ export default {
 const contents: ContentProp[] = [
   {
     text: "Save",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Save and execute",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },
   {
     text: "Save as draft",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Delete",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },

--- a/src/components/DropdownButton/__tests__/DropDownButton.test.tsx
+++ b/src/components/DropdownButton/__tests__/DropDownButton.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { cleanup, act, fireEvent } from "@testing-library/react";
 import DropdownButton from "..";
 import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
+import { ContentProp } from "../../MenuList/MenuList";
 
 jest.mock("react-dom", () => {
   const original = jest.requireActual("react-dom");
@@ -12,24 +13,28 @@ jest.mock("react-dom", () => {
   };
 });
 
-const contents = [
+const contents: ContentProp[] = [
   {
     text: "Save",
-    onClick: () => {},
+    handleClick: () => {},
     divideTop: true,
+    type: "default",
   },
   {
     text: "Save and execute",
-    onClick: () => {},
+    handleClick: () => {},
+    type: "default",
   },
   {
     text: "Save as draft",
-    onClick: () => {},
+    handleClick: () => {},
     divideTop: true,
+    type: "default",
   },
   {
     text: "Cancel",
-    onClick: () => {},
+    handleClick: () => {},
+    type: "default",
   },
 ];
 

--- a/src/components/DropdownButton/__tests__/DropDownButton.test.tsx
+++ b/src/components/DropdownButton/__tests__/DropDownButton.test.tsx
@@ -16,24 +16,24 @@ jest.mock("react-dom", () => {
 const contents: ContentProp[] = [
   {
     text: "Save",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },
   {
     text: "Save and execute",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Save as draft",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },
   {
     text: "Cancel",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
 ];

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -39,25 +39,25 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     </button>
   </div>
   <div
-    class="sc-crrsfI iItuYr"
+    class="sc-dQppl jQuwEN"
   >
     <div
-      class="sc-iqHYGH icbpBe"
+      class="sc-crrsfI ksPwZT"
       style="position: absolute; left: 0px; top: 0px;"
     >
       <div
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -65,10 +65,10 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -76,15 +76,15 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -92,10 +92,10 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -146,13 +146,13 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     </button>
   </div>
   <div
-    class="sc-crrsfI eAnzhb"
+    class="sc-dQppl kWrRil"
   >
     <div
-      class="sc-dQppl bHQPKQ sc-bqyKva iUBVx fade-transition-enter fade-transition-enter-active"
+      class="sc-bqyKva gArbhj sc-kstrdz hlYJXb fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-iqHYGH icbpBe"
+      class="sc-crrsfI ksPwZT"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -162,15 +162,15 @@ exports[`DropdownButton component testing not splited enable 1`] = `
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -178,10 +178,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -189,15 +189,15 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -205,10 +205,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -264,25 +264,25 @@ exports[`DropdownButton component testing splited disable 1`] = `
     </button>
   </div>
   <div
-    class="sc-crrsfI iItuYr"
+    class="sc-dQppl jQuwEN"
   >
     <div
-      class="sc-iqHYGH icbpBe"
+      class="sc-crrsfI ksPwZT"
       style="position: absolute; left: 0px; top: 0px;"
     >
       <div
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -290,10 +290,10 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -301,15 +301,15 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -317,10 +317,10 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -374,13 +374,13 @@ exports[`DropdownButton component testing splited enable 1`] = `
     </button>
   </div>
   <div
-    class="sc-crrsfI eAnzhb"
+    class="sc-dQppl kWrRil"
   >
     <div
-      class="sc-dQppl bHQPKQ sc-bqyKva iUBVx fade-transition-enter fade-transition-enter-active"
+      class="sc-bqyKva gArbhj sc-kstrdz hlYJXb fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-iqHYGH icbpBe"
+      class="sc-crrsfI ksPwZT"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -390,15 +390,15 @@ exports[`DropdownButton component testing splited enable 1`] = `
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -406,10 +406,10 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -417,15 +417,15 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-kEjbxe gJAmGL"
+          class="sc-iqHYGH bCAJMq"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >
@@ -433,10 +433,10 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-jrAGrp hsKOsc"
+          class="sc-kEjbxe jJevVb"
         >
           <p
-            class="sc-bdfBwQ gNlqto"
+            class="sc-bdfBwQ gNlqto sc-jrAGrp"
             color="#041C33"
             font-size="13px"
           >

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -22,11 +22,13 @@ A Menu displays a list of choices. It appears when the user interacts with a but
       contents: [
         {
           text: "Save",
-          onClick: () => {},
+          handleClick: () => {},
+          type: "default",
         },
         {
           text: "Edit",
-          onClick: () => {},
+          handleClick: () => {},
+          type: "default",
         },
       ],
     }}

--- a/src/components/Menu/Menu.stories.mdx
+++ b/src/components/Menu/Menu.stories.mdx
@@ -22,12 +22,12 @@ A Menu displays a list of choices. It appears when the user interacts with a but
       contents: [
         {
           text: "Save",
-          handleClick: () => {},
+          onClick: () => {},
           type: "default",
         },
         {
           text: "Edit",
-          handleClick: () => {},
+          onClick: () => {},
           type: "default",
         },
       ],

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -16,10 +16,10 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
     name="Example"
     args={{
       contents: [
-        { text: "Save", handleClick: () => {}, type: "default" },
-        { text: "Edit", handleClick: () => {}, type: "default" },
-        { text: "Delete", handleClick: () => {}, type: "disabled" },
-        { text: "Update", handleClick: () => {}, type: "warning" },
+        { text: "Save", onClick: () => {}, type: "default" },
+        { text: "Edit", onClick: () => {}, type: "default" },
+        { text: "Delete", onClick: () => {}, type: "disabled" },
+        { text: "Update", onClick: () => {}, type: "warning" },
       ],
       maxHeight: "100px",
     }}

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -18,8 +18,8 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
       contents: [
         { text: "Save", onClick: () => {} },
         { text: "Edit", onClick: () => {} },
-        { text: "Delete", onClick: () => {}, disabled: true },
-        { text: "Update", onClick: () => {} },
+        { text: "Delete", onClick: () => {}, type: "disabled" },
+        { text: "Update", onClick: () => {}, type: "warning" },
       ],
       maxHeight: "100px",
     }}

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -16,10 +16,10 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
     name="Example"
     args={{
       contents: [
-        { text: "Save", onClick: () => {} },
-        { text: "Edit", onClick: () => {} },
-        { text: "Delete", onClick: () => {}, type: "disabled" },
-        { text: "Update", onClick: () => {}, type: "warning" },
+        { text: "Save", handleClick: () => {}, type: "default" },
+        { text: "Edit", handleClick: () => {}, type: "default" },
+        { text: "Delete", handleClick: () => {console.log("hoge")}, type: "disabled" },
+        { text: "Update", handleClick: () => {console.log("hoge")}, type: "warning" },
       ],
       maxHeight: "100px",
     }}

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -18,8 +18,8 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
       contents: [
         { text: "Save", handleClick: () => {}, type: "default" },
         { text: "Edit", handleClick: () => {}, type: "default" },
-        { text: "Delete", handleClick: () => {console.log("hoge")}, type: "disabled" },
-        { text: "Update", handleClick: () => {console.log("hoge")}, type: "warning" },
+        { text: "Delete", handleClick: () => {}, type: "disabled" },
+        { text: "Update", handleClick: () => {}, type: "warning" },
       ],
       maxHeight: "100px",
     }}

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -2,15 +2,64 @@ import React from "react";
 import * as Styled from "./styled";
 import { Property } from "csstype";
 import Divider from "../Divider";
-import Typography from "../Typography";
-import { useTheme } from "../../themes";
+import { Theme, useTheme } from "../../themes";
+
+export type ContentType = "warning" | "disabled";
+
+export type ContentTypeStyle = {
+  normal: {
+    background: string;
+    color: string;
+  };
+  hover: {
+    background: string;
+    color: string;
+  };
+  active: {
+    background: string;
+    color: string;
+  };
+};
+
+export const getContentTypeStyles = (
+  theme: Theme,
+): { [P in ContentType]: ContentTypeStyle } => ({
+  warning: {
+    normal: {
+      background: theme.palette.gray.highlight,
+      color: theme.palette.danger.main,
+    },
+    hover: {
+      background: theme.palette.danger.main,
+      color: theme.palette.text.white,
+    },
+    active: {
+      background: theme.palette.danger.dark,
+      color: theme.palette.text.white,
+    },
+  },
+  disabled: {
+    normal: {
+      background: "auto",
+      color: "disabled",
+    },
+    hover: {
+      background: "auto",
+      color: "disabled",
+    },
+    active: {
+      background: "auto",
+      color: "disabled",
+    },
+  },
+});
 
 export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   text: string;
   // TODO: rename "handleClick"
   onClick: () => void;
   divideTop?: boolean;
-  disabled?: boolean;
+  type?: ContentType;
 };
 
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
@@ -22,6 +71,8 @@ export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
 const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   ({ inline = false, contents, maxHeight = "none", ...rest }, ref) => {
     const theme = useTheme();
+    const contentTypeStyles = getContentTypeStyles(theme);
+
     return (
       <Styled.Container
         inline={inline}
@@ -36,15 +87,36 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
             )}
             {/* eslint-disable-next-line react/jsx-handler-names */}
             <Styled.TextContainer
-              disabled={content.disabled}
-              onClick={content.onClick}
+              disabled={content.type === "disabled"}
+              bgColorAtHover={
+                content.type
+                  ? contentTypeStyles[content.type]["hover"]["background"]
+                  : theme.palette.gray.light
+              }
+              bgColorAtActive={
+                content.type
+                  ? contentTypeStyles[content.type]["active"]["background"]
+                  : theme.palette.gray.main
+              }
+              textColorAtHover={
+                content.type
+                  ? contentTypeStyles[content.type]["hover"]["color"]
+                  : theme.palette.black
+              }
+              onClick={
+                content.type === "disabled" ? undefined : content.onClick
+              }
             >
-              <Typography
+              <Styled.Text
                 size="sm"
-                color={content.disabled ? "disabled" : "initial"}
+                color={
+                  content.type
+                    ? contentTypeStyles[content.type]["normal"]["color"]
+                    : "initial"
+                }
               >
                 {content.text}
-              </Typography>
+              </Styled.Text>
             </Styled.TextContainer>
           </React.Fragment>
         ))}

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -4,7 +4,7 @@ import { Property } from "csstype";
 import Divider from "../Divider";
 import { Theme, useTheme } from "../../themes";
 
-export type ContentType = "warning" | "disabled";
+export type ContentType = "default" | "warning" | "disabled";
 
 export type ContentTypeStyle = {
   normal: {
@@ -24,6 +24,20 @@ export type ContentTypeStyle = {
 export const getContentTypeStyles = (
   theme: Theme,
 ): { [P in ContentType]: ContentTypeStyle } => ({
+  default: {
+    normal: {
+      background: theme.palette.background.default,
+      color: theme.palette.black,
+    },
+    hover: {
+      background: theme.palette.gray.light,
+      color: theme.palette.black,
+    },
+    active: {
+      background: theme.palette.gray.main,
+      color: theme.palette.black,
+    },
+  },
   warning: {
     normal: {
       background: theme.palette.gray.highlight,
@@ -56,10 +70,9 @@ export const getContentTypeStyles = (
 
 export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   text: string;
-  // TODO: rename "handleClick"
-  onClick: () => void;
+  handleClick: () => void;
   divideTop?: boolean;
-  type?: ContentType;
+  type: ContentType;
 };
 
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
@@ -73,6 +86,14 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
     const theme = useTheme();
     const contentTypeStyles = getContentTypeStyles(theme);
 
+    const checkIsDisabled = (type: ContentType) => type === "disabled";
+    const handleClick = (content: ContentProp) => (): void => {
+      if (content.type === "disabled") {
+        return;
+      }
+      content.handleClick();
+    };
+
     return (
       <Styled.Container
         inline={inline}
@@ -85,35 +106,22 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
             {content.divideTop && (
               <Divider my={1} mx={2} color={theme.palette.gray.light} />
             )}
-            {/* eslint-disable-next-line react/jsx-handler-names */}
             <Styled.TextContainer
-              disabled={content.type === "disabled"}
+              disabled={checkIsDisabled(content.type)}
               bgColorAtHover={
-                content.type
-                  ? contentTypeStyles[content.type]["hover"]["background"]
-                  : theme.palette.gray.light
+                contentTypeStyles[content.type]["hover"]["background"]
               }
               bgColorAtActive={
-                content.type
-                  ? contentTypeStyles[content.type]["active"]["background"]
-                  : theme.palette.gray.main
+                contentTypeStyles[content.type]["active"]["background"]
               }
               textColorAtHover={
-                content.type
-                  ? contentTypeStyles[content.type]["hover"]["color"]
-                  : theme.palette.black
+                contentTypeStyles[content.type]["hover"]["color"]
               }
-              onClick={
-                content.type === "disabled" ? undefined : content.onClick
-              }
+              onClick={handleClick(content)}
             >
               <Styled.Text
                 size="sm"
-                color={
-                  content.type
-                    ? contentTypeStyles[content.type]["normal"]["color"]
-                    : "initial"
-                }
+                color={contentTypeStyles[content.type]["normal"]["color"]}
               >
                 {content.text}
               </Styled.Text>

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -70,7 +70,7 @@ export const getContentTypeStyles = (
 
 export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   text: string;
-  handleClick: () => void;
+  onClick: () => void;
   divideTop?: boolean;
   type: ContentType;
 };
@@ -91,7 +91,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       if (content.type === "disabled") {
         return;
       }
-      content.handleClick();
+      content.onClick();
     };
 
     return (

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -73,7 +73,7 @@ export const getContentTypeStyles = (
   if (type) {
     return contentTypeStyle[type];
   } else {
-    return contentTypeStyle["default"];
+    return contentTypeStyle.default;
   }
 };
 
@@ -84,7 +84,10 @@ export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   type?: ContentType;
 
   /**
-   * @deprecated since version 8.0.0
+   * @deprecated
+   *
+   * I'll delete it in the future.
+   * Please use "type: disabled".
    */
   disabled?: boolean;
 };
@@ -106,7 +109,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       return false;
     };
 
-    // TODO: deprecated function since version 8.0.0
+    // TODO: I'll delete in the future.
     const selectStyleInDisabledProp = (
       theme: Theme,
       type?: ContentType,

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -118,8 +118,11 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       return getContentTypeStyles(theme, type);
     };
 
-    const handleClick = (content: ContentProp) => (): void => {
-      if (content.type === "disabled") {
+    const handleClick = (
+      content: ContentProp,
+      disabled?: boolean,
+    ) => (): void => {
+      if (checkIsDisabled(content.type, disabled)) {
         return;
       }
       content.onClick();
@@ -140,27 +143,18 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
             <Styled.TextContainer
               disabled={checkIsDisabled(content.type, content.disabled)}
               normal={
-                selectStyleInDisabledProp(
-                  theme,
-                  content.type,
-                  checkIsDisabled(content.type, content.disabled),
-                ).normal
+                selectStyleInDisabledProp(theme, content.type, content.disabled)
+                  .normal
               }
               hover={
-                selectStyleInDisabledProp(
-                  theme,
-                  content.type,
-                  checkIsDisabled(content.type, content.disabled),
-                ).hover
+                selectStyleInDisabledProp(theme, content.type, content.disabled)
+                  .hover
               }
               active={
-                selectStyleInDisabledProp(
-                  theme,
-                  content.type,
-                  checkIsDisabled(content.type, content.disabled),
-                ).active
+                selectStyleInDisabledProp(theme, content.type, content.disabled)
+                  .active
               }
-              onClick={handleClick(content)}
+              onClick={handleClick(content, content.disabled)}
             >
               <Styled.Text
                 size="sm"
@@ -168,7 +162,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
                   selectStyleInDisabledProp(
                     theme,
                     content.type,
-                    checkIsDisabled(content.type, content.disabled),
+                    content.disabled,
                   ).normal.color
                 }
               >

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -23,56 +23,70 @@ export type ContentTypeStyle = {
 
 export const getContentTypeStyles = (
   theme: Theme,
-): { [P in ContentType]: ContentTypeStyle } => ({
-  default: {
-    normal: {
-      background: theme.palette.background.default,
-      color: theme.palette.black,
+  type?: ContentType,
+): ContentTypeStyle => {
+  const contentTypeStyle = {
+    default: {
+      normal: {
+        background: theme.palette.background.default,
+        color: theme.palette.black,
+      },
+      hover: {
+        background: theme.palette.gray.light,
+        color: theme.palette.black,
+      },
+      active: {
+        background: theme.palette.gray.main,
+        color: theme.palette.black,
+      },
     },
-    hover: {
-      background: theme.palette.gray.light,
-      color: theme.palette.black,
+    warning: {
+      normal: {
+        background: theme.palette.gray.highlight,
+        color: theme.palette.danger.main,
+      },
+      hover: {
+        background: theme.palette.danger.main,
+        color: theme.palette.text.white,
+      },
+      active: {
+        background: theme.palette.danger.dark,
+        color: theme.palette.text.white,
+      },
     },
-    active: {
-      background: theme.palette.gray.main,
-      color: theme.palette.black,
+    disabled: {
+      normal: {
+        background: "auto",
+        color: "disabled",
+      },
+      hover: {
+        background: "auto",
+        color: "disabled",
+      },
+      active: {
+        background: "auto",
+        color: "disabled",
+      },
     },
-  },
-  warning: {
-    normal: {
-      background: theme.palette.gray.highlight,
-      color: theme.palette.danger.main,
-    },
-    hover: {
-      background: theme.palette.danger.main,
-      color: theme.palette.text.white,
-    },
-    active: {
-      background: theme.palette.danger.dark,
-      color: theme.palette.text.white,
-    },
-  },
-  disabled: {
-    normal: {
-      background: "auto",
-      color: "disabled",
-    },
-    hover: {
-      background: "auto",
-      color: "disabled",
-    },
-    active: {
-      background: "auto",
-      color: "disabled",
-    },
-  },
-});
+  };
+
+  if (type) {
+    return contentTypeStyle[type];
+  } else {
+    return contentTypeStyle["default"];
+  }
+};
 
 export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   text: string;
   onClick: () => void;
   divideTop?: boolean;
-  type: ContentType;
+  type?: ContentType;
+
+  /**
+   * @deprecated since version 8.0.0
+   */
+  disabled?: boolean;
 };
 
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
@@ -84,9 +98,26 @@ export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
 const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   ({ inline = false, contents, maxHeight = "none", ...rest }, ref) => {
     const theme = useTheme();
-    const contentTypeStyles = getContentTypeStyles(theme);
 
-    const checkIsDisabled = (type: ContentType) => type === "disabled";
+    const checkIsDisabled = (type?: ContentType, disabled?: boolean) => {
+      if (type === "disabled" || disabled === true) {
+        return true;
+      }
+      return false;
+    };
+
+    // TODO: deprecated function since version 8.0.0
+    const selectStyleInDisabledProp = (
+      theme: Theme,
+      type?: ContentType,
+      disabled?: boolean,
+    ) => {
+      if (checkIsDisabled(type, disabled)) {
+        return getContentTypeStyles(theme, "disabled");
+      }
+      return getContentTypeStyles(theme, type);
+    };
+
     const handleClick = (content: ContentProp) => (): void => {
       if (content.type === "disabled") {
         return;
@@ -107,15 +138,39 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
               <Divider my={1} mx={2} color={theme.palette.gray.light} />
             )}
             <Styled.TextContainer
-              disabled={checkIsDisabled(content.type)}
-              normal={contentTypeStyles[content.type].normal}
-              hover={contentTypeStyles[content.type].hover}
-              active={contentTypeStyles[content.type].active}
+              disabled={checkIsDisabled(content.type, content.disabled)}
+              normal={
+                selectStyleInDisabledProp(
+                  theme,
+                  content.type,
+                  checkIsDisabled(content.type, content.disabled),
+                ).normal
+              }
+              hover={
+                selectStyleInDisabledProp(
+                  theme,
+                  content.type,
+                  checkIsDisabled(content.type, content.disabled),
+                ).hover
+              }
+              active={
+                selectStyleInDisabledProp(
+                  theme,
+                  content.type,
+                  checkIsDisabled(content.type, content.disabled),
+                ).active
+              }
               onClick={handleClick(content)}
             >
               <Styled.Text
                 size="sm"
-                color={contentTypeStyles[content.type]["normal"]["color"]}
+                color={
+                  selectStyleInDisabledProp(
+                    theme,
+                    content.type,
+                    checkIsDisabled(content.type, content.disabled),
+                  ).normal.color
+                }
               >
                 {content.text}
               </Styled.Text>

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -108,15 +108,9 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
             )}
             <Styled.TextContainer
               disabled={checkIsDisabled(content.type)}
-              bgColorAtHover={
-                contentTypeStyles[content.type]["hover"]["background"]
-              }
-              bgColorAtActive={
-                contentTypeStyles[content.type]["active"]["background"]
-              }
-              textColorAtHover={
-                contentTypeStyles[content.type]["hover"]["color"]
-              }
+              normal={contentTypeStyles[content.type].normal}
+              hover={contentTypeStyles[content.type].hover}
+              active={contentTypeStyles[content.type].active}
               onClick={handleClick(content)}
             >
               <Styled.Text

--- a/src/components/MenuList/__tests__/MenuList.test.tsx
+++ b/src/components/MenuList/__tests__/MenuList.test.tsx
@@ -3,25 +3,29 @@ import "@testing-library/jest-dom/extend-expect";
 import { cleanup } from "@testing-library/react";
 import MenuList from "..";
 import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
+import { ContentProp } from "../MenuList";
 
-const contents = [
+const contents: ContentProp[] = [
   {
     text: "Save",
-    onClick: () => {},
-    divideTop: true,
+    handleClick: () => {},
+    type: "default",
   },
   {
     text: "Save and execute",
-    onClick: () => {},
+    handleClick: () => {},
+    divideTop: true,
+    type: "default",
   },
   {
     text: "Save as draft",
-    onClick: () => {},
-    divideTop: true,
+    handleClick: () => {},
+    type: "warning",
   },
   {
     text: "Cancel",
-    onClick: () => {},
+    handleClick: () => {},
+    type: "disabled",
   },
 ];
 

--- a/src/components/MenuList/__tests__/MenuList.test.tsx
+++ b/src/components/MenuList/__tests__/MenuList.test.tsx
@@ -8,23 +8,23 @@ import { ContentProp } from "../MenuList";
 const contents: ContentProp[] = [
   {
     text: "Save",
-    handleClick: () => {},
+    onClick: () => {},
     type: "default",
   },
   {
     text: "Save and execute",
-    handleClick: () => {},
+    onClick: () => {},
     divideTop: true,
     type: "default",
   },
   {
     text: "Save as draft",
-    handleClick: () => {},
+    onClick: () => {},
     type: "warning",
   },
   {
     text: "Cancel",
-    handleClick: () => {},
+    onClick: () => {},
     type: "disabled",
   },
 ];

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -5,11 +5,6 @@ exports[`MenuList component testing MenuList splited 1`] = `
   <div
     class="sc-gsTCUz pKiIS"
   >
-    <hr
-      class="sc-eCssSg dxgEOm"
-      color="#E2E8EA"
-      orientation="horizontal"
-    />
     <div
       class="sc-hKgILt cgOKnC"
     >
@@ -21,17 +16,6 @@ exports[`MenuList component testing MenuList splited 1`] = `
         Save
       </p>
     </div>
-    <div
-      class="sc-hKgILt cgOKnC"
-    >
-      <p
-        class="sc-bdfBwQ gNlqto sc-dlfnbm"
-        color="#041C33"
-        font-size="13px"
-      >
-        Save and execute
-      </p>
-    </div>
     <hr
       class="sc-eCssSg dxgEOm"
       color="#E2E8EA"
@@ -45,15 +29,27 @@ exports[`MenuList component testing MenuList splited 1`] = `
         color="#041C33"
         font-size="13px"
       >
+        Save and execute
+      </p>
+    </div>
+    <div
+      class="sc-hKgILt llPkGB"
+    >
+      <p
+        class="sc-bdfBwQ kbxRUt sc-dlfnbm"
+        color="#EB0A4E"
+        font-size="13px"
+      >
         Save as draft
       </p>
     </div>
     <div
-      class="sc-hKgILt cgOKnC"
+      class="sc-hKgILt dObLPw"
+      disabled=""
     >
       <p
-        class="sc-bdfBwQ gNlqto sc-dlfnbm"
-        color="#041C33"
+        class="sc-bdfBwQ iQudAe sc-dlfnbm"
+        color="#B3BAC1"
         font-size="13px"
       >
         Cancel

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -3,18 +3,18 @@
 exports[`MenuList component testing MenuList splited 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdfBwQ hWeOum"
+    class="sc-gsTCUz pKiIS"
   >
     <hr
-      class="sc-dlfnbm jOeRSr"
+      class="sc-eCssSg dxgEOm"
       color="#E2E8EA"
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz gFfxhE"
+      class="sc-hKgILt cgOKnC"
     >
       <p
-        class="sc-hKgILt jKKuBF"
+        class="sc-bdfBwQ gNlqto sc-dlfnbm"
         color="#041C33"
         font-size="13px"
       >
@@ -22,10 +22,10 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz gFfxhE"
+      class="sc-hKgILt cgOKnC"
     >
       <p
-        class="sc-hKgILt jKKuBF"
+        class="sc-bdfBwQ gNlqto sc-dlfnbm"
         color="#041C33"
         font-size="13px"
       >
@@ -33,15 +33,15 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <hr
-      class="sc-dlfnbm jOeRSr"
+      class="sc-eCssSg dxgEOm"
       color="#E2E8EA"
       orientation="horizontal"
     />
     <div
-      class="sc-gsTCUz gFfxhE"
+      class="sc-hKgILt cgOKnC"
     >
       <p
-        class="sc-hKgILt jKKuBF"
+        class="sc-bdfBwQ gNlqto sc-dlfnbm"
         color="#041C33"
         font-size="13px"
       >
@@ -49,10 +49,10 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-gsTCUz gFfxhE"
+      class="sc-hKgILt cgOKnC"
     >
       <p
-        class="sc-hKgILt jKKuBF"
+        class="sc-bdfBwQ gNlqto sc-dlfnbm"
         color="#041C33"
         font-size="13px"
       >

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { Property } from "csstype";
 import { addScrollbarProperties } from "../../utils/scrollbar";
+import Typography from "../Typography";
 
 type ContainerProps = {
   inline: boolean;
@@ -15,22 +16,28 @@ export const Container = styled.div<ContainerProps>`
   ${({ maxHeight }) => addScrollbarProperties({ maxHeight })}
 `;
 
-export const TextContainer = styled.div<{ disabled?: boolean }>`
+export const Text = styled(Typography)``;
+
+export const TextContainer = styled.div<{
+  disabled: boolean;
+  bgColorAtHover: string;
+  bgColorAtActive: string;
+  textColorAtHover: string;
+}>`
   cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   display: flex;
   align-items: center;
-  color: ${({ disabled, theme }) =>
-    disabled ? theme.palette.text.disabled : "auto"};
   height: 32px;
   margin: 0 ${({ theme }) => theme.spacing}px;
   padding: 0 ${({ theme }) => theme.spacing}px;
   border-radius: ${({ theme }) => theme.radius}px;
   &:hover {
-    background-color: ${({ disabled, theme }) =>
-      disabled ? "auto" : theme.palette.gray.light};
+    ${Text} {
+      color: ${({ textColorAtHover }) => textColorAtHover};
+    }
+    background-color: ${({ bgColorAtHover }) => bgColorAtHover};
   }
   &:active {
-    background-color: ${({ disabled, theme }) =>
-      disabled ? "auto" : theme.palette.gray.main};
+    background-color: ${({ bgColorAtActive }) => bgColorAtActive};
   }
 `;

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -2,10 +2,15 @@ import styled from "styled-components";
 import { Property } from "csstype";
 import { addScrollbarProperties } from "../../utils/scrollbar";
 import Typography from "../Typography";
+import { ContentTypeStyle } from "./MenuList";
 
 type ContainerProps = {
   inline: boolean;
   maxHeight: Property.MaxHeight;
+};
+
+type TextContainerProps = ContentTypeStyle & {
+  disabled: boolean;
 };
 
 export const Container = styled.div<ContainerProps>`
@@ -18,12 +23,7 @@ export const Container = styled.div<ContainerProps>`
 
 export const Text = styled(Typography)``;
 
-export const TextContainer = styled.div<{
-  disabled: boolean;
-  bgColorAtHover: string;
-  bgColorAtActive: string;
-  textColorAtHover: string;
-}>`
+export const TextContainer = styled.div<TextContainerProps>`
   cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   display: flex;
   align-items: center;
@@ -33,11 +33,11 @@ export const TextContainer = styled.div<{
   border-radius: ${({ theme }) => theme.radius}px;
   &:hover {
     ${Text} {
-      color: ${({ textColorAtHover }) => textColorAtHover};
+      color: ${({ hover }) => hover.color};
     }
-    background-color: ${({ bgColorAtHover }) => bgColorAtHover};
+    background-color: ${({ hover }) => hover.background};
   }
   &:active {
-    background-color: ${({ bgColorAtActive }) => bgColorAtActive};
+    background-color: ${({ active }) => active.background};
   }
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

# Ref
Branch from [PR#287](https://github.com/voyagegroup/ingred-ui/pull/287)

## やったこと
- [x] `type: "default" | warning" | "disabled"` を追加
- [x] `type: "default"`でデフォルト、`type: "warning"` で WarnText 、`type: "disabled"` で disabled にした
- [x] disabled時はonClickを反応させない

## スクショ
### Before
<img width="203" alt="スクリーンショット 2021-04-07 12 25 56" src="https://user-images.githubusercontent.com/50824354/113806005-83fcb080-979c-11eb-88d6-bc6ce40a39fb.png">

### After
【`type: warning` 追加時】

![70235c60e9019a71d662ab3299686fe1](https://user-images.githubusercontent.com/50824354/113806025-8c54eb80-979c-11eb-84dd-fbe74c676539.gif)

【Editに `type: default` 、`disabled: true` 追加時（後方互換性を保つため disabled が優先される）】

![image](https://user-images.githubusercontent.com/50824354/114117829-7a9d5080-9922-11eb-9263-6001d2a97d7c.png)


## 補足
disabled prop は ver. 8.0.0 で deprecated.