### PR TITLE
Add: jsx-a11y

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,12 @@
 module.exports = {
-  plugins: ["prettier", "@typescript-eslint", "react", "react-hooks", "jest"],
+  plugins: [
+    "prettier",
+    "@typescript-eslint",
+    "react",
+    "react-hooks",
+    "jsx-a11y",
+    "jest",
+  ],
   extends: [
     "eslint:recommended",
     "prettier",
@@ -11,6 +18,7 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:jest/recommended",
     "plugin:mdx/recommended",
+    "plugin:jsx-a11y/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -144,6 +152,7 @@ module.exports = {
             format: ["PascalCase", "camelCase", "UPPER_CASE"],
           },
         ],
+        "jsx-a11y/no-autofocus": "off", // We want to use `autoFocus` in a fluct optimized component <MultipleFilter />.
       },
     },
     {
@@ -158,6 +167,9 @@ module.exports = {
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "react/no-multi-comp": "off",
+        // I realize it's silly of me, but I'll turn it off here for the sake of specs for once.
+        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/no-static-element-interactions": "off",
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,6 +153,12 @@ module.exports = {
           },
         ],
         "jsx-a11y/no-autofocus": "off", // We want to use `autoFocus` in a fluct optimized component <MultipleFilter />.
+        "jsx-a11y/control-has-associated-label": [
+          "error",
+          {
+            depth: 10,
+          },
+        ],
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.0.1",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-mdx": "1.17.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.7",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.0.1",
-    "eslint-plugin-jsx-a11y": "^6.6.1",
+    "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-mdx": "1.17.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.7",

--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -17,7 +17,7 @@ export type FileUploaderProps = {
   width?: Property.Width;
   onSelectFiles: (
     event: React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLElement>,
-    files: FileList | null
+    files: FileList | null,
   ) => void;
 };
 
@@ -41,7 +41,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         setFilesDraggedOver(false);
         onSelectFiles(e, e.dataTransfer.files);
       },
-      [setFilesDraggedOver, onSelectFiles]
+      [setFilesDraggedOver, onSelectFiles],
     );
 
     const handleDragOver = React.useCallback(
@@ -50,7 +50,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         e.stopPropagation();
         setFilesDraggedOver(true);
       },
-      [setFilesDraggedOver]
+      [setFilesDraggedOver],
     );
 
     const handleDragLeave = React.useCallback(() => {
@@ -61,7 +61,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         onSelectFiles(e, e.target.files);
       },
-      [onSelectFiles]
+      [onSelectFiles],
     );
 
     const handleClickZone = () => {
@@ -109,7 +109,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         </Styled.TextContainer>
       </Styled.Container>
     );
-  }
+  },
 );
 
 export default FileUploader;

--- a/src/components/FileUploader/FileUploader.tsx
+++ b/src/components/FileUploader/FileUploader.tsx
@@ -17,7 +17,7 @@ export type FileUploaderProps = {
   width?: Property.Width;
   onSelectFiles: (
     event: React.DragEvent<HTMLElement> | React.ChangeEvent<HTMLElement>,
-    files: FileList | null,
+    files: FileList | null
   ) => void;
 };
 
@@ -41,7 +41,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         setFilesDraggedOver(false);
         onSelectFiles(e, e.dataTransfer.files);
       },
-      [setFilesDraggedOver, onSelectFiles],
+      [setFilesDraggedOver, onSelectFiles]
     );
 
     const handleDragOver = React.useCallback(
@@ -50,7 +50,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         e.stopPropagation();
         setFilesDraggedOver(true);
       },
-      [setFilesDraggedOver],
+      [setFilesDraggedOver]
     );
 
     const handleDragLeave = React.useCallback(() => {
@@ -61,7 +61,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         onSelectFiles(e, e.target.files);
       },
-      [onSelectFiles],
+      [onSelectFiles]
     );
 
     const handleClickZone = () => {
@@ -81,6 +81,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         <input
           ref={fileRef}
           multiple
+          aria-label="file-uploader"
           type="file"
           accept={accept}
           onChange={handleChange}
@@ -108,7 +109,7 @@ const FileUploader = React.forwardRef<HTMLDivElement, FileUploaderProps>(
         </Styled.TextContainer>
       </Styled.Container>
     );
-  },
+  }
 );
 
 export default FileUploader;

--- a/src/components/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/src/components/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
     class="sc-bczRLJ gxuZtk"
   >
     <input
+      aria-label="file-uploader"
       multiple=""
       type="file"
     />

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -268,7 +268,7 @@ const Icon = React.forwardRef<HTMLDivElement, Props>(
         {iconFactory(name)({ type, fill: getIconColor(color, theme) })}
       </Styled.Container>
     );
-  },
+  }
 );
 
 export default Icon;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -268,7 +268,7 @@ const Icon = React.forwardRef<HTMLDivElement, Props>(
         {iconFactory(name)({ type, fill: getIconColor(color, theme) })}
       </Styled.Container>
     );
-  }
+  },
 );
 
 export default Icon;

--- a/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
+++ b/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Pager component testing Pager 1`] = `
     display="flex"
   >
     <button
