### PR TITLE
eslint-plugin-prettierを除去

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,5 @@
 module.exports = {
-  plugins: [
-    "prettier",
-    "@typescript-eslint",
-    "react",
-    "react-hooks",
-    "jsx-a11y",
-    "jest",
-  ],
+  plugins: ["@typescript-eslint", "react", "react-hooks", "jsx-a11y", "jest"],
   extends: [
     "eslint:recommended",
     "prettier",
@@ -59,19 +52,6 @@ module.exports = {
     "import/prefer-default-export": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
-    "prettier/prettier": [
-      "error",
-      {
-        singleQuote: false,
-        useTabs: false,
-        tabWidth: 2,
-        semi: true,
-        bracketSpacing: true,
-        trailingComma: "all",
-        arrowParens: "always",
-      },
-    ],
-
     "react/jsx-handler-names": [
       "error",
       {

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  singleQuote: false,
+  useTabs: false,
+  tabWidth: 2,
+  semi: true,
+  bracketSpacing: true,
+  trailingComma: "all",
+  arrowParens: "always",
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   },
   "eslint.options": {
     "extensions": [".js", ".jsx", ".md", ".ts", ".tsx"]
-  }
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "playground": "yarn build && cd testEnv && yarn install && yarn start",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "generate": "yarn scaffdog generate",
-    "format": "yarn lint --fix"
+    "lint": "eslint 'src/**/*.{ts,tsx}' && prettier --check 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx}'",
+    "generate": "yarn scaffdog generate"
   },
   "dependencies": {
     "@popperjs/core": "^2.4.0",
@@ -67,7 +67,6 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.1",
     "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.7",
     "eslint-plugin-react-hooks": "4.6.0",
     "jest": "28.1.0",

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -45,11 +45,15 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
     },
     ref,
   ) => {
-    /* eslint-disable prettier/prettier */
-  const [baseElement, setBaseElement] = React.useState<HTMLElement | null>(null);
-  const [arrowElement, setArrowElement] = React.useState<HTMLElement | null>(null);
-  const [popperElement, setPopperElement] = React.useState<HTMLElement | null>(null);
-  /* eslint-enable prettier/prettier */
+    const [baseElement, setBaseElement] = React.useState<HTMLElement | null>(
+      null,
+    );
+    const [arrowElement, setArrowElement] = React.useState<HTMLElement | null>(
+      null,
+    );
+    const [popperElement, setPopperElement] =
+      React.useState<HTMLElement | null>(null);
+
     const [open, setOpen] = React.useState<boolean>(false);
     const [openTimer, setOpenTimer] = React.useState<number | null>(null);
     const [closeTimer, setCloseTimer] = React.useState<number | null>(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7235,13 +7235,6 @@ eslint-plugin-jsx-a11y@6.6.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
-eslint-plugin-prettier@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
-  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -7645,11 +7638,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -12427,13 +12415,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@2.7.1:
   version "2.7.1"


### PR DESCRIPTION
## 背景
* eslint-plugin-prettierの利用が公式非推奨になった ([参考](https://prettier.io/docs/en/integrating-with-linters.html#notes))
  * エディター上でエラー表示されるため、(意識しなくていいよう導入しているはずなのに)
  フォーマッターを意識することになってしまう
  * Prettierを直接実行するよりも遅い
  * プラグインという余計なレイヤーがあることでそこで何かしらの問題が発生する可能性がある
 
## やったこと
* 公式に倣って `eslint-plugin-prettier` を使わないように修正
* フォーマットはeslintから切り離してprettierで全部やるようにする