### PR TITLE
react-transition-group の warning 対応

### DIFF
--- a/src/components/Backdrop/__tests__/__snapshots__/Backdrop.test.tsx.snap
+++ b/src/components/Backdrop/__tests__/__snapshots__/Backdrop.test.tsx.snap
@@ -3,7 +3,11 @@
 exports[`Backdrop component testing Backdrop 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdvvtL cQENSx sc-gsDKAQ fFBudr fade-transition-appear fade-transition-appear-active"
-  />
+    class="sc-gsDKAQ fFBudr fade-transition-appear fade-transition-appear-active"
+  >
+    <div
+      class="sc-bdvvtL cQENSx"
+    />
+  </div>
 </DocumentFragment>
 `;

--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -6,66 +6,74 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
     class="sc-fFeiMQ fJuGfT"
   >
     <div
-      class="sc-bkkeKt fEwjBL sc-ieecCq ixODts fade-transition-appear fade-transition-appear-active"
-    />
-    <div
-      class="sc-gsDKAQ sc-hKwDye dCDjlW cnIyXF sc-ieecCq ixODts fade-transition-appear fade-transition-appear-active"
+      class="sc-ieecCq ixODts fade-transition-appear fade-transition-appear-active"
     >
-      <form>
-        <div
-          class="sc-eCImPb hMUlJt"
-        >
+      <div
+        class="sc-bkkeKt fEwjBL"
+      />
+    </div>
+    <div
+      class="sc-ieecCq ixODts fade-transition-appear fade-transition-appear-active"
+    >
+      <div
+        class="sc-gsDKAQ sc-hKwDye gmmrAP cnIyXF"
+      >
+        <form>
           <div
-            class="sc-jRQBWg gNzDsc"
-          >
-            <p
-              class="sc-iqseJM bkdyck"
-              color="#041C33"
-              font-size="20px"
-            >
-              Title
-            </p>
-            <div
-              class="sc-egiyK haNrTA"
-            />
-          </div>
-          <div
-            class="sc-furwcr enHelU"
+            class="sc-eCImPb hMUlJt"
           >
             <div
-              class="sc-crHmcD hehbzV"
-              size="24"
+              class="sc-jRQBWg gNzDsc"
             >
-              <svg
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <p
+                class="sc-iqseJM bkdyck"
+                color="#041C33"
+                font-size="20px"
               >
-                <rect
-                  fill="#041C33"
-                  height="23.141"
-                  rx="2.571"
-                  transform="translate(18.364 2) rotate(45)"
-                  width="5.142"
-                />
-                <rect
-                  fill="#041C33"
-                  height="23.141"
-                  rx="2.571"
-                  transform="translate(2 5.636) rotate(-45)"
-                  width="5.143"
-                />
-              </svg>
+                Title
+              </p>
+              <div
+                class="sc-egiyK haNrTA"
+              />
+            </div>
+            <div
+              class="sc-furwcr enHelU"
+            >
+              <div
+                class="sc-crHmcD hehbzV"
+                size="24"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    fill="#041C33"
+                    height="23.141"
+                    rx="2.571"
+                    transform="translate(18.364 2) rotate(45)"
+                    width="5.142"
+                  />
+                  <rect
+                    fill="#041C33"
+                    height="23.141"
+                    rx="2.571"
+                    transform="translate(2 5.636) rotate(-45)"
+                    width="5.143"
+                  />
+                </svg>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          class="sc-gKclnd dmgRET"
-        >
           <div
-            class="sc-egiyK eHvOtZ"
-          />
-        </div>
-      </form>
+            class="sc-gKclnd dmgRET"
+          >
+            <div
+              class="sc-egiyK eHvOtZ"
+            />
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -39,8 +39,12 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     class="sc-kDTinF cvlHxF"
   >
     <div
-      class="sc-iqseJM bDSzMX sc-crHmcD bXnuhj fade-transition-enter fade-transition-enter-active"
-    />
+      class="sc-crHmcD bXnuhj fade-transition-enter fade-transition-enter-active"
+    >
+      <div
+        class="sc-iqseJM bDSzMX"
+      />
+    </div>
     <div
       class="sc-jrQzAO jahegW"
       data-popper-escaped="true"

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -149,8 +149,12 @@ exports[`DropdownButton component testing not splited enable 1`] = `
     class="sc-bqiRlB fgnFUF"
   >
     <div
-      class="sc-ksdxgE hJTxxA sc-hBUSln kZfwTK fade-transition-enter fade-transition-enter-active"
-    />
+      class="sc-hBUSln kZfwTK fade-transition-enter fade-transition-enter-active"
+    >
+      <div
+        class="sc-ksdxgE hJTxxA"
+      />
+    </div>
     <div
       class="sc-egiyK AIhFW"
       data-popper-escaped="true"
@@ -377,8 +381,12 @@ exports[`DropdownButton component testing splited enable 1`] = `
     class="sc-bqiRlB fgnFUF"
   >
     <div
-      class="sc-ksdxgE hJTxxA sc-hBUSln kZfwTK fade-transition-enter fade-transition-enter-active"
-    />
+      class="sc-hBUSln kZfwTK fade-transition-enter fade-transition-enter-active"
+    >
+      <div
+        class="sc-ksdxgE hJTxxA"
+      />
+    </div>
     <div
       class="sc-egiyK AIhFW"
       data-popper-escaped="true"

--- a/src/components/Fade/Fade.tsx
+++ b/src/components/Fade/Fade.tsx
@@ -9,6 +9,7 @@ const Fade: React.FunctionComponent<CSSTransitionProps> = ({
   ...rest
 }) => {
   const nodeRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <Styled.CSSTransition
       nodeRef={nodeRef}

--- a/src/components/Fade/Fade.tsx
+++ b/src/components/Fade/Fade.tsx
@@ -8,15 +8,17 @@ const Fade: React.FunctionComponent<CSSTransitionProps> = ({
   children,
   ...rest
 }) => {
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Styled.CSSTransition
+      nodeRef={nodeRef}
       appear={true}
       mountOnEnter={true}
       timeout={timeout}
       classNames={Styled.transitionClass}
       {...rest}
     >
-      {children}
+      <div ref={nodeRef}>{children}</div>
     </Styled.CSSTransition>
   );
 };

--- a/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
+++ b/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
@@ -6,8 +6,12 @@ exports[`FloatingTip component testing FloatingTip 1`] = `
     class="sc-eCImPb gEZCVL"
   >
     <div
-      class="sc-jRQBWg iRPcoZ sc-gKclnd frGHeV fade-transition-appear fade-transition-appear-active"
-    />
+      class="sc-gKclnd frGHeV fade-transition-appear fade-transition-appear-active"
+    >
+      <div
+        class="sc-jRQBWg iRPcoZ"
+      />
+    </div>
     <div
       class="sc-hKwDye kvypRT"
       style="position: absolute; left: 0px; top: 0px;"

--- a/src/components/Grow/Grow.tsx
+++ b/src/components/Grow/Grow.tsx
@@ -8,15 +8,17 @@ const Grow: React.FunctionComponent<CSSTransitionProps> = ({
   children,
   ...rest
 }) => {
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   return (
     <Styled.CSSTransition
+      nodeRef={nodeRef}
       appear={true}
       mountOnEnter={true}
       timeout={timeout}
       classNames={Styled.transitionClass}
       {...rest}
     >
-      {children}
+      <div ref={nodeRef}>{children}</div>
     </Styled.CSSTransition>
   );
 };

--- a/src/components/Grow/Grow.tsx
+++ b/src/components/Grow/Grow.tsx
@@ -9,6 +9,7 @@ const Grow: React.FunctionComponent<CSSTransitionProps> = ({
   ...rest
 }) => {
   const nodeRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <Styled.CSSTransition
       nodeRef={nodeRef}

--- a/src/components/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -6,8 +6,12 @@ exports[`Modal component testing Modal with background 1`] = `
     class="sc-bdvvtL cttKBd"
   >
     <div
-      class="sc-gsDKAQ dLmdEA sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
-    />
+      class="sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
+    >
+      <div
+        class="sc-gsDKAQ dLmdEA"
+      />
+    </div>
     <div>
       hoge
     </div>
@@ -21,8 +25,12 @@ exports[`Modal component testing Modal without background 1`] = `
     class="sc-bdvvtL cttKBd"
   >
     <div
-      class="sc-gsDKAQ dLmdEA sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
-    />
+      class="sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
+    >
+      <div
+        class="sc-gsDKAQ dLmdEA"
+      />
+    </div>
     <div>
       hoge
     </div>

--- a/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -6,8 +6,12 @@ exports[`Popover component testing Popover 1`] = `
     class="sc-gsDKAQ gzCcYc"
   >
     <div
-      class="sc-dkPtRN jXTMGN sc-hKwDye dOfRKQ fade-transition-appear fade-transition-appear-active"
-    />
+      class="sc-hKwDye dOfRKQ fade-transition-appear fade-transition-appear-active"
+    >
+      <div
+        class="sc-dkPtRN jXTMGN"
+      />
+    </div>
     <div
       class="sc-bdvvtL wkcbx"
       style="position: absolute; left: 0px; top: 0px;"

--- a/src/components/Slide/Slide.tsx
+++ b/src/components/Slide/Slide.tsx
@@ -9,15 +9,18 @@ const Slide: React.FunctionComponent<CSSTransitionProps> = ({
   direction = "down",
   ...rest
 }) => {
+  const nodeRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <Styled.CSSTransition
+      nodeRef={nodeRef}
       appear={true}
       timeout={timeout}
       direction={direction}
       classNames={Styled.transitionClass}
       {...rest}
     >
-      {children}
+      <div ref={nodeRef}>{children}</div>
     </Styled.CSSTransition>
   );
 };

