### PR TITLE
minify 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "react-dates": "^21.8.0",
     "react-popper": "^2.2.3",
     "react-select": "^5.1.0",
-    "react-transition-group": "^4.4.1",
-    "rollup-plugin-terser": "^7.0.2"
+    "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 || ^17.0.1",
@@ -77,6 +76,7 @@
     "rollup-plugin-imagemin": "0.5.0",
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-postcss": "4.0.2",
+    "rollup-plugin-terser": "^7.0.2",
     "scaffdog": "1.2.0",
     "styled-components": "5.3.3",
     "ts-jest": "27.1.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dates": "^21.8.0",
     "react-popper": "^2.2.3",
     "react-select": "^5.1.0",
-    "react-transition-group": "^4.4.1"
+    "react-transition-group": "^4.4.1",
+    "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 || ^17.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "cross-env CI=1 jest --runInBand",
     "test:watch": "jest --watchAll",
     "test:update": "jest --updateSnapshot",
-    "build": "rollup -c",
+    "build": "NODE_ENV=production rollup -c",
     "start": "rollup -c -w",
     "playground": "yarn build && cd testEnv && yarn install && yarn start",
     "storybook": "start-storybook -s ./assets -p 6006",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,8 @@ import { terser } from "rollup-plugin-terser";
 
 import pkg from "./package.json";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 export default {
   input: "src/index.ts",
   output: [
@@ -39,6 +41,6 @@ export default {
     }),
     typescript({ tsconfig: "./tsconfig.json" }),
     commonjs(),
-    terser(),
+    isProduction && terser(),
   ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import svgr from "@svgr/rollup";
 import external from "rollup-plugin-peer-deps-external";
 import { imagemin } from "rollup-plugin-imagemin";
 import postcss from "rollup-plugin-postcss";
+import { terser } from "rollup-plugin-terser";
 
 import pkg from "./package.json";
 
@@ -38,5 +39,6 @@ export default {
     }),
     typescript({ tsconfig: "./tsconfig.json" }),
     commonjs(),
+    terser(),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9300,7 +9300,7 @@ jest-watcher@^27.4.6:
     jest-util "^27.4.2"
     string-length "^4.0.1"
 
-jest-worker@^26.5.0, jest-worker@^26.6.2:
+jest-worker@^26.2.1, jest-worker@^26.5.0, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -12493,6 +12493,16 @@ rollup-plugin-postcss@4.0.2:
     safe-identifier "^0.4.2"
     style-inject "^0.3.0"
 
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -13572,7 +13582,7 @@ terser@^4.1.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.4:
+terser@^5.0.0, terser@^5.3.4:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc"
   integrity sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==


### PR DESCRIPTION
bundle 後のファイルが minify されてなかったのでする。

[rollup-plugin-terser](https://github.com/TrySound/rollup-plugin-terser) を使ってやる。

## 比較

入れる前と後で 3MB くらい減った。

```sh
# befor 
$ du -sh 
 11M    .

# after
$ du -sh     
7.8M    .
```