### PR TITLE
rubyのバージョンを2.7にあげる

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           ruby-version: 2.7
       - name: install github_changelog_generate
-        run: gem install github_changelog_generator
+        run: gem install -N github_changelog_generator
       - name: create CHANGELOG
         run: make -f ci.mk changelog
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       release_version:
         required: true
-        description:  release version
+        description: release version
 
 jobs:
   release:
@@ -26,10 +26,10 @@ jobs:
         run: make -f ci.mk lint
       - name: test
         run: make -f ci.mk test
-      - name: Use Ruby 2.6
+      - name: Use Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
       - name: install github_changelog_generate
         run: gem install github_changelog_generator
       - name: create CHANGELOG


### PR DESCRIPTION
- https://github.com/voyagegroup/ingred-ui/runs/4545032051?check_suite_focus=true

```
ERROR:  Error installing github_changelog_generator:
	The last version of activesupport (>= 0) to support your Ruby & RubyGems was 6.1.4.4. Try installing it with `gem install activesupport -v 6.1.4.4` and then running the current command again
	activesupport requires Ruby version >= 2.7.0. The current ruby version is 2.6.9.207.
```