### PR TITLE
`typing.d.ts` の `React.StatelessComponent` を `React.FunctionComponent` にする 

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,9 +7,7 @@ declare module "*.css" {
   export default content;
 }
 
-type SvgrComponent = {} & React.StatelessComponent<
-  React.SVGAttributes<SVGElement>
->;
+type SvgrComponent = {} & React.FC<React.SVGAttributes<SVGElement>>;
 
 declare module "*.png" {
   const value: any;


### PR DESCRIPTION
solve #987 

現状ここ以外に使用箇所は無さそうでした。
https://github.com/voyagegroup/ingred-ui/search?q=StatelessComponent