### PR TITLE
Modify multiple filter

### DIFF
--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -71,12 +71,6 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
     ReferedFilterType[]
   >([]);
 
-  // React.useEffect(() => {
-  //   if (onChange !== undefined) {
-  //     onChange(currentReferedFilters);
-  //   }
-  // }, [currentReferedFilters, onChange]);
-
   const handleOnFocus = () => {
     setIsFocus(true);
   };

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -159,6 +159,7 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
     }
 
     setIsFocus(false);
+    setSelectedFilterPack(null);
     setWillEditFilter(null);
   };
 

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -71,11 +71,11 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
     ReferedFilterType[]
   >([]);
 
-  React.useEffect(() => {
-    if (onChange !== undefined) {
-      onChange(currentReferedFilters);
-    }
-  }, [currentReferedFilters, onChange]);
+  // React.useEffect(() => {
+  //   if (onChange !== undefined) {
+  //     onChange(currentReferedFilters);
+  //   }
+  // }, [currentReferedFilters, onChange]);
 
   const handleOnFocus = () => {
     setIsFocus(true);
@@ -103,6 +103,10 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
   const handleApply = (newReferedFilter: ReferedFilterType) => {
     const newReferedFilters = currentReferedFilters.concat([newReferedFilter]);
     setCurrentReferedFilters(newReferedFilters);
+    if (onChange !== undefined) {
+      onChange(newReferedFilters);
+    }
+
     setSelectedFilterPack(null);
     setIsFocus(false);
   };
@@ -112,10 +116,16 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
       (referedFilter) => referedFilter.filterName !== removedFilter.filterName,
     );
     setCurrentReferedFilters(newReferedFilters);
+    if (onChange !== undefined) {
+      onChange(newReferedFilters);
+    }
   };
 
   const handleClear = () => {
     setCurrentReferedFilters([]);
+    if (onChange !== undefined) {
+      onChange([] as ReferedFilterType[]);
+    }
   };
 
   const hasReferedFilter = (refoeredfilters: ReferedFilterType[]) => {
@@ -143,6 +153,9 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
     );
     currentReferedFilters[editIndex] = editedFilter;
     setCurrentReferedFilters(currentReferedFilters.slice());
+    if (onChange !== undefined) {
+      onChange(currentReferedFilters);
+    }
     setIsFocus(false);
     setWillEditFilter(null);
   };

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -145,11 +145,19 @@ const MultipleFilter: React.FunctionComponent<MultipleFilterProps> = ({
     const editIndex = currentReferedFilters.findIndex(
       (referedfilter) => referedfilter.filterName === editedFilter.filterName,
     );
-    currentReferedFilters[editIndex] = editedFilter;
-    setCurrentReferedFilters(currentReferedFilters.slice());
-    if (onChange !== undefined) {
-      onChange(currentReferedFilters);
+
+    const isEdited =
+      currentReferedFilters[editIndex].filterCondtion !==
+      editedFilter.filterCondtion;
+
+    if (isEdited) {
+      currentReferedFilters[editIndex] = editedFilter;
+      setCurrentReferedFilters(currentReferedFilters.slice());
+      if (onChange !== undefined) {
+        onChange(currentReferedFilters);
+      }
     }
+
     setIsFocus(false);
     setWillEditFilter(null);
   };


### PR DESCRIPTION
## 背景
`useEffect`でフィルターの条件の変更を検知していたが、`useEffect`ではマウント時に実行されるため、変更がないのにも関わらず、onChageイベントが発火していた。

## やったこと
条件の適用、変更、適用時のみに変更した。