### PR TITLE
Add background-color white to children of `<Accordion />`

### DIFF
--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Accordion component testing Accordion 1`] = `
       </div>
     </div>
     <div
-      class="sc-iBkjds gfHllz"
+      class="sc-iBkjds cEjDqL"
       height="0"
     >
       Accordion Content
@@ -100,7 +100,7 @@ exports[`Accordion component testing Disable Accordion 1`] = `
       </div>
     </div>
     <div
-      class="sc-iBkjds gfHllz"
+      class="sc-iBkjds cEjDqL"
       height="0"
     >
       Accordion Content

--- a/src/components/Accordion/styled.ts
+++ b/src/components/Accordion/styled.ts
@@ -54,4 +54,5 @@ export const AccordionContent = styled.div<{
   height: ${({ height }) => height}px;
   overflow: hidden;
   transition: 0.3s all;
+  background-color: ${({ theme }) => theme.palette.white};
 `;


### PR DESCRIPTION
ref #1225

こういう背景が赤い時とかに透けないようにする。
![image](https://user-images.githubusercontent.com/50351271/233241487-8d96a6ea-4ebf-44a3-8e5f-be5b5b965fb2.png)
