### PR TITLE
Update typescript@4.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "scaffdog": "2.4.0",
     "styled-components": "5.3.5",
     "ts-jest": "28.0.4",
-    "typescript": "4.8.2"
+    "typescript": "4.9.3"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14883,10 +14883,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+typescript@4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
+  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
 uglify-js@^3.1.4:
   version "3.16.0"


### PR DESCRIPTION
ref #1017

周辺のツールが追いついてなさそうなので satisfies を使うのは一旦なしにして、TypeScript のバージョンだけ上げておく。