### PR TITLE
Fix flexible with or without badge in `<Tabs />`

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -28,7 +28,5 @@ export const WithBadge = () => {
     ],
   };
 
-  return (
-    <Tabs {...options} value={value} withBadge={true} onChange={setValue} />
-  );
+  return <Tabs {...options} value={value} onChange={setValue} />;
 };

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -30,3 +30,16 @@ export const WithBadge = () => {
 
   return <Tabs {...options} value={value} onChange={setValue} />;
 };
+
+export const FixableBadge = () => {
+  const [value, setValue] = React.useState("home");
+  const options = {
+    data: [
+      { text: "ホーム", value: "home" },
+      { text: "タイムライン", value: "timeline" },
+      { text: "通知", count: 5, value: "notification" },
+    ],
+  };
+
+  return <Tabs {...options} value={value} onChange={setValue} />;
+};

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -11,7 +11,6 @@ type TabsProps<T> = {
     value: T;
   }[];
   value: T;
-  withBadge?: boolean;
   onChange?: (value: T) => void;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
@@ -20,7 +19,7 @@ const Tabs = <T,>(
   props: TabsProps<T>,
   ref: React.Ref<HTMLDivElement>,
 ): React.ReactElement<TabsProps<T>> => {
-  const { data, value, withBadge = false, onChange, onClick } = props;
+  const { data, value, onChange, onClick } = props;
   const valueToIndex = new Map<T, number>();
   const childrenRef = React.useRef<HTMLDivElement>(null);
   const [indicatorStyle, setIndicatorStyle] = React.useState({});
@@ -114,7 +113,6 @@ const Tabs = <T,>(
               selected={selected}
               value={childValue}
               count={d.count}
-              withBadge={withBadge}
               text={d.text}
               onChange={onChange}
               onClick={onClick}

--- a/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -30,7 +30,7 @@ describe("Tabs component testing", () => {
       ],
     };
     const { asFragment } = renderWithThemeProvider(
-      <Tabs {...options} value={"hoge"} withBadge={true} />,
+      <Tabs {...options} value={"hoge"} />,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/src/components/Tabs/internal/Tab.tsx
+++ b/src/components/Tabs/internal/Tab.tsx
@@ -9,13 +9,12 @@ type TabProps = {
   count?: number;
   value: any;
   selected: boolean;
-  withBadge: boolean;
   onChange?: (value: any) => void;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
-  ({ text, count, value, withBadge, selected, onChange, onClick }, ref) => {
+  ({ text, count, value, selected, onChange, onClick }, ref) => {
     const theme = useTheme();
     const badgeColor = selected ? "primary" : "secondary";
 
@@ -40,7 +39,7 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
       >
         <Flex display="flex" justifyContent="space-between" alignItems="center">
           <Styled.Text selected={selected}>{text} </Styled.Text>
-          {withBadge ? (
+          {count ? (
             <Badge color={badgeColor} type="pill" fontWeight="bold">
               {count}
             </Badge>


### PR DESCRIPTION
Tabs コンポーネントは withBadge を使用した際全てのタブにバッジがつくか、全てのタブにバッジがつかないかしか選択できない。
そのため、count プロパティの有無でバッジの有無を判定するように変更した。