+      aria-label="arrow_left"
       class="sc-dkzDqf irbZCc"
       disabled=""
       type="button"
@@ -111,6 +112,7 @@ exports[`Pager component testing Pager 1`] = `
       </span>
     </button>
     <button
+      aria-label="arrow_right"
       class="sc-dkzDqf dWTLA"
       type="button"
     >

--- a/src/components/Pager/internal/ArrowButton/index.tsx
+++ b/src/components/Pager/internal/ArrowButton/index.tsx
@@ -17,7 +17,12 @@ export const ArrowButton: React.FunctionComponent<Props> = ({
 }) => {
   const theme = useTheme();
   return (
-    <Styled.ArrowButton disabled={disabled} type="button" onClick={onClick}>
+    <Styled.ArrowButton
+      disabled={disabled}
+      type="button"
+      aria-label={isRight ? "arrow_right" : "arrow_left"}
+      onClick={onClick}
+    >
       <Icon
         name={isRight ? "arrow_right" : "arrow_left"}
         size="md"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,25 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.1.tgz#f0cbbe7edda7c4109cd253bb1dee99aba4594ad9"
+  integrity sha512-j2vJGnkopRzH+ykJ8h68wrHnEUmtK//E723jjixiAl/PPf6FhqY/vYRcMVlNydRKQjQsTsYEjpx+DZMIvnGk/g==
+  dependencies:
+    core-js-pure "^3.25.1"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
   integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.18.9":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -4277,6 +4292,14 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 aria-query@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
@@ -4420,6 +4443,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
+
 ast-types@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
@@ -4464,6 +4492,16 @@ autoprefixer@^9.8.6:
     picocolors "^0.2.1"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+axe-core@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
+  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+
+axobject-query@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
+  integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 babel-jest@^28.1.1:
   version "28.1.1"
@@ -5739,6 +5777,11 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1, core-js-compat@^3.8.1:
     browserslist "^4.20.4"
     semver "7.0.0"
 
+core-js-pure@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.2.tgz#44a4fd873bdd4fecf6ca11512bcefedbe87e744a"
+  integrity sha512-ItD7YpW1cUB4jaqFLZXe1AXkyqIxz6GqPnsDV4uF4hVcWh/WAGIqSqw5p0/WdsILM0Xht9s3Koyw05R3K6RtiA==
+
 core-js-pure@^3.8.1:
   version "3.23.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.23.1.tgz#0b27e4c3ad46178b84e790dbbb81987218ab82ad"
@@ -6060,6 +6103,11 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
+
+damerau-levenshtein@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
+  integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
 data-urls@^3.0.2:
   version "3.0.2"
@@ -6541,6 +6589,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
@@ -6802,6 +6855,25 @@ eslint-plugin-jest@27.0.1:
   integrity sha512-LosUsrkwVSs/8Z/I8Hqn5vWgTEsHrfIquDEKOsV8/cl+gbFR4tiRCE1AimEotsHjSC0Rx1tYm6vPhw8C3ktmmg==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
+
+eslint-plugin-jsx-a11y@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz#93736fc91b83fdc38cc8d115deedfc3091aef1ff"
+  integrity sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    aria-query "^4.2.2"
+    array-includes "^3.1.5"
+    ast-types-flow "^0.0.7"
+    axe-core "^4.4.3"
+    axobject-query "^2.2.0"
+    damerau-levenshtein "^1.0.8"
+    emoji-regex "^9.2.2"
+    has "^1.0.3"
+    jsx-ast-utils "^3.3.2"
+    language-tags "^1.0.5"
+    minimatch "^3.1.2"
+    semver "^6.3.0"
 
 eslint-plugin-markdown@^2.2.1:
   version "2.2.1"
@@ -9871,6 +9943,14 @@ jsonfile@^6.0.1:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
+jsx-ast-utils@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
+
 junk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
@@ -9923,6 +10003,18 @@ klona@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
+
+language-subtag-registry@~0.3.2:
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
+  integrity sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==
+  dependencies:
+    language-subtag-registry "~0.3.2"
 
 latest-version@^5.1.0:
   version "5.1.0"
@@ -10903,6 +10995,16 @@ object.assign@^4.1.0, object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.0, object.entries@^1.1.2, object.entries@^1.1.5:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6856,7 +6856,7 @@ eslint-plugin-jest@27.0.1:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
-eslint-plugin-jsx-a11y@^6.6.1:
+eslint-plugin-jsx-a11y@6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz#93736fc91b83fdc38cc8d115deedfc3091aef1ff"
   integrity sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==


### PR DESCRIPTION
add https://github.com/jsx-eslint/eslint-plugin-jsx-a11y

https://cartaholdings.slack.com/archives/C02Q8F3FQBC/p1664103047961649
> 以前、a11y は必要最低限の担保という話をしたと思うんですけど（多分みんな覚えてないけど）、必要最低限を満たすための plugin を入れます。

a11y は完璧に対応したりガイドラインを作ったりはしないけど、最低限は満たすのような話をした。
そのためのプラグイン（その話をしたときは最低限というものの定義をしていなかったので、今回独断で「lint で弾ける範囲」と定義してみた）を入れてみる。