### PR TITLE
Update TypeScript to v4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "scaffdog": "1.2.0",
     "styled-components": "5.3.3",
     "ts-jest": "27.1.5",
-    "typescript": "4.5.5"
+    "typescript": "4.7.2"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14163,10 +14163,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
ref: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/

- Node.jsのECMAScript対応系がメイン
- あとは型の補完が充実した
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#go-to-source-definition
  - ライブラリから提供されるパッケージの該当するソースコードへジャンプできる機能
  - 手元のVSCodeは最新だったけどできなかった(まだ実験的だからできないのかも)