### PR TITLE
Return version 12.0.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingred-ui",
-  "version": "12.1.0",
+  "version": "12.0.0",
   "description": "",
   "author": "CARTA HOLDINGS, Inc.",
   "license": "MIT",


### PR DESCRIPTION
ビルドが落ちてリリースが失敗した。（再発防止の対応は #1246 #1247 でやった）
しかし、package.json のバージョンは進んでしまっているので対処。
revert しようと思ったけど #1247 で package.json に変更を入れてしまったので手動で修正。