### PR TITLE
[DropdownButton] コンテキストメニューの座標を更新するように

### DIFF
--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -42,17 +42,20 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
   children,
 }) => {
   const theme = useTheme();
-  const [
-    buttonElement,
-    setButtonElement,
-  ] = React.useState<HTMLDivElement | null>(null);
+  const [buttonElement, setButtonElement] = React.useState<
+    HTMLDivElement | HTMLButtonElement | null
+  >(null);
   const [showContent, setShowContent] = React.useState<boolean>(false);
 
-  const handleToggleContent = (showContent: boolean) => () => {
-    if (showContent && !split && onClick) {
+  const handleToggleContent = (
+    event: React.MouseEvent<HTMLDivElement | HTMLButtonElement, MouseEvent>,
+  ) => {
+    setButtonElement(event.currentTarget);
+
+    if (!showContent && !split && onClick) {
       onClick();
     }
-    setShowContent(showContent);
+    setShowContent(!showContent);
   };
 
   const setIconColor = (disabled: boolean, color: DropdownButtonColor) => {
@@ -67,7 +70,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
 
   return (
     <>
-      <Styled.ButtonContainer ref={setButtonElement} role="button">
+      <Styled.ButtonContainer role="button">
         {split ? (
           <>
             <Styled.MainButton
@@ -85,7 +88,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
               inline={true}
               disabled={disabled}
               data-testid="menu-toggle"
-              onClick={handleToggleContent(!showContent)}
+              onClick={handleToggleContent}
             >
               <Icon
                 name={"arrow_bottom"}
@@ -101,7 +104,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
             color={color}
             disabled={disabled}
             data-testid="menu-toggle"
-            onClick={handleToggleContent(!showContent)}
+            onClick={handleToggleContent}
           >
             {children}
             <Spacer pr={0.5} />
@@ -121,10 +124,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
         positionPriority={positionPriority}
         maxHeight={menuMaxHeight}
         {...menuProps}
-        onClose={createChainedFunction(
-          handleToggleContent(false),
-          menuProps?.onClose,
-        )}
+        onClose={createChainedFunction(handleToggleContent, menuProps?.onClose)}
       />
     </>
   );


### PR DESCRIPTION
## やったこと
- DropdownButtonのトグルの位置を修正

## before / after

### before

https://user-images.githubusercontent.com/56141035/120735761-2380ba00-c526-11eb-8eb0-fc4bbefe7a20.mov

### after

https://user-images.githubusercontent.com/56141035/120735730-195ebb80-c526-11eb-8fa0-3bb862056078.mov

## issue
- https://github.com/voyagegroup/fluct_datastrap/issues/2802
