### PR TITLE
release & publishのflowを修正する

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
 
 jobs:
   publish:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,7 @@ jobs:
           body: |
             ## Check List
             - [ ] CHANGELOGの確認
-            - [ ] [最新のリリースノート](https://github.com/voyagegroup/ingred-ui/releases/tag/v${{ env.RELEASE_VERSION }})に変更内容を追加する
-                - releaseを取り消す場合は[v${{ env.RELEASE_VERSION }}のリリースとタグ](https://github.com/voyagegroup/ingred-ui/releases/tag/v${{ env.RELEASE_VERSION }})を消して、このPRを閉じてください
+            - [ ] [draftのリリースノート](https://github.com/voyagegroup/ingred-ui/releases/)の変更内容を編集してpublish
           labels: release
           base: master
           branch: ${{ env.RELEASE_BRANCH }}
@@ -72,6 +71,7 @@ jobs:
           tag: ${{ env.RELEASE_TAG_NAME }}
           token: ${{ secrets.FLUCT_MEMBER_GITHUB_TOKEN }}
           commit: ${{ steps.get_last_commit_hash.outputs.HASH }}
+          draft: true
         env:
           RELEASE_BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
           RELEASE_VERSION: ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
<!-- If️ you added new component, please add example to `.storybook/documents/Information/Samples/Samples.stories.tsx` -->

## やったこと

- 今の状態だとtag pushのtriggerが発火しない
    - commit messageに `[ci skip]` が入っているため
- なので以下のフローに変更
    - releaseをdraftで作成
    - CHANGELOGを記載
    - releaseを公開する
        - 公開をkickにnpm publishする