### PR TITLE
MenuにGroupを追加

### DIFF
--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -36,13 +36,13 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     />
   </button>
   <div
-    class="sc-jrAGrp hiCsBc"
+    class="sc-kEjbxe feirlT"
   >
     <div
-      class="sc-kEjbxe gDEJEG sc-iqHYGH jmmggR fade-transition-enter fade-transition-enter-active"
+      class="sc-iqHYGH cNhazb sc-crrsfI kRcxdo fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-pFZIQ horHys"
+      class="sc-jrAGrp eDBZNU"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -52,10 +52,10 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
         class="sc-jSgupP hzoSSJ"
       >
         <div
-          class="sc-iBPRYJ eNbA-Dk"
+          class="sc-fubCfw fvfTXF"
         >
           <p
-            class="sc-hKgILt jKKuBF sc-gKsewC"
+            class="sc-hKgILt jKKuBF sc-iBPRYJ"
             color="#041C33"
             font-size="13px"
           >
@@ -63,15 +63,15 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <hr
-          class="sc-fubCfw gdSgwf"
+          class="sc-pFZIQ cAneBo"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-iBPRYJ eNbA-Dk"
+          class="sc-fubCfw fvfTXF"
         >
           <p
-            class="sc-hKgILt jKKuBF sc-gKsewC"
+            class="sc-hKgILt jKKuBF sc-iBPRYJ"
             color="#041C33"
             font-size="13px"
           >
@@ -79,10 +79,10 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <div
-          class="sc-iBPRYJ eNbA-Dk"
+          class="sc-fubCfw fvfTXF"
         >
           <p
-            class="sc-hKgILt jKKuBF sc-gKsewC"
+            class="sc-hKgILt jKKuBF sc-iBPRYJ"
             color="#041C33"
             font-size="13px"
           >
@@ -90,15 +90,15 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
           </p>
         </div>
         <hr
-          class="sc-fubCfw gdSgwf"
+          class="sc-pFZIQ cAneBo"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-iBPRYJ eNbA-Dk"
+          class="sc-fubCfw fvfTXF"
         >
           <p
-            class="sc-hKgILt jKKuBF sc-gKsewC"
+            class="sc-hKgILt jKKuBF sc-iBPRYJ"
             color="#041C33"
             font-size="13px"
           >

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -39,25 +39,25 @@ exports[`DropdownButton component testing not splited disable 1`] = `
     </button>
   </div>
   <div
-    class="sc-dQppl jQuwEN"
+    class="sc-bqyKva ljsHPS"
   >
     <div
-      class="sc-crrsfI ksPwZT"
+      class="sc-dQppl gZuiDR"
       style="position: absolute; left: 0px; top: 0px;"
     >
       <div
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -65,10 +65,10 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -76,15 +76,15 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -92,10 +92,10 @@ exports[`DropdownButton component testing not splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -146,13 +146,13 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     </button>
   </div>
   <div
-    class="sc-dQppl kWrRil"
+    class="sc-bqyKva QlijG"
   >
     <div
