### PR TITLE
MenuPropsからReact.ComponentPropsWithRef<"div">を取り除く

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -7,9 +7,7 @@ import { createChainedFunction } from "../../utils/createChainedFunction";
 
 export type MenuCloseReason = "clickMenuList";
 
-// TODO: need breaking change(#211)
-//       remove 'React.ComponentPropsWithoutRef<"div">' because it is included menuListProps
-export type MenuProps = React.ComponentPropsWithoutRef<"div"> & {
+export type MenuProps = {
   isOpen?: boolean;
   /**
    * Basis of `<Menu />` position.
@@ -74,7 +72,6 @@ const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
           {...menuListProps}
           onClick={createChainedFunction(
             handleCloseMenuList,
-            rest.onClick,
             menuListProps?.onClick,
           )}
         />


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
fix: https://github.com/voyagegroup/ingred-ui/issues/211

やったこと
MenuPropsからReact.ComponentPropsWithRef<"div">を取り除く