--- a/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -6,14 +6,18 @@ exports[`Tooltip component testing Tooltip 1`] = `
     text
   </div>
   <div
-    class="sc-gsDKAQ chwUAn sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
-    style="position: absolute; left: 0px; top: 0px;"
+    class="sc-dkPtRN jMueqr fade-transition-appear fade-transition-appear-active"
   >
-    tooltip text
     <div
-      class="sc-bdvvtL bIjFMV"
-      data-popper-arrow="true"
-    />
+      class="sc-gsDKAQ chwUAn"
+      style="position: absolute; left: 0px; top: 0px;"
+    >
+      tooltip text
+      <div
+        class="sc-bdvvtL bIjFMV"
+        data-popper-arrow="true"
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/lib/react-toast-notification/src/ToastProvider.tsx
+++ b/src/lib/react-toast-notification/src/ToastProvider.tsx
@@ -144,6 +144,7 @@ export class ToastProvider extends Component<ToastProviderProps, State> {
                     >
                       {(transitionState) => (
                         <ToastController
+                          key={id}
                           appearance={appearance}
                           autoDismiss={
                             autoDismiss !== undefined
@@ -187,10 +188,10 @@ export class ToastProvider extends Component<ToastProviderProps, State> {
   };
   onDismiss =
     (id: Id, cb: Callback = NOOP) =>
-    () => {
-      cb(id);
-      this.remove(id);
-    };
+      () => {
+        cb(id);
+        this.remove(id);
+      };
 
   // Public API
   // ------------------------------

--- a/src/lib/react-toast-notification/src/ToastProvider.tsx
+++ b/src/lib/react-toast-notification/src/ToastProvider.tsx
@@ -188,10 +188,10 @@ export class ToastProvider extends Component<ToastProviderProps, State> {
   };
   onDismiss =
     (id: Id, cb: Callback = NOOP) =>
-      () => {
-        cb(id);
-        this.remove(id);
-      };
+    () => {
+      cb(id);
+      this.remove(id);
+    };
 
   // Public API
   // ------------------------------

--- a/src/lib/react-toast-notification/src/ToastProvider.tsx
+++ b/src/lib/react-toast-notification/src/ToastProvider.tsx
@@ -76,6 +76,8 @@ type Context = {
 };
 
 export class ToastProvider extends Component<ToastProviderProps, State> {
+  nodeRef: React.RefObject<HTMLDivElement>;
+
   static defaultProps = {
     autoDismiss: false,
     autoDismissTimeout: 5000,
@@ -83,7 +85,13 @@ export class ToastProvider extends Component<ToastProviderProps, State> {
     newestOnTop: false,
     placement: "top-right",
     transitionDuration: 220,
+    nodeRef: null,
   };
+
+  constructor(props: ToastProviderProps | Readonly<ToastProviderProps>) {
+    super(props);
+    this.nodeRef = React.createRef();
+  }
 
   state = { toasts: [] as State["toasts"] };
 
@@ -131,11 +139,11 @@ export class ToastProvider extends Component<ToastProviderProps, State> {
                       appear
                       mountOnEnter
                       unmountOnExit
+                      nodeRef={this.nodeRef}
                       timeout={transitionDuration as number}
                     >
                       {(transitionState) => (
                         <ToastController
-                          key={id}
                           appearance={appearance}
                           autoDismiss={
                             autoDismiss !== undefined


### PR DESCRIPTION
Toast で内部的に使用している [react-transition-group](https://github.com/reactjs/react-transition-group) が、findDOMNodeに直接変更を加えている行為が非推奨だったため、nodeRef という props を追加して対処した。
https://github.com/reactjs/react-transition-group/issues/429#issuecomment-624243135

それに合わせた対応。