-      class="sc-bqyKva gArbhj sc-kstrdz hlYJXb fade-transition-enter fade-transition-enter-active"
+      class="sc-kstrdz cRtzzp sc-hBEYos bDmGLR fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-crrsfI ksPwZT"
+      class="sc-dQppl gZuiDR"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -162,15 +162,15 @@ exports[`DropdownButton component testing not splited enable 1`] = `
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -178,10 +178,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -189,15 +189,15 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -205,10 +205,10 @@ exports[`DropdownButton component testing not splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -264,25 +264,25 @@ exports[`DropdownButton component testing splited disable 1`] = `
     </button>
   </div>
   <div
-    class="sc-dQppl jQuwEN"
+    class="sc-bqyKva ljsHPS"
   >
     <div
-      class="sc-crrsfI ksPwZT"
+      class="sc-dQppl gZuiDR"
       style="position: absolute; left: 0px; top: 0px;"
     >
       <div
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -290,10 +290,10 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -301,15 +301,15 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -317,10 +317,10 @@ exports[`DropdownButton component testing splited disable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -374,13 +374,13 @@ exports[`DropdownButton component testing splited enable 1`] = `
     </button>
   </div>
   <div
-    class="sc-dQppl kWrRil"
+    class="sc-bqyKva QlijG"
   >
     <div
-      class="sc-bqyKva gArbhj sc-kstrdz hlYJXb fade-transition-enter fade-transition-enter-active"
+      class="sc-kstrdz cRtzzp sc-hBEYos bDmGLR fade-transition-enter fade-transition-enter-active"
     />
     <div
-      class="sc-crrsfI ksPwZT"
+      class="sc-dQppl gZuiDR"
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
@@ -390,15 +390,15 @@ exports[`DropdownButton component testing splited enable 1`] = `
         class="sc-pFZIQ flczYu"
       >
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -406,10 +406,10 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -417,15 +417,15 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <hr
-          class="sc-iqHYGH bCAJMq"
+          class="sc-crrsfI dqZXMz"
           color="#E2E8EA"
           orientation="horizontal"
         />
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >
@@ -433,10 +433,10 @@ exports[`DropdownButton component testing splited enable 1`] = `
           </p>
         </div>
         <div
-          class="sc-kEjbxe jJevVb"
+          class="sc-iqHYGH fPNkRl"
         >
           <p
-            class="sc-bdfBwQ gNlqto sc-jrAGrp"
+            class="sc-bdfBwQ gNlqto sc-kEjbxe"
             color="#041C33"
             font-size="13px"
           >

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -38,16 +38,25 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
     args={{
       contents: [
         {
-          title: "フルーツ",
+          title: "Fruits",
           contents: [
-            { text: "Save", onClick: () => {} },
-            { text: "Edit", onClick: () => {} },
-            { text: "Delete", onClick: () => {}, disabled: true },
-            { text: "Update", onClick: () => {} },
+            { text: "Apple", onClick: () => {} },
+            { text: "Peach", onClick: () => {} },
+            { text: "Orange", onClick: () => {}, disabled: true },
+            { text: "Strawberry", onClick: () => {} },
           ]
-        }
+        },
+        {
+          title: "Vegetables",
+          contents: [
+            { text: "Cabbage", onClick: () => {} },
+            { text: "Carrot", onClick: () => {} },
+            { text: "Radish", onClick: () => {}, disabled: true },
+            { text: "Cucumber", onClick: () => {} },
+          ]
+        },
       ],
-      maxHeight: "100px",
+      maxHeight: "250px",
     }}
   >
     {(args) => (

--- a/src/components/MenuList/MenuList.stories.mdx
+++ b/src/components/MenuList/MenuList.stories.mdx
@@ -31,3 +31,29 @@ MenuList is a lower-level component that is leveraged [`<Menu />`](/?path=/docs/
     )}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story
+    name="Group Example"
+    args={{
+      contents: [
+        {
+          title: "フルーツ",
+          contents: [
+            { text: "Save", onClick: () => {} },
+            { text: "Edit", onClick: () => {} },
+            { text: "Delete", onClick: () => {}, disabled: true },
+            { text: "Update", onClick: () => {} },
+          ]
+        }
+      ],
+      maxHeight: "100px",
+    }}
+  >
+    {(args) => (
+      <div style={{ backgroundColor: "silver", padding: "10px" }}>
+        <MenuList {...args} />
+      </div>
+    )}
+  </Story>
+</Canvas>

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -139,7 +139,10 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
 
     const isGroupContent = (
       content: GroupContentProp | ContentProp,
-    ): content is GroupContentProp => !!content.title;
+    ): content is GroupContentProp => {
+      if (content.title === "") return true;
+      return !!content.title;
+    };
 
     const renderContent = (content: ContentProp) => (
       <React.Fragment key={content.text}>
@@ -185,15 +188,17 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
         {contents.map((content) =>
           isGroupContent(content) ? (
             <React.Fragment key={content.title}>
-              <Styled.TitleContainer>
-                <Typography
-                  size="xs"
-                  color={theme.palette.text.secondary}
-                  weight="bold"
-                >
-                  {content.title}
-                </Typography>
-              </Styled.TitleContainer>
+              {content.title && (
+                <Styled.TitleContainer>
+                  <Typography
+                    size="xs"
+                    color={theme.palette.text.secondary}
+                    weight="bold"
+                  >
+                    {content.title}
+                  </Typography>
+                </Styled.TitleContainer>
+              )}
               {content.contents.map(renderContent)}
             </React.Fragment>
           ) : (

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -137,6 +137,15 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       content.onClick();
     };
 
+    const isGroupContent = (
+      content: GroupContentProp | ContentProp,
+    ): content is GroupContentProp => {
+      if (content.title === "") {
+        return true;
+      }
+      return !!content.title;
+    };
+
     const renderContent = (content: ContentProp) => (
       <React.Fragment key={content.text}>
         {content.divideTop && (
@@ -171,10 +180,6 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       </React.Fragment>
     );
 
-    const isGroupContent = (
-      content: GroupContentProp | ContentProp,
-    ): content is GroupContentProp => !!content.title;
-
     return (
       <Styled.Container
         inline={inline}
@@ -184,7 +189,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       >
         {contents.map((content: ContentProp | GroupContentProp) =>
           isGroupContent(content) ? (
-            <>
+            <React.Fragment key={content.title}>
               <Styled.TitleContainer>
                 <Typography
                   size="xs"
@@ -195,7 +200,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
                 </Typography>
               </Styled.TitleContainer>
               {content.contents.map((content) => renderContent(content))}
-            </>
+            </React.Fragment>
           ) : (
             renderContent(content)
           ),

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -28,13 +28,19 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
     const theme = useTheme();
 
     const renderGroupContent = (content: GroupContentProp) => (
-      <>
+      <React.Fragment key={content.title}>
         <Styled.TitleContainer>
-          <Typography size="sm">{content.title}</Typography>
+          <Typography
+            size="xs"
+            color={theme.palette.text.secondary}
+            weight="bold"
+          >
+            {content.title}
+          </Typography>
         </Styled.TitleContainer>
         {content.contents.map((content: ContentProp) => (
           <Styled.TextContainer
-            key={content.title}
+            key={content.text}
             disabled={content.disabled}
             onClick={content.onClick}
           >
@@ -46,7 +52,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
             </Typography>
           </Styled.TextContainer>
         ))}
-      </>
+      </React.Fragment>
     );
 
     const renderContent = (content: ContentProp) => (

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -171,20 +171,9 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
       </React.Fragment>
     );
 
-    const renderGroupContent = (content: GroupContentProp) => (
-      <React.Fragment key={content.title}>
-        <Styled.TitleContainer>
-          <Typography
-            size="xs"
-            color={theme.palette.text.secondary}
-            weight="bold"
-          >
-            {content.title}
-          </Typography>
-        </Styled.TitleContainer>
-        {content.contents.map((content: ContentProp) => renderContent(content))}
-      </React.Fragment>
-    );
+    const isGroupContent = (
+      content: GroupContentProp | ContentProp,
+    ): content is GroupContentProp => !!content.title;
 
     return (
       <Styled.Container
@@ -194,9 +183,22 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
         ref={ref}
       >
         {contents.map((content: ContentProp | GroupContentProp) =>
-          content.title
-            ? renderGroupContent(content as GroupContentProp)
-            : renderContent(content as ContentProp),
+          isGroupContent(content) ? (
+            <>
+              <Styled.TitleContainer>
+                <Typography
+                  size="xs"
+                  color={theme.palette.text.secondary}
+                  weight="bold"
+                >
+                  {content.title}
+                </Typography>
+              </Styled.TitleContainer>
+              {content.contents.map((content) => renderContent(content))}
+            </>
+          ) : (
+            renderContent(content)
+          ),
         )}
       </Styled.Container>
     );

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -7,21 +7,67 @@ import { useTheme } from "../../themes";
 
 export type ContentProp = React.ComponentPropsWithRef<"div"> & {
   text: string;
-  // TODO: rename "handleClick"
   onClick: () => void;
   divideTop?: boolean;
   disabled?: boolean;
 };
 
+export type GroupContentProp = React.ComponentPropsWithRef<"div"> & {
+  title: string;
+  contents: ContentProp[];
+};
+
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
   inline?: boolean;
-  contents: ContentProp[];
+  contents: ContentProp[] | GroupContentProp[];
   maxHeight?: Property.MaxHeight;
 };
 
 const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
   ({ inline = false, contents, maxHeight = "none", ...rest }, ref) => {
     const theme = useTheme();
+
+    const renderGroupContent = (content: GroupContentProp) => (
+      <>
+        <Styled.TitleContainer>
+          <Typography size="sm">{content.title}</Typography>
+        </Styled.TitleContainer>
+        {content.contents.map((content: ContentProp) => (
+          <Styled.TextContainer
+            key={content.title}
+            disabled={content.disabled}
+            onClick={content.onClick}
+          >
+            <Typography
+              size="sm"
+              color={content.disabled ? "disabled" : "initial"}
+            >
+              {content.text}
+            </Typography>
+          </Styled.TextContainer>
+        ))}
+      </>
+    );
+
+    const renderContent = (content: ContentProp) => (
+      <React.Fragment key={content.text}>
+        {content.divideTop && (
+          <Divider my={1} mx={2} color={theme.palette.gray.light} />
+        )}
+        <Styled.TextContainer
+          disabled={content.disabled}
+          onClick={content.onClick}
+        >
+          <Typography
+            size="sm"
+            color={content.disabled ? "disabled" : "initial"}
+          >
+            {content.text}
+          </Typography>
+        </Styled.TextContainer>
+      </React.Fragment>
+    );
+
     return (
       <Styled.Container
         inline={inline}
@@ -29,25 +75,11 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
         {...rest}
         ref={ref}
       >
-        {contents.map((content) => (
-          <React.Fragment key={content.text}>
-            {content.divideTop && (
-              <Divider my={1} mx={2} color={theme.palette.gray.light} />
-            )}
-            {/* eslint-disable-next-line react/jsx-handler-names */}
-            <Styled.TextContainer
-              disabled={content.disabled}
-              onClick={content.onClick}
-            >
-              <Typography
-                size="sm"
-                color={content.disabled ? "disabled" : "initial"}
-              >
-                {content.text}
-              </Typography>
-            </Styled.TextContainer>
-          </React.Fragment>
-        ))}
+        {contents.map((content: ContentProp | GroupContentProp) =>
+          content.title
+            ? renderGroupContent(content as GroupContentProp)
+            : renderContent(content as ContentProp),
+        )}
       </Styled.Container>
     );
   },

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -100,7 +100,7 @@ export type GroupContentProp = React.ComponentPropsWithRef<"div"> & {
 
 export type MenuListProps = React.ComponentPropsWithRef<"div"> & {
   inline?: boolean;
-  contents: ContentProp[] | GroupContentProp[];
+  contents: Array<ContentProp | GroupContentProp>;
   maxHeight?: Property.MaxHeight;
 };
 
@@ -139,12 +139,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
 
     const isGroupContent = (
       content: GroupContentProp | ContentProp,
-    ): content is GroupContentProp => {
-      if (content.title === "") {
-        return true;
-      }
-      return !!content.title;
-    };
+    ): content is GroupContentProp => !!content.title;
 
     const renderContent = (content: ContentProp) => (
       <React.Fragment key={content.text}>
@@ -187,7 +182,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
         {...rest}
         ref={ref}
       >
-        {contents.map((content: ContentProp | GroupContentProp) =>
+        {contents.map((content) =>
           isGroupContent(content) ? (
             <React.Fragment key={content.title}>
               <Styled.TitleContainer>
@@ -199,7 +194,7 @@ const MenuList = React.forwardRef<HTMLDivElement, MenuListProps>(
                   {content.title}
                 </Typography>
               </Styled.TitleContainer>
-              {content.contents.map((content) => renderContent(content))}
+              {content.contents.map(renderContent)}
             </React.Fragment>
           ) : (
             renderContent(content)

--- a/src/components/MenuList/__tests__/MenuList.test.tsx
+++ b/src/components/MenuList/__tests__/MenuList.test.tsx
@@ -3,29 +3,34 @@ import "@testing-library/jest-dom/extend-expect";
 import { cleanup } from "@testing-library/react";
 import MenuList from "..";
 import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
-import { ContentProp } from "../MenuList";
+import { ContentProp, GroupContentProp } from "../MenuList";
 
-const contents: ContentProp[] = [
+const contents: Array<ContentProp | GroupContentProp> = [
   {
-    text: "Save",
-    onClick: () => {},
-    type: "default",
-  },
-  {
-    text: "Save and execute",
-    onClick: () => {},
-    divideTop: true,
-    type: "default",
-  },
-  {
-    text: "Save as draft",
-    onClick: () => {},
-    type: "warning",
-  },
-  {
-    text: "Cancel",
-    onClick: () => {},
-    type: "disabled",
+    title: "Title",
+    contents: [
+      {
+        text: "Save",
+        onClick: () => {},
+        type: "default",
+      },
+      {
+        text: "Save and execute",
+        onClick: () => {},
+        divideTop: true,
+        type: "default",
+      },
+      {
+        text: "Save as draft",
+        onClick: () => {},
+        type: "warning",
+      },
+      {
+        text: "Cancel",
+        onClick: () => {},
+        type: "disabled",
+      },
+    ],
   },
 ];
 

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -6,6 +6,17 @@ exports[`MenuList component testing MenuList splited 1`] = `
     class="sc-gsTCUz pKiIS"
   >
     <div
