### PR TITLE
feat `<Accordion />` component

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { Story } from "@storybook/react/types-6-0";
+import Accordion, { AccordionProps } from "./Accordion";
+
+export default {
+  title: "Components/utils/Accordion",
+  component: Accordion,
+  args: {
+    title: "Accordion Title",
+  },
+};
+
+export const Example: Story<AccordionProps> = (args) => (
+  <>
+    <Accordion {...args}>
+      <div style={{ padding: "4px 8px" }}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
+        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+      </div>
+    </Accordion>
+    <Accordion {...args}>
+      <div style={{ padding: "4px 8px" }}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
+        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+      </div>
+    </Accordion>
+    <Accordion {...args}>
+      <div style={{ padding: "4px 8px" }}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
+        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+      </div>
+    </Accordion>
+  </>
+);
+
+export const ControlledAccordion: Story<AccordionProps> = () => {
+  const [expanded, setExpanded] = React.useState<string | false>(false);
+  const handleChange =
+    (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
+      setExpanded(newExpanded ? panel : false);
+    };
+
+  return (
+    <>
+      <Accordion
+        title="title1"
+        expanded={expanded === "title1"}
+        onChange={handleChange("title1")}
+      >
+        <div style={{ padding: "4px 8px" }}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
+          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+        </div>
+      </Accordion>
+      <Accordion
+        title="title2"
+        expanded={expanded === "title2"}
+        onChange={handleChange("title2")}
+      >
+        <div style={{ padding: "4px 8px" }}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
+          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+        </div>
+      </Accordion>
+      <Accordion
+        title="title3"
+        expanded={expanded === "title3"}
+        onChange={handleChange("title3")}
+      >
+        <div style={{ padding: "4px 8px" }}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
+          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
+          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
+          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
+          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
+        </div>
+      </Accordion>
+    </>
+  );
+};

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -5,14 +5,11 @@ import Accordion, { AccordionProps } from "./Accordion";
 export default {
   title: "Components/utils/Accordion",
   component: Accordion,
-  args: {
-    title: "Accordion Title",
-  },
 };
 
