### PR TITLE
Fix proposal element outside `<Icon />` component from a div to a span.

### DIFF
--- a/src/components/ActionButton/__tests__/__snapshots__/ActionButton.test.tsx.snap
+++ b/src/components/ActionButton/__tests__/__snapshots__/ActionButton.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`ActionButton component testing ActionButton 1`] = `
     <div
       class="sc-gsnTZi gXnMIX"
     >
-      <div
-        class="sc-dkzDqf eMgeuW"
+      <span
+        class="sc-dkzDqf kPdxGi"
         size="18"
       >
         <svg
@@ -26,7 +26,7 @@ exports[`ActionButton component testing ActionButton 1`] = `
             transform="translate(-0.75 -0.757)"
           />
         </svg>
-      </div>
+      </span>
     </div>
     <p
       class="sc-hKMtZM gKJkyD"

--- a/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/src/components/ConfirmModal/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -39,8 +39,8 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
             <div
               class="sc-ftvSup uBGUH"
             >
-              <div
-                class="sc-crXcEl bpDtVj"
+              <span
+                class="sc-crXcEl jeqSVX"
                 size="24"
               >
                 <svg
@@ -62,7 +62,7 @@ exports[`ConfirmModal component testing ConfirmModal 1`] = `
                     width="5.143"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div

--- a/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/components/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
     <div
       class="sc-gsnTZi gXnMIX"
     >
-      <div
-        class="sc-dkzDqf eMgeuW"
+      <span
+        class="sc-dkzDqf kPdxGi"
         size="18"
       >
         <svg
@@ -27,7 +27,7 @@ exports[`ContextMenu component testing ContextMenu 1`] = `
             transform="translate(-2.5 -0.75)"
           />
         </svg>
-      </div>
+      </span>
     </div>
     <p
       class="sc-hKMtZM gKJkyD"

