### PR TITLE
<Input /> で type="number" が指定された時にスクロールで値が変更されるのを防ぐ

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -11,7 +11,10 @@ export default {
   },
 };
 
-export const Example: Story<InputProps> = (args) => <Input {...args} />;
+// TODO: type="number" を外す
+export const Example: Story<InputProps> = (args) => (
+  <Input {...args} type="number" />
+);
 
 export const Textarea: Story<InputProps> = (args) => <Input {...args} />;
 Textarea.args = {

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -11,10 +11,7 @@ export default {
   },
 };
 
-// TODO: type="number" を外す
-export const Example: Story<InputProps> = (args) => (
-  <Input {...args} type="number" />
-);
+export const Example: Story<InputProps> = (args) => <Input {...args} />;
 
 export const Textarea: Story<InputProps> = (args) => <Input {...args} />;
 Textarea.args = {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -6,9 +6,18 @@ export type InputProps = (
   | React.ComponentPropsWithoutRef<"input">
   | React.ComponentPropsWithoutRef<"textarea">
 ) & {
+  type?: string;
   error?: boolean;
   multiline?: boolean;
   resize?: Property.Resize;
+};
+
+const isNumber = (n: string) => {
+  // empty or white space
+  if (n === "" || n === " ") {
+    return false;
+  }
+  return !isNaN(Number(n));
 };
 
 const Input = React.forwardRef<
@@ -16,22 +25,22 @@ const Input = React.forwardRef<
   InputProps
 >(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
   if (rest.type === "number") {
-    const onChange = (e: any) => {
-      const n = Number(e.target.value);
-      if (!Number.isFinite(n)) return;
-      if (rest.onChange) rest.onChange(e);
+    const onChange = (
+      event: React.ChangeEvent<HTMLInputElement> &
+        React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      if (!isNumber(event.target.value)) return;
+      if (rest.onChange) rest.onChange(event);
     };
 
     const onKeyDown = (
-      e: React.KeyboardEvent<HTMLInputElement> &
+      event: React.KeyboardEvent<HTMLInputElement> &
         React.KeyboardEvent<HTMLTextAreaElement>,
     ) => {
-      const n = Number(e.key);
-
-      if (!Number.isFinite(n) && !(e.key === "Backspace")) {
-        e.preventDefault();
+      if (!isNumber(event.key) && !(event.key === "Backspace")) {
+        event.preventDefault();
       }
-      if (rest.onKeyDown) rest.onKeyDown(e);
+      if (rest.onKeyDown) rest.onKeyDown(event);
     };
 
     return (

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Styled from "./styled";
 import { Property } from "csstype";
+import { createChainedFunction } from "../../utils/createChainedFunction";
 
 export type InputProps = (
   | React.ComponentPropsWithoutRef<"input">
@@ -16,25 +17,14 @@ const Input = React.forwardRef<
   HTMLTextAreaElement | HTMLInputElement,
   InputProps
 >(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
-  if (rest.type === "number") {
-    const onWheel = (
-      event: React.WheelEvent<HTMLInputElement> &
-        React.WheelEvent<HTMLTextAreaElement>,
-    ) => {
-      event.currentTarget.blur();
-      if (rest.onWheel) rest.onWheel(event);
-    };
-    return (
-      <Styled.Input
-        {...rest}
-        ref={ref as any}
-        as={(multiline ? "textarea" : "input") as any}
-        isError={error}
-        resize={resize}
-        onWheel={onWheel}
-      />
-    );
-  }
+  const handleWheel = (
+    event: React.WheelEvent<HTMLInputElement> &
+      React.WheelEvent<HTMLTextAreaElement>,
+  ) => {
+    event.currentTarget.blur();
+    if (rest.onWheel) rest.onWheel(event);
+  };
+
   return (
     <Styled.Input
       {...rest}
@@ -42,6 +32,10 @@ const Input = React.forwardRef<
       as={(multiline ? "textarea" : "input") as any}
       isError={error}
       resize={resize}
+      onWheel={createChainedFunction(
+        rest.type === "number" ? handleWheel : null,
+        rest.onWheel ? rest.onWheel : null,
+      )}
     />
   );
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -22,7 +22,6 @@ const Input = React.forwardRef<
       React.WheelEvent<HTMLTextAreaElement>,
   ) => {
     event.currentTarget.blur();
-    if (rest.onWheel) rest.onWheel(event);
   };
 
   return (
@@ -34,7 +33,7 @@ const Input = React.forwardRef<
       resize={resize}
       onWheel={createChainedFunction(
         rest.type === "number" ? handleWheel : null,
-        rest.onWheel
+        rest.onWheel ? rest.onWheel : null,
       )}
     />
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as Styled from "./styled";
 import { Property } from "csstype";
-import { useMergeRefs } from "../../hooks/useMergeRefs";
 
 export type InputProps = (
   | React.ComponentPropsWithoutRef<"input">
@@ -13,60 +12,30 @@ export type InputProps = (
   resize?: Property.Resize;
 };
 
-const NumberInput = React.forwardRef<
-  HTMLTextAreaElement | HTMLInputElement,
-  InputProps
->(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
-  const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement>(null);
-  const mergeedRef = useMergeRefs(ref, inputRef);
-
-  const onChange = React.useCallback(
-    (
-      event: React.ChangeEvent<HTMLInputElement> &
-        React.ChangeEvent<HTMLTextAreaElement>,
-    ) => {
-      const value = event.target.value;
-      if (isNaN(Number(value)) || value === " ") {
-        if (inputRef.current) {
-          inputRef.current.value = value.substring(0, value.length - 1);
-        }
-        return;
-      }
-      if (rest.onChange) rest.onChange(event);
-    },
-    [rest],
-  );
-
-  const onKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === " ") {
-        event.preventDefault();
-      }
-    },
-    [],
-  );
-
-  return (
-    <Styled.Input
-      {...rest}
-      ref={mergeedRef}
-      type="text"
-      as={(multiline ? "textarea" : "input") as any}
-      isError={error}
-      resize={resize}
-      onChange={onChange}
-      onKeyDown={onKeyDown}
-    />
-  );
-});
-
 const Input = React.forwardRef<
   HTMLTextAreaElement | HTMLInputElement,
   InputProps
->(({ error = false, multiline = false, resize = "both", ...rest }, ref) =>
-  rest.type === "number" ? (
-    <NumberInput {...rest} ref={ref} />
-  ) : (
+>(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
+  if (rest.type === "number") {
+    const onWheel = (
+      event: React.WheelEvent<HTMLInputElement> &
+        React.WheelEvent<HTMLTextAreaElement>,
+    ) => {
+      event.currentTarget.blur();
+      if (rest.onWheel) rest.onWheel(event);
+    };
+    return (
+      <Styled.Input
+        {...rest}
+        ref={ref as any}
+        as={(multiline ? "textarea" : "input") as any}
+        isError={error}
+        resize={resize}
+        onWheel={onWheel}
+      />
+    );
+  }
+  return (
     <Styled.Input
       {...rest}
       ref={ref as any}
@@ -74,7 +43,7 @@ const Input = React.forwardRef<
       isError={error}
       resize={resize}
     />
-  ),
-);
+  );
+});
 
 export default Input;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -34,7 +34,7 @@ const Input = React.forwardRef<
       resize={resize}
       onWheel={createChainedFunction(
         rest.type === "number" ? handleWheel : null,
-        rest.onWheel ? rest.onWheel : null,
+        rest.onWheel
       )}
     />
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -33,7 +33,7 @@ const Input = React.forwardRef<
       resize={resize}
       onWheel={createChainedFunction(
         rest.type === "number" ? handleWheel : null,
-        rest.onWheel ? rest.onWheel : null,
+        rest.onWheel,
       )}
     />
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -14,14 +14,49 @@ export type InputProps = (
 const Input = React.forwardRef<
   HTMLTextAreaElement | HTMLInputElement,
   InputProps
->(({ error = false, multiline = false, resize = "both", ...rest }, ref) => (
-  <Styled.Input
-    {...rest}
-    ref={ref as any}
-    as={(multiline ? "textarea" : "input") as any}
-    isError={error}
-    resize={resize}
-  />
-));
+>(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
+  if (rest.type === "number") {
+    const onChange = (e: any) => {
+      const n = Number(e.target.value);
+      if (!Number.isFinite(n)) return;
+      if (rest.onChange) rest.onChange(e);
+    };
+
+    const onKeyDown = (
+      e: React.KeyboardEvent<HTMLInputElement> &
+        React.KeyboardEvent<HTMLTextAreaElement>
+    ) => {
+      const n = Number(e.key);
+
+      if (!Number.isFinite(n) && !(e.key === "Backspace")) {
+        e.preventDefault();
+      }
+      if (rest.onKeyDown) rest.onKeyDown(e);
+    };
+
+    return (
+      <Styled.Input
+        {...rest}
+        ref={ref as any}
+        type="text"
+        as={(multiline ? "textarea" : "input") as any}
+        isError={error}
+        resize={resize}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+      />
+    );
+  }
+
+  return (
+    <Styled.Input
+      {...rest}
+      ref={ref as any}
+      as={(multiline ? "textarea" : "input") as any}
+      isError={error}
+      resize={resize}
+    />
+  );
+});
 
 export default Input;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Styled from "./styled";
 import { Property } from "csstype";
+import { useMergeRefs } from "../../hooks/useMergeRefs";
 
 export type InputProps = (
   | React.ComponentPropsWithoutRef<"input">
@@ -12,52 +13,60 @@ export type InputProps = (
   resize?: Property.Resize;
 };
 
-const isNumber = (n: string) => {
-  // empty or white space
-  if (n === "" || n === " ") {
-    return false;
-  }
-  return !isNaN(Number(n));
-};
+const NumberInput = React.forwardRef<
+  HTMLTextAreaElement | HTMLInputElement,
+  InputProps
+>(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
+  const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const mergeedRef = useMergeRefs(ref, inputRef);
+
+  const onChange = React.useCallback(
+    (
+      event: React.ChangeEvent<HTMLInputElement> &
+        React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      const value = event.target.value;
+      if (isNaN(Number(value)) || value === " ") {
+        if (inputRef.current) {
+          inputRef.current.value = value.substring(0, value.length - 1);
+        }
+        return;
+      }
+      if (rest.onChange) rest.onChange(event);
+    },
+    [rest],
+  );
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === " ") {
+        event.preventDefault();
+      }
+    },
+    [],
+  );
+
+  return (
+    <Styled.Input
+      {...rest}
+      ref={mergeedRef}
+      type="text"
+      as={(multiline ? "textarea" : "input") as any}
+      isError={error}
+      resize={resize}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+    />
+  );
+});
 
 const Input = React.forwardRef<
   HTMLTextAreaElement | HTMLInputElement,
   InputProps
->(({ error = false, multiline = false, resize = "both", ...rest }, ref) => {
-  if (rest.type === "number") {
-    const onChange = (
-      event: React.ChangeEvent<HTMLInputElement> &
-        React.ChangeEvent<HTMLTextAreaElement>,
-    ) => {
-      if (!isNumber(event.target.value)) return;
-      if (rest.onChange) rest.onChange(event);
-    };
-
-    const onKeyDown = (
-      event: React.KeyboardEvent<HTMLInputElement> &
-        React.KeyboardEvent<HTMLTextAreaElement>,
-    ) => {
-      if (!isNumber(event.key) && !(event.key === "Backspace")) {
-        event.preventDefault();
-      }
-      if (rest.onKeyDown) rest.onKeyDown(event);
-    };
-
-    return (
-      <Styled.Input
-        {...rest}
-        ref={ref as any}
-        type="text"
-        as={(multiline ? "textarea" : "input") as any}
-        isError={error}
-        resize={resize}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
-      />
-    );
-  }
-
-  return (
+>(({ error = false, multiline = false, resize = "both", ...rest }, ref) =>
+  rest.type === "number" ? (
+    <NumberInput {...rest} ref={ref} />
+  ) : (
     <Styled.Input
       {...rest}
       ref={ref as any}
@@ -65,7 +74,7 @@ const Input = React.forwardRef<
       isError={error}
       resize={resize}
     />
-  );
-});
+  ),
+);
 
 export default Input;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -24,7 +24,7 @@ const Input = React.forwardRef<
 
     const onKeyDown = (
       e: React.KeyboardEvent<HTMLInputElement> &
-        React.KeyboardEvent<HTMLTextAreaElement>
+        React.KeyboardEvent<HTMLTextAreaElement>,
     ) => {
       const n = Number(e.key);
 

--- a/src/utils/createChainedFunction.ts
+++ b/src/utils/createChainedFunction.ts
@@ -1,5 +1,5 @@
 /**
- * ref: https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/utils/createChainedFunction.js
+ * ref: https://github.com/mui/material-ui/blob/master/packages/mui-utils/src/createChainedFunction.ts
  * TODO: resolve "any" type assertion
  */
 export function createChainedFunction<F extends Function>(


### PR DESCRIPTION
## 問題

`<Input type="number" />` を指定した際に、フォームにフォーカスした状態でスクロールをすると値が変わってしまう。

## 解決方法

- type=“number”が指定されたときは内部の<input />にはtypeを指定しない
- onKeyDown 発火時に数字と Backspace 以外だったら preeventDefault でイベントを抑制する