+      class="sc-dlfnbm djzfeK"
+    >
+      <p
+        class="sc-bdfBwQ flmsLJ"
+        color="#596978"
+        font-size="12px"
+      >
+        Title
+      </p>
+    </div>
+    <div
       class="sc-eCssSg MluwL"
     >
       <p

--- a/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
+++ b/src/components/MenuList/__tests__/__snapshots__/MenuList.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`MenuList component testing MenuList splited 1`] = `
     class="sc-gsTCUz pKiIS"
   >
     <div
-      class="sc-hKgILt cgOKnC"
+      class="sc-eCssSg MluwL"
     >
       <p
-        class="sc-bdfBwQ gNlqto sc-dlfnbm"
+        class="sc-bdfBwQ gNlqto sc-hKgILt"
         color="#041C33"
         font-size="13px"
       >
@@ -17,15 +17,15 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <hr
-      class="sc-eCssSg dxgEOm"
+      class="sc-jSgupP hrdszH"
       color="#E2E8EA"
       orientation="horizontal"
     />
     <div
-      class="sc-hKgILt cgOKnC"
+      class="sc-eCssSg MluwL"
     >
       <p
-        class="sc-bdfBwQ gNlqto sc-dlfnbm"
+        class="sc-bdfBwQ gNlqto sc-hKgILt"
         color="#041C33"
         font-size="13px"
       >
@@ -33,10 +33,10 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-hKgILt llPkGB"
+      class="sc-eCssSg jGGxNk"
     >
       <p
-        class="sc-bdfBwQ kbxRUt sc-dlfnbm"
+        class="sc-bdfBwQ kbxRUt sc-hKgILt"
         color="#EB0A4E"
         font-size="13px"
       >
@@ -44,11 +44,11 @@ exports[`MenuList component testing MenuList splited 1`] = `
       </p>
     </div>
     <div
