### PR TITLE
renovate minorやpatchアップデートををまとめないように

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,11 @@
     "before 6:30pm every weekday"
   ],
   "recreateClosed": true,
-  "pin": {
-    "automerge": true
-  },
   "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "patch"],
+      "automerge": true
+    },
     {
       "matchPackagePatterns": ["^@types/"],
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "labels": ["renovate"],
   "timezone": "Asia/Tokyo",
   "schedule": [
@@ -20,10 +18,6 @@
     {
       "matchPackagePatterns": ["^@testing-library/"],
       "automerge": true
-    },
-    {
-      "groupName": "non-major",
-      "matchUpdateTypes": ["patch", "minor"]
     }
   ]
 }


### PR DESCRIPTION
**これはjust ideaですので、議論大歓迎。**

https://github.com/voyagegroup/ingred-ui/pull/435 のようにスタックしがち。
やるには腰が重くなりがちなので、PRをまとめないように設定を変更する。