--- a/src/components/CreatableSelect/__tests__/__snapshots__/CreatableSelect.test.tsx.snap
+++ b/src/components/CreatableSelect/__tests__/__snapshots__/CreatableSelect.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -94,7 +94,7 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -110,8 +110,8 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -167,7 +167,7 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -205,8 +205,8 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -223,7 +223,7 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -313,8 +313,8 @@ exports[`CreatableSelect component testing Disable not CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -331,7 +331,7 @@ exports[`CreatableSelect component testing Disable not CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -430,8 +430,8 @@ exports[`CreatableSelect component testing Disable one CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -448,7 +448,7 @@ exports[`CreatableSelect component testing Disable one CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -520,8 +520,8 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -577,7 +577,7 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -593,8 +593,8 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -650,7 +650,7 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -687,8 +687,8 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -744,7 +744,7 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -754,8 +754,8 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -772,7 +772,7 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -861,8 +861,8 @@ exports[`CreatableSelect component testing Error not CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -879,7 +879,7 @@ exports[`CreatableSelect component testing Error not CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -977,8 +977,8 @@ exports[`CreatableSelect component testing Error one CreatableSelected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1034,7 +1034,7 @@ exports[`CreatableSelect component testing Error one CreatableSelected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1044,8 +1044,8 @@ exports[`CreatableSelect component testing Error one CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1062,7 +1062,7 @@ exports[`CreatableSelect component testing Error one CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1134,8 +1134,8 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1191,7 +1191,7 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1207,8 +1207,8 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1264,7 +1264,7 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1301,8 +1301,8 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1358,7 +1358,7 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1368,8 +1368,8 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1386,7 +1386,7 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1475,8 +1475,8 @@ exports[`CreatableSelect component testing Normal not CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1493,7 +1493,7 @@ exports[`CreatableSelect component testing Normal not CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1591,8 +1591,8 @@ exports[`CreatableSelect component testing Normal one CreatableSelected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1648,7 +1648,7 @@ exports[`CreatableSelect component testing Normal one CreatableSelected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1658,8 +1658,8 @@ exports[`CreatableSelect component testing Normal one CreatableSelected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1676,7 +1676,7 @@ exports[`CreatableSelect component testing Normal one CreatableSelected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
+++ b/src/components/DropdownButton/__tests__/__snapshots__/DropDownButton.test.tsx.snap
@@ -17,8 +17,8 @@ exports[`DropdownButton component testing not splited disable 1`] = `
       <div
         class="sc-ftvSup junqHC"
       />
-      <div
-        class="sc-iBkjds eplxZV"
+      <span
+        class="sc-iBkjds kTxGwl"
         size="18"
       >
         <svg
@@ -35,7 +35,7 @@ exports[`DropdownButton component testing not splited disable 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
   <div
@@ -124,8 +124,8 @@ exports[`DropdownButton component testing not splited enable 1`] = `
       <div
         class="sc-ftvSup junqHC"
       />
-      <div
-        class="sc-iBkjds eplxZV"
+      <span
+        class="sc-iBkjds kTxGwl"
         size="18"
       >
         <svg
@@ -142,7 +142,7 @@ exports[`DropdownButton component testing not splited enable 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
   <div
@@ -246,8 +246,8 @@ exports[`DropdownButton component testing splited disable 1`] = `
       font-size="14px"
       font-weight="normal"
     >
-      <div
-        class="sc-iBkjds eplxZV"
+      <span
+        class="sc-iBkjds kTxGwl"
         size="18"
       >
         <svg
@@ -264,7 +264,7 @@ exports[`DropdownButton component testing splited disable 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
   <div
@@ -356,8 +356,8 @@ exports[`DropdownButton component testing splited enable 1`] = `
       font-size="14px"
       font-weight="normal"
     >
-      <div
-        class="sc-iBkjds eplxZV"
+      <span
+        class="sc-iBkjds kTxGwl"
         size="18"
       >
         <svg
@@ -374,7 +374,7 @@ exports[`DropdownButton component testing splited enable 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
   <div

--- a/src/components/ErrorText/__tests__/__snapshots__/ErrorText.test.tsx.snap
+++ b/src/components/ErrorText/__tests__/__snapshots__/ErrorText.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`ErrorText component testing ErrorText 1`] = `
     <div
       class="sc-gsnTZi cQnjyp"
     >
-      <div
-        class="sc-bczRLJ hVIYff"
+      <span
+        class="sc-bczRLJ gJuzRf"
         size="18"
       >
         <svg
@@ -27,7 +27,7 @@ exports[`ErrorText component testing ErrorText 1`] = `
             transform="translate(-0.25 -0.75)"
           />
         </svg>
-      </div>
+      </span>
     </div>
     <p
       class="sc-dkzDqf jceGiB"

--- a/src/components/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/src/components/FileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -16,8 +16,8 @@ exports[`FileUploader component testing FileUploader 1`] = `
         class="sc-hKMtZM gmMVFG"
         display="flex"
       >
-        <div
-          class="sc-eCYdqJ gWXZjc"
+        <span
+          class="sc-eCYdqJ iymozk"
           size="18"
         >
           <svg
@@ -35,7 +35,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
               fill="#0B82F4"
             />
           </svg>
-        </div>
+        </span>
         <p
           class="sc-dkzDqf eEHJTS"
           color="#0B82F4"

--- a/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
+++ b/src/components/FloatingTip/__tests__/__snapshots__/FloatingTip.test.tsx.snap
@@ -29,8 +29,8 @@ exports[`FloatingTip component testing FloatingTip 1`] = `
         <div
           class="sc-dkzDqf jAiQlO"
         >
-          <div
-            class="sc-iBkjds eplxZV"
+          <span
+            class="sc-iBkjds kTxGwl"
             size="18"
           >
             <svg
@@ -52,7 +52,7 @@ exports[`FloatingTip component testing FloatingTip 1`] = `
                 width="5.143"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -260,7 +260,7 @@ export type Props = {
   color?: IconColor;
 };
 
-const Icon = React.forwardRef<HTMLDivElement, Props>(
+const Icon = React.forwardRef<HTMLSpanElement, Props>(
   ({ name, type = "line", size = "md", color = "fill" }, ref) => {
     const theme = useTheme();
     return (

--- a/src/components/Icon/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Icon component testing Icon 1`] = `
 <DocumentFragment>
-  <div
-    class="sc-bczRLJ hVIYff"
+  <span
+    class="sc-bczRLJ gJuzRf"
     size="18"
   >
     <svg
@@ -19,6 +19,6 @@ exports[`Icon component testing Icon 1`] = `
         fill="#596978"
       />
     </svg>
-  </div>
+  </span>
 </DocumentFragment>
 `;

--- a/src/components/Icon/styled.ts
+++ b/src/components/Icon/styled.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
-export const Container = styled.div<{ size: number }>`
+export const Container = styled.span<{ size: number }>`
+  display: block;
   position: relative;
   width: ${({ size }) => `${size}px`};
   height: ${({ size }) => `${size}px`};

--- a/src/components/MultipleFilter/__tests__/__snapshots__/MultipleFilter.test.tsx.snap
+++ b/src/components/MultipleFilter/__tests__/__snapshots__/MultipleFilter.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`MultipleFilter component testing MultipleFilter 1`] = `
     <div
       class="sc-hKMtZM fZVlmg"
     >
-      <div
-        class="sc-hAZoDl fnCvPo"
+      <span
+        class="sc-hAZoDl iIvdks"
         size="18"
       >
         <svg
@@ -26,7 +26,7 @@ exports[`MultipleFilter component testing MultipleFilter 1`] = `
             transform="translate(-0.5 -0.5)"
           />
         </svg>
-      </div>
+      </span>
     </div>
     <div
       class="sc-eCYdqJ lfunFR"

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -23,8 +23,8 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             <div
               class="sc-breuTD jDboYn"
             >
-              <div
-                class="sc-iBkjds fBKvKB"
+              <span
+                class="sc-iBkjds RltOZ"
                 size="24"
               >
                 <svg
@@ -40,7 +40,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                     fill="#0B82F4"
                   />
                 </svg>
-              </div>
+              </span>
               <span
                 class="sc-ksZaOG enNxAq"
               >
@@ -61,8 +61,8 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             <div
               class="sc-idiyUo kOEvVG"
             >
-              <div
-                class="sc-iBkjds eplxZV"
+              <span
+                class="sc-iBkjds kTxGwl"
                 size="18"
               >
                 <svg
@@ -79,7 +79,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -114,8 +114,8 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           <div
             class="sc-breuTD jDboYn"
           >
-            <div
-              class="sc-iBkjds fBKvKB"
+            <span
+              class="sc-iBkjds RltOZ"
               size="24"
             >
               <svg
@@ -131,7 +131,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                   fill="#041C33"
                 />
               </svg>
-            </div>
+            </span>
             <span
               class="sc-ksZaOG enNxAq"
             >
@@ -162,8 +162,8 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
         <div
           class="sc-gKXOVf hakqLa"
         >
-          <div
-            class="sc-iBkjds eplxZV"
+          <span
+            class="sc-iBkjds kTxGwl"
             size="18"
           >
             <svg
@@ -185,7 +185,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
                 transform="translate(19.171 -2.829) rotate(90)"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
+++ b/src/components/Pager/__tests__/__snapshots__/Pager.test.tsx.snap
@@ -11,8 +11,8 @@ exports[`Pager component testing Pager 1`] = `
       disabled=""
       type="button"
     >
-      <div
-        class="sc-hKMtZM jjwhPN"
+      <span
+        class="sc-hKMtZM gLnfjV"
         size="18"
       >
         <svg
@@ -30,7 +30,7 @@ exports[`Pager component testing Pager 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
     <button
       class="sc-bczRLJ hFtSAg"
@@ -114,8 +114,8 @@ exports[`Pager component testing Pager 1`] = `
       class="sc-dkzDqf dWTLA"
       type="button"
     >
-      <div
-        class="sc-hKMtZM jjwhPN"
+      <span
+        class="sc-hKMtZM gLnfjV"
         size="18"
       >
         <svg
@@ -133,7 +133,7 @@ exports[`Pager component testing Pager 1`] = `
             transform="translate(-1.414 -1.114)"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
 </DocumentFragment>

--- a/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`Select component testing Disable multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -94,7 +94,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -110,8 +110,8 @@ exports[`Select component testing Disable multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -167,7 +167,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -205,8 +205,8 @@ exports[`Select component testing Disable multiple selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -223,7 +223,7 @@ exports[`Select component testing Disable multiple selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -313,8 +313,8 @@ exports[`Select component testing Disable not selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -331,7 +331,7 @@ exports[`Select component testing Disable not selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -430,8 +430,8 @@ exports[`Select component testing Disable one selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -448,7 +448,7 @@ exports[`Select component testing Disable one selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -520,8 +520,8 @@ exports[`Select component testing Error multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -577,7 +577,7 @@ exports[`Select component testing Error multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -593,8 +593,8 @@ exports[`Select component testing Error multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -650,7 +650,7 @@ exports[`Select component testing Error multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -687,8 +687,8 @@ exports[`Select component testing Error multiple selected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -744,7 +744,7 @@ exports[`Select component testing Error multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -754,8 +754,8 @@ exports[`Select component testing Error multiple selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -772,7 +772,7 @@ exports[`Select component testing Error multiple selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -861,8 +861,8 @@ exports[`Select component testing Error not selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -879,7 +879,7 @@ exports[`Select component testing Error not selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -977,8 +977,8 @@ exports[`Select component testing Error one selected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1034,7 +1034,7 @@ exports[`Select component testing Error one selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1044,8 +1044,8 @@ exports[`Select component testing Error one selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1062,7 +1062,7 @@ exports[`Select component testing Error one selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1134,8 +1134,8 @@ exports[`Select component testing Normal multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1191,7 +1191,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1207,8 +1207,8 @@ exports[`Select component testing Normal multiple selected 1`] = `
               class="css-p9ckie"
               role="button"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1264,7 +1264,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1301,8 +1301,8 @@ exports[`Select component testing Normal multiple selected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1358,7 +1358,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1368,8 +1368,8 @@ exports[`Select component testing Normal multiple selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1386,7 +1386,7 @@ exports[`Select component testing Normal multiple selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1475,8 +1475,8 @@ exports[`Select component testing Normal not selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1493,7 +1493,7 @@ exports[`Select component testing Normal not selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>
@@ -1591,8 +1591,8 @@ exports[`Select component testing Normal one selected 1`] = `
               aria-hidden="true"
               class=" css-tlfecz-indicatorContainer"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1648,7 +1648,7 @@ exports[`Select component testing Normal one selected 1`] = `
                     </g>
                   </g>
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
           <div
@@ -1658,8 +1658,8 @@ exports[`Select component testing Normal one selected 1`] = `
             <div
               class="sc-eCYdqJ hxHEPC"
             >
-              <div
-                class="sc-hKMtZM jjwhPN"
+              <span
+                class="sc-hKMtZM gLnfjV"
                 size="18"
               >
                 <svg
@@ -1676,7 +1676,7 @@ exports[`Select component testing Normal one selected 1`] = `
                     transform="translate(-1.414 -1.114)"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/Snackbar/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/Snackbar/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -11,8 +11,8 @@ exports[`Snackbar component testing Snackbar 1`] = `
       <div
         class="sc-dkzDqf chbnnt"
       >
-        <div
-          class="sc-hKMtZM jjwhPN"
+        <span
+          class="sc-hKMtZM gLnfjV"
           size="18"
         >
           <svg
@@ -34,7 +34,7 @@ exports[`Snackbar component testing Snackbar 1`] = `
               width="5.143"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/TextField/__tests__/__snapshots__/TextField.test.tsx.snap
@@ -31,8 +31,8 @@ exports[`TextField component testing TextField passward 1`] = `
       <div
         class="sc-dkzDqf sc-eCYdqJ ipdCxW lePLkB"
       >
-        <div
-          class="sc-gKXOVf eQUwDP"
+        <span
+          class="sc-gKXOVf kFgTzX"
           size="18"
         >
           <svg
@@ -48,7 +48,7 @@ exports[`TextField component testing TextField passward 1`] = `
               fill="#041C33"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </div>
   </div>
@@ -66,8 +66,8 @@ exports[`TextField component testing TextField with icon 1`] = `
       <div
         class="sc-dkzDqf sc-hKMtZM ipdCxW eHVwRj"
       >
-        <div
-          class="sc-gKXOVf eQUwDP"
+        <span
+          class="sc-gKXOVf kFgTzX"
           size="18"
         >
           <svg
@@ -84,7 +84,7 @@ exports[`TextField component testing TextField with icon 1`] = `
               transform="translate(-0.5 -0.5)"
             />
           </svg>
-        </div>
+        </span>
       </div>
       <input
         class="sc-jSMfEi cNRsja"

--- a/src/components/Toast/DefaultToast/__tests__/__snapshots__/DefaultToast.test.tsx.snap
+++ b/src/components/Toast/DefaultToast/__tests__/__snapshots__/DefaultToast.test.tsx.snap
@@ -22,8 +22,8 @@ exports[`DefaultToast component testing DefaultToast error 1`] = `
           <div
             class="sc-dkzDqf kXpBi"
           >
-            <div
-              class="sc-gKXOVf kNytYv"
+            <span
+              class="sc-gKXOVf fmZGCL"
               size="24"
             >
               <svg
@@ -39,7 +39,7 @@ exports[`DefaultToast component testing DefaultToast error 1`] = `
                   fill="#EB0A4E"
                 />
               </svg>
-            </div>
+            </span>
           </div>
           <p
             class="sc-iBkjds idbXdJ"
@@ -52,8 +52,8 @@ exports[`DefaultToast component testing DefaultToast error 1`] = `
         <div
           class="sc-hKMtZM jCCKuz"
         >
-          <div
-            class="sc-gKXOVf eQUwDP"
+          <span
+            class="sc-gKXOVf kFgTzX"
             size="18"
           >
             <svg
@@ -75,7 +75,7 @@ exports[`DefaultToast component testing DefaultToast error 1`] = `
                 width="5.143"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
       <div
@@ -109,8 +109,8 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
           <div
             class="sc-dkzDqf kXpBi"
           >
-            <div
-              class="sc-gKXOVf kNytYv"
+            <span
+              class="sc-gKXOVf fmZGCL"
               size="24"
             >
               <svg
@@ -126,7 +126,7 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
                   transform="translate(-16711 -12642)"
                 />
               </svg>
-            </div>
+            </span>
           </div>
           <p
             class="sc-iBkjds gATKuv"
@@ -139,8 +139,8 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
         <div
           class="sc-hKMtZM jCCKuz"
         >
-          <div
-            class="sc-gKXOVf eQUwDP"
+          <span
+            class="sc-gKXOVf kFgTzX"
             size="18"
           >
             <svg
@@ -162,7 +162,7 @@ exports[`DefaultToast component testing DefaultToast info 1`] = `
                 width="5.143"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
       <div
@@ -196,8 +196,8 @@ exports[`DefaultToast component testing DefaultToast success 1`] = `
           <div
             class="sc-dkzDqf kXpBi"
           >
-            <div
-              class="sc-gKXOVf kNytYv"
+            <span
+              class="sc-gKXOVf fmZGCL"
               size="24"
             >
               <svg
@@ -213,7 +213,7 @@ exports[`DefaultToast component testing DefaultToast success 1`] = `
                   fill="#63C427"
                 />
               </svg>
-            </div>
+            </span>
           </div>
           <p
             class="sc-iBkjds gATEzB"
@@ -226,8 +226,8 @@ exports[`DefaultToast component testing DefaultToast success 1`] = `
         <div
           class="sc-hKMtZM jCCKuz"
         >
-          <div
-            class="sc-gKXOVf eQUwDP"
+          <span
+            class="sc-gKXOVf kFgTzX"
             size="18"
           >
             <svg
@@ -249,7 +249,7 @@ exports[`DefaultToast component testing DefaultToast success 1`] = `
                 width="5.143"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
       <div
@@ -283,8 +283,8 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
           <div
             class="sc-dkzDqf kXpBi"
           >
-            <div
-              class="sc-gKXOVf kNytYv"
+            <span
+              class="sc-gKXOVf fmZGCL"
               size="24"
             >
               <svg
@@ -300,7 +300,7 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
                   fill="#FCD914"
                 />
               </svg>
-            </div>
+            </span>
           </div>
           <p
             class="sc-iBkjds dLpBiE"
@@ -313,8 +313,8 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
         <div
           class="sc-hKMtZM jCCKuz"
         >
-          <div
-            class="sc-gKXOVf eQUwDP"
+          <span
+            class="sc-gKXOVf kFgTzX"
             size="18"
           >
             <svg
@@ -336,7 +336,7 @@ exports[`DefaultToast component testing DefaultToast warning 1`] = `
                 width="5.143"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
       <div


### PR DESCRIPTION
ingred-ui 内でも存在するが、コードを書いてるとために `<Icon />` を button で囲いたくなる時がある。

mdn の [button のリファレンス](https://developer.mozilla.org/ja/docs/Web/HTML/Element/button) を見てみると、




許可されている内容	| [記述コンテンツ](https://developer.mozilla.org/ja/docs/Web/Guide/HTML/Content_categories#%E8%A8%98%E8%BF%B0%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84)、但し[対話型コンテンツ](https://developer.mozilla.org/ja/docs/Web/Guide/HTML/Content_categories#%E5%AF%BE%E8%A9%B1%E5%9E%8B%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84)があってはならない
-- | --





とある。
記述コンテンツには `<div>` は含まれないので、これを `<span>` に変更をした。
https://developer.mozilla.org/ja/docs/Web/Guide/HTML/Content_categories#%E8%A8%98%E8%BF%B0%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84

`<div>` と `<span>` の互換を取るために `display: block;` を追加した。