-      class="sc-hKgILt dObLPw"
+      class="sc-eCssSg kpgArZ"
       disabled=""
     >
       <p
-        class="sc-bdfBwQ iQudAe sc-dlfnbm"
+        class="sc-bdfBwQ iQudAe sc-hKgILt"
         color="#B3BAC1"
         font-size="13px"
       >

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -26,7 +26,8 @@ export const TitleContainer = styled.div`
   align-items: center;
   height: 32px;
   background: ${({ theme }) => theme.palette.gray.highlight};
-  padding: 0 ${({ theme }) => theme.spacing}px;
+  margin: ${({ theme }) => theme.spacing}px 0;
+  padding: ${({ theme }) => theme.spacing}px;
 `;
 
 export const Text = styled(Typography)``;

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -15,6 +15,8 @@ export const Container = styled.div<ContainerProps>`
   ${({ maxHeight }) => addScrollbarProperties({ maxHeight })}
 `;
 
+export const TitleContainer = styled.div``;
+
 export const TextContainer = styled.div<{ disabled?: boolean }>`
   cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   display: flex;

--- a/src/components/MenuList/styled.ts
+++ b/src/components/MenuList/styled.ts
@@ -15,7 +15,13 @@ export const Container = styled.div<ContainerProps>`
   ${({ maxHeight }) => addScrollbarProperties({ maxHeight })}
 `;
 
-export const TitleContainer = styled.div``;
+export const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: 32px;
+  background: ${({ theme }) => theme.palette.gray.highlight};
+  padding: 0 ${({ theme }) => theme.spacing}px;
+`;
 
 export const TextContainer = styled.div<{ disabled?: boolean }>`
   cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## Ref
- From [#287](https://github.com/voyagegroup/ingred-ui/pull/287)
- [XD](https://xd.adobe.com/view/a2977fa3-990f-4e0b-7eb7-1f835cc8c42a-d4a6/screen/d51117bd-b807-4e7d-91b7-68a3cd052043/specs/)

## やったこと
- Groupの追加
  - `title: string, contents: ContentProp[]`でGroup化
  - それ以外の時はdefaultのスタイル
- MenuListに依存しているコンポーネント（Menu, DropdownButton etc.）のcontents propの型を修正

## スクショ
### After
タイトル追加時

![image](https://user-images.githubusercontent.com/50824354/114352647-117a3f00-9ba7-11eb-868c-df99ead5d6a2.png)

タイトルが空の時 → タイトルは表示せず、中のコンテンツだけ表示する。

![image](https://user-images.githubusercontent.com/50824354/114352579-ff000580-9ba6-11eb-9825-c96889eb9aed.png)

