### PR TITLE
Rubyのバージョンを3.0にあげる

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,10 @@ jobs:
         run: make -f ci.mk lint
       - name: test
         run: make -f ci.mk test
-      - name: Use Ruby 2.7
+      - name: Use Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
       - name: install github_changelog_generate
         run: gem install -N github_changelog_generator
       - name: create CHANGELOG


### PR DESCRIPTION
リリースの CI が落ちてるので Ruby のバージョンを上げる。

ref https://github.com/voyagegroup/ingred-ui/runs/4877991528?check_suite_focus=true

```
Run gem install -N github_changelog_generator
  gem install -N github_changelog_generator
  shell: /usr/bin/bash -e {0}
ERROR:  Error installing github_changelog_generator:
	There are no versions of io-event (~> 1.0.0) compatible with your Ruby & RubyGems. Maybe try installing an older version of the gem you're looking for?
	io-event requires Ruby version >= 3.0. The current ruby version is 2.7.5.203.
Successfully installed concurrent-ruby-1.1.9
Successfully installed tzinfo-2.0.4
Successfully installed i18n-1.8.11
Successfully installed activesupport-7.0.1
Successfully installed fiber-local-1.0.0
Successfully installed console-1.14.0
Error: Process completed with exit code 1.
```