### PR TITLE
release noteをGitHubのAPIでいい感じにしてもらう

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,17 +26,6 @@ jobs:
         run: make -f ci.mk lint
       - name: test
         run: make -f ci.mk test
-      - name: Use Ruby 3.0
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.0
-      - name: install github_changelog_generate
-        run: gem install -N github_changelog_generator
-      - name: create CHANGELOG
-        run: make -f ci.mk changelog
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          GITHUB_TOKEN: ${{ secrets.FLUCT_MEMBER_GITHUB_TOKEN }}
       - name: npm version
         run: make -f ci.mk release_version
         env:
@@ -47,7 +36,7 @@ jobs:
           git config --local user.email ${{ secrets.FLUCT_MEMBER_GITHUB_USER_EMAIL }}
       - name: git add & commit & push
         run: |
-          git add CHANGELOG.md package.json
+          git add package.json
           git commit -m "[ci skip] release v${{ env.RELEASE_VERSION }}"
           git push
         env:
@@ -56,12 +45,6 @@ jobs:
         run: make -f ci.mk publish
         env:
           NPM_TOKEN: ${{ secrets.FLUCT_NPM_TOKEN }}
-      - name: Create Release Note
-        run: make -f ci.mk release_note
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          OUTPUT_FILE: release_note.md
-          GITHUB_TOKEN: ${{ secrets.FLUCT_MEMBER_GITHUB_TOKEN }}
       - name: Create Tag & Release
         uses: ncipollo/release-action@v1
         with:
@@ -69,6 +52,6 @@ jobs:
           name: Release ${{ env.RELEASE_TAG_NAME }}
           tag: ${{ env.RELEASE_TAG_NAME }}
           token: ${{ secrets.FLUCT_MEMBER_GITHUB_TOKEN }}
-          bodyFile: release_note.md
+          generateReleaseNotes: true
         env:
           RELEASE_TAG_NAME: v${{ github.event.inputs.release_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**このファイルはv9.9.0以降更新されません。**
+
+**[こちら](https://github.com/voyagegroup/ingred-ui/releases)を参考にしてください**
+
 ## [v9.9.0](https://github.com/voyagegroup/ingred-ui/tree/v9.9.0) (2022-05-26)
 
 [Full Changelog](https://github.com/voyagegroup/ingred-ui/compare/v9.8.0...v9.9.0)

--- a/ci.mk
+++ b/ci.mk
@@ -1,4 +1,4 @@
-.PHONY: install test lint changelog release_note release_version publish
+.PHONY: install test lint release_version publish
 
 RELEASE_VERSION ?=
 GITHUB_TOKEN ?=
@@ -20,24 +20,6 @@ test:
 
 lint:
 	yarn lint
-
-changelog:
-	github_changelog_generator \
-		--user voyagegroup \
-		--project ingred-ui \
-		--exclude-labels release \
-		--future-release v${RELEASE_VERSION} \
-		--token ${GITHUB_TOKEN}
-
-release_note:
-	github_changelog_generator \
-		--user voyagegroup \
-		--project ingred-ui \
-		--exclude-labels release \
-		--future-release v${RELEASE_VERSION} \
-		--since-tag $(shell git describe --abbrev=0 --tags) \
-		--output ${OUTPUT_FILE} \
-		--token ${GITHUB_TOKEN}
 
 release_version:
 	npm config set git-tag-version false


### PR DESCRIPTION
- release noteを `github_changelog_generate` から GitHub APIに以降した
  - いらなくなったものは削除
- CHANGELOGは更新しなくなったので、注意書きを追加した