-export const Example: Story<AccordionProps> = (args) => (
+export const Example: Story<AccordionProps> = () => (
   <>
-    <Accordion {...args}>
+    <Accordion title="title1">
       <div style={{ padding: "4px 8px" }}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
         magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
@@ -21,7 +18,7 @@ export const Example: Story<AccordionProps> = (args) => (
         et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
       </div>
     </Accordion>
-    <Accordion {...args}>
+    <Accordion title="title2">
       <div style={{ padding: "4px 8px" }}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
         magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
@@ -30,7 +27,7 @@ export const Example: Story<AccordionProps> = (args) => (
         et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
       </div>
     </Accordion>
-    <Accordion {...args}>
+    <Accordion disabled title="disabled">
       <div style={{ padding: "4px 8px" }}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
         magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -3,7 +3,7 @@ import { Story } from "@storybook/react/types-6-0";
 import Accordion, { AccordionProps } from "./Accordion";
 
 export default {
-  title: "Components/utils/Accordion",
+  title: "Components/navigation/Accordion",
   component: Accordion,
 };
 

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -5,9 +5,27 @@ import Accordion, { AccordionProps } from "./Accordion";
 export default {
   title: "Components/navigation/Accordion",
   component: Accordion,
+  args: {
+    title: "title",
+    children: "Lorem ipsum dolor sit amet",
+    disabled: false,
+    expanded: false,
+  },
 };
 
-export const Example: Story<AccordionProps> = () => (
+export const Example: Story<AccordionProps> = (args) => (
+  <>
+    <Accordion
+      title={args.title}
+      disabled={args.disabled}
+      expanded={args.expanded}
+    >
+      <div style={{ padding: "4px 8px" }}>{args.children}</div>
+    </Accordion>
+  </>
+);
+
+export const Multiple: Story<AccordionProps> = () => (
   <>
     <Accordion title="title1">
       <div style={{ padding: "4px 8px" }}>
@@ -39,7 +57,7 @@ export const Example: Story<AccordionProps> = () => (
   </>
 );
 
-export const ControlledAccordion: Story<AccordionProps> = () => {
+export const Controlled: Story<AccordionProps> = () => {
   const [expanded, setExpanded] = React.useState<string | false>(false);
   const handleChange =
     (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -39,6 +39,16 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
     onChange && onChange(event, expanded);
   };
 
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    handleChange(event, !expandedState);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter") {
+      handleChange(event, !expandedState);
+    }
+  };
+
   useEffect(() => {
     setExpandedState(expanded);
   }, [expanded]);
@@ -53,16 +63,8 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
         aria-controls={`accordion-content-${title}`}
         expanded={expandedState}
         disabled={disabled}
-        // eslint-disable-next-line react/jsx-handler-names
-        onClick={(event) => {
-          handleChange(event, !expandedState);
-        }}
-        // eslint-disable-next-line react/jsx-handler-names
-        onKeyDown={(event) => {
-          if (event.key === "Enter") {
-            handleChange(event, !expandedState);
-          }
-        }}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
       >
         <Styled.AccordionTitleChildren>{title}</Styled.AccordionTitleChildren>
         <Styled.DropdownIndicator>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,73 @@
+import React, {
+  ReactNode,
+  forwardRef,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Icon from "../Icon";
+import * as Styled from "./styled";
+
+export type AccordionProps = {
+  title: ReactNode;
+  expanded?: boolean;
+  disabled?: boolean;
+  onChange?: (event: React.SyntheticEvent, expanded: boolean) => void;
+  children: ReactNode | ReactNode[];
+};
+
+const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
+  { title, expanded = false, disabled = false, onChange, children, ...rest },
+  ref,
+) {
+  const [expandedState, setExpandedState] = useState(expanded);
+  const accordionContentContainerRef = useRef<HTMLDivElement>(null);
+
+  const height = useMemo(() => {
+    if (expandedState && accordionContentContainerRef.current) {
+      return accordionContentContainerRef.current.scrollHeight;
+    }
+    return 0;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedState, accordionContentContainerRef.current]);
+
+  const handleChange = (event: React.SyntheticEvent, expanded: boolean) => {
+    setExpandedState(expanded);
+    onChange && onChange(event, expanded);
+  };
+
+  useEffect(() => {
+    setExpandedState(expanded);
+  }, [expanded]);
+
+  return (
+    <div ref={ref} {...rest}>
+      <Styled.AccordionTitle
+        display="flex"
+        expanded={expandedState}
+        disabled={disabled}
+        // eslint-disable-next-line react/jsx-handler-names
+        onClick={(event) => {
+          handleChange(event, !expandedState);
+        }}
+      >
+        <Styled.AccordionTitleChildren>{title}</Styled.AccordionTitleChildren>
+        <Styled.DropdownIndicator>
+          <Styled.IconButton expanded={expandedState}>
+            <Icon name="arrow_bottom" size="md" color="black" />
+          </Styled.IconButton>
+        </Styled.DropdownIndicator>
+      </Styled.AccordionTitle>
+      <Styled.AccordionContent
+        ref={accordionContentContainerRef}
+        expanded={expandedState}
+        height={height}
+      >
+        {children}
+      </Styled.AccordionContent>
+    </div>
+  );
+});
+
+export default Accordion;

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useTheme } from "../../themes";
 import Icon from "../Icon";
 import * as Styled from "./styled";
 
@@ -21,6 +22,7 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
   { title, expanded = false, disabled = false, onChange, children, ...rest },
   ref,
 ) {
+  const theme = useTheme();
   const [expandedState, setExpandedState] = useState(expanded);
   const accordionContentContainerRef = useRef<HTMLDivElement>(null);
 
@@ -55,7 +57,11 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
         <Styled.AccordionTitleChildren>{title}</Styled.AccordionTitleChildren>
         <Styled.DropdownIndicator>
           <Styled.IconButton expanded={expandedState}>
-            <Icon name="arrow_bottom" size="md" color="black" />
+            <Icon
+              name="arrow_bottom"
+              size="md"
+              color={disabled ? theme.palette.text.disabled : "black"}
+            />
           </Styled.IconButton>
         </Styled.DropdownIndicator>
       </Styled.AccordionTitle>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -47,11 +47,21 @@ const Accordion = forwardRef<HTMLDivElement, AccordionProps>(function Accordion(
     <div ref={ref} {...rest}>
       <Styled.AccordionTitle
         display="flex"
+        tabIndex={disabled ? -1 : 0}
+        role="button"
+        aria-expanded={expandedState}
+        aria-controls={`accordion-content-${title}`}
         expanded={expandedState}
         disabled={disabled}
         // eslint-disable-next-line react/jsx-handler-names
         onClick={(event) => {
           handleChange(event, !expandedState);
+        }}
+        // eslint-disable-next-line react/jsx-handler-names
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            handleChange(event, !expandedState);
+          }
         }}
       >
         <Styled.AccordionTitleChildren>{title}</Styled.AccordionTitleChildren>

--- a/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -13,4 +13,13 @@ describe("Accordion component testing", () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test("Disable Accordion", () => {
+    const { asFragment } = renderWithThemeProvider(
+      <Accordion disabled title="Accordion Title">
+        Accordion Content
+      </Accordion>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { cleanup } from "@testing-library/react";
+import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
+import Accordion from "../";
+
+describe("Accordion component testing", () => {
+  afterEach(cleanup);
+
+  test("Accordion", () => {
+    const { asFragment } = renderWithThemeProvider(
+      <Accordion title="Accordion Title">Accordion Content</Accordion>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accordion component testing Accordion 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="sc-gsnTZi sc-dkzDqf iFjddk khxAjh"
+      display="flex"
+    >
+      <div
+        class="sc-hKMtZM hWStLy"
+      >
+        Accordion Title
+      </div>
+      <div
+        class="sc-gKXOVf iwyGgb"
+      >
+        <div
+          class="sc-jSMfEi jmkEMm"
+        >
+          <span
+            class="sc-bczRLJ gJuzRf"
+            size="18"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0,0H24V24H0Z"
+                fill="none"
+              />
+              <path
+                d="M13.414,16.886,7.757,11.228,9.644,9.343l3.771,3.772,3.771-3.772,1.887,1.885Z"
+                fill="black"
+                transform="translate(-1.414 -1.114)"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sc-iBkjds gfHllz"
+      height="0"
+    >
+      Accordion Content
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -4,8 +4,12 @@ exports[`Accordion component testing Accordion 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="sc-gsnTZi sc-dkzDqf iFjddk khxAjh"
+      aria-controls="accordion-content-Accordion Title"
+      aria-expanded="false"
+      class="sc-gsnTZi sc-dkzDqf cbhMfa khxAjh"
       display="flex"
+      role="button"
+      tabindex="0"
     >
       <div
         class="sc-hKMtZM hWStLy"
@@ -33,6 +37,61 @@ exports[`Accordion component testing Accordion 1`] = `
               <path
                 d="M13.414,16.886,7.757,11.228,9.644,9.343l3.771,3.772,3.771-3.772,1.887,1.885Z"
                 fill="black"
+                transform="translate(-1.414 -1.114)"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sc-iBkjds gfHllz"
+      height="0"
+    >
+      Accordion Content
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion component testing Disable Accordion 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      aria-controls="accordion-content-Accordion Title"
+      aria-expanded="false"
+      class="sc-gsnTZi sc-dkzDqf gBKSdN fhXfqR"
+      disabled=""
+      display="flex"
+      role="button"
+      tabindex="-1"
+    >
+      <div
+        class="sc-hKMtZM hWStLy"
+      >
+        Accordion Title
+      </div>
+      <div
+        class="sc-gKXOVf iwyGgb"
+      >
+        <div
+          class="sc-jSMfEi jmkEMm"
+        >
+          <span
+            class="sc-bczRLJ gJuzRf"
+            size="18"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0,0H24V24H0Z"
+                fill="none"
+              />
+              <path
+                d="M13.414,16.886,7.757,11.228,9.644,9.343l3.771,3.772,3.771-3.772,1.887,1.885Z"
+                fill="#B3BAC1"
                 transform="translate(-1.414 -1.114)"
               />
             </svg>

--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Accordion component testing Accordion 1`] = `
     <div
       aria-controls="accordion-content-Accordion Title"
       aria-expanded="false"
-      class="sc-gsnTZi sc-dkzDqf cbhMfa khxAjh"
+      class="sc-gsnTZi sc-dkzDqf jUiVsm khxAjh"
       display="flex"
       role="button"
       tabindex="0"
@@ -60,7 +60,7 @@ exports[`Accordion component testing Disable Accordion 1`] = `
     <div
       aria-controls="accordion-content-Accordion Title"
       aria-expanded="false"
-      class="sc-gsnTZi sc-dkzDqf gBKSdN fhXfqR"
+      class="sc-gsnTZi sc-dkzDqf dfqrSd fhXfqR"
       disabled=""
       display="flex"
       role="button"

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./Accordion";
+export type { AccordionProps } from "./Accordion";

--- a/src/components/Accordion/styled.ts
+++ b/src/components/Accordion/styled.ts
@@ -8,7 +8,7 @@ export const AccordionTitle = styled(Flex)<{
   background-color: ${({ expanded, disabled, theme }) =>
     // eslint-disable-next-line no-nested-ternary
     disabled
-      ? theme.palette.text.disabled
+      ? theme.palette.gray.light
       : expanded
       ? theme.palette.primary.highlight
       : theme.palette.gray.highlight};

--- a/src/components/Accordion/styled.ts
+++ b/src/components/Accordion/styled.ts
@@ -1,0 +1,57 @@
+import Flex from "../Flex";
+import styled from "styled-components";
+
+export const AccordionTitle = styled(Flex)<{
+  expanded: boolean;
+  disabled?: boolean;
+}>`
+  background-color: ${({ expanded, disabled, theme }) =>
+    // eslint-disable-next-line no-nested-ternary
+    disabled
+      ? theme.palette.text.disabled
+      : expanded
+      ? theme.palette.primary.highlight
+      : theme.palette.gray.highlight};
+  color: ${({ disabled, theme }) =>
+    disabled ? theme.palette.text.disabled : "auto"};
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
+  pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
+  justify-content: space-between;
+  border-top: ${({ expanded, theme }) =>
+    !expanded ? `1px solid ${theme.palette.divider}` : "none"};
+  transition: background-color 0.3s, border-top 0.3s;
+`;
+
+export const AccordionTitleChildren = styled.div`
+  padding: ${({ theme }) => theme.spacing * 1.25}px;
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  box-sizing: border-box;
+`;
+
+export const IconButton = styled.div<{ expanded: boolean }>`
+  padding: ${({ theme }) => `${theme.spacing * 1.25}px ${theme.spacing * 2}px`};
+  transition: transform 150ms;
+  transform-origin: center center;
+  transform: ${({ expanded }) => (expanded ? "rotate(180deg)" : "rotate(0)")};
+`;
+
+export const DropdownIndicator = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  width: ${({ theme }) => theme.spacing * 5}px;
+`;
+
+export const AccordionContent = styled.div<{
+  expanded: boolean;
+  height: number;
+}>`
+  height: ${({ height }) => height}px;
+  overflow: hidden;
+  transition: 0.3s all;
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,7 @@
 /* eslint-disable import/export */
+export { default as Accordion } from "./Accordion";
+export * from "./Accordion";
+
 export { default as ActionButton } from "./ActionButton";
 export * from "./ActionButton";
 


### PR DESCRIPTION
close https://github.com/voyagegroup/ingred-ui/issues/963

`<Accordion />` コンポーネントの追加。
title の文言は title prop で、開いた時に見える文言は children で指定する。

## 動作確認環境

https://deploy-preview-1225--ingred-ui.netlify.app/?path=/story/components-navigation-accordion--example

## 例

普通にアコーディオンを作るならこうなる。

```tsx
const AccordionExample = () => (
  <>
    <Accordion {...args}>
      <div style={{ padding: "4px 8px" }}>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
      </div>
    </Accordion>
    <Accordion {...args}>
      <div style={{ padding: "4px 8px" }}>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
      </div>
    </Accordion>
    <Accordion {...args}>
      <div style={{ padding: "4px 8px" }}>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
        magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
        augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
        elit lorem, id ullamcorper libero elementum non. Sed rutrum porta enim,
        et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
      </div>
    </Accordion>
  </>
);
```

## カスタマイズ例

デフォルトだと複数個の Accordion を開くことができるけど単一の Accordion のみを開きたいユースケースもそれなりに存在すると想定している。そのような場合は以下のように書くことで対応できる。

```tsx
const SingleOpenAccoridon = () => {
const [expanded, setExpanded] = React.useState<string | false>(false);
  const handleChange =
    (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
      setExpanded(newExpanded ? panel : false);
    };

  return (
    <>
      <Accordion
        title="title1"
        expanded={expanded === "title1"}
        onChange={handleChange("title1")}
      >
        <div style={{ padding: "4px 8px" }}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
        </div>
      </Accordion>
      <Accordion
        title="title2"
        expanded={expanded === "title2"}
        onChange={handleChange("title2")}
      >
        <div style={{ padding: "4px 8px" }}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
        </div>
      </Accordion>
      <Accordion
        title="title3"
        expanded={expanded === "title3"}
        onChange={handleChange("title3")}
      >
        <div style={{ padding: "4px 8px" }}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc velit
          magna, dictum vel elementum ac, fermentum quis lorem. Aliquam sapien
          augue, efficitur eget tincidunt non, accumsan et est. Aliquam lobortis
          elit lorem, id ullamcorper libero elementum non. Sed rutrum porta
          enim, et aliquet velit hendrerit ac. Morbi tincidunt eleifend elit.
        </div>
      </Accordion>
    </>
  );
}
```


## スクリーンショット

### 閉じてる時
![image](https://user-images.githubusercontent.com/50351271/231915922-3232e9c1-b273-4e26-b5df-9c44438a1b3d.png)

### 開いてる時
![image](https://user-images.githubusercontent.com/50351271/231915943-33e35ea9-d0ee-4294-a530-6a0469125b4e.png)

## 迷いごと

- `defaultExpanded` というプロパティを追加するか
  - 現状 `expanded` で対処可能
  - 一見わかりにくいかもしれない
- children の height の計算は本当に必要か
  - `expanded` の状態から animation を付与できないか
- storybook の分類は何になるんだろう、今は utils に入れてる
  - mui の場合や surface