### PR TITLE
Storybookv7化、deprecated対応

### DIFF
--- a/src/components/ActionButton/ActionButton.stories.tsx
+++ b/src/components/ActionButton/ActionButton.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Description, Stories, Title } from "@storybook/addon-docs";
+import { ArgsTable, Stories, Title } from "@storybook/addon-docs";
 import { StoryObj } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import React from "react";
 import ActionButton, { ActionButtonProps } from "./ActionButton";
 
@@ -18,7 +19,7 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description markdown={"It can behave like a `<button />` tags."} />
+          <Markdown>{"It can behave like a `<button />` tags."}</Markdown>
           <ArgsTable of={ActionButton} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 import Button, { ButtonProps } from "./Button";
 
@@ -18,8 +19,8 @@ export default {
           <Title />
           <ArgsTable of={Button} />
           <Stories includePrimary title="Samples" />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               '### Use with router library like "react-router"',
               "Here's an example code.  ",
               "",
@@ -39,7 +40,7 @@ export default {
               ");",
               "```",
             ].join("\n")}
-          />
+          </Markdown>
         </>
       ),
     },

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Card, { CardProps } from "./Card";
 
 export default {
@@ -17,13 +18,13 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "It is used when we want to express something gathering of information.",
               "",
               "It can contains `<Flex />`props & `<Spacer />`props.",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={Card} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,6 @@
-import { ArgsTable, Description, Stories, Title } from "@storybook/addon-docs";
+import { ArgsTable, Stories, Title } from "@storybook/addon-docs";
 import { StoryObj } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import dayjs from "dayjs";
 import React from "react";
 import DatePicker from "./DatePicker";
@@ -15,16 +16,16 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "The wrapper of [react-dates](https://github.com/airbnb/react-dates).",
               "",
               "For more detail props, please see [it](https://github.com/airbnb/react-dates#singledatepicker).",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={DatePicker} />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "## When the display is strange",
               "",
               "Please import css from `react-dates`.",
@@ -34,7 +35,7 @@ export default {
               'import "react-dates/lib/css/_datepicker.css";',
               "```",
             ].join("\n")}
-          />
+          </Markdown>
           <Stories includePrimary title="Stories" />
         </>
       ),

--- a/src/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { StoryObj } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import dayjs from "dayjs";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import DateRangePicker from "./DateRangePicker";
 import "react-dates/lib/css/_datepicker.css";
 import "dayjs/locale/ja";
@@ -16,16 +17,16 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "The wrapper of [react-dates](https://github.com/airbnb/react-dates).",
               "",
               "For more detail props, please see [it](https://github.com/airbnb/react-dates#daterangepicker).",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={DateRangePicker} />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "## When the display is strange",
               "",
               "Please import css from `react-dates`.",
@@ -35,7 +36,7 @@ export default {
               'import "react-dates/lib/css/_datepicker.css";',
               "```",
             ].join("\n")}
-          />
+          </Markdown>
           <Stories includePrimary title="Stories" />
         </>
       ),

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Divider, { DividerProps } from "./Divider";
 
 export default {
@@ -8,11 +9,15 @@ export default {
   components: Divider,
   parameters: {
     docs: {
-      source: { language: "tsx" },
+      source: { type: "code" },
       page: () => (
         <>
           <Title />
-          <Description markdown="`<Divider />` is wrapper of `<hr />` tag that separate content into clear groups." />
+          <Markdown>
+            {
+              "`<Divider />` is wrapper of `<hr />` tag that separate content into clear groups."
+            }
+          </Markdown>
           <ArgsTable of={Divider} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Fade/Fade.stories.tsx
+++ b/src/components/Fade/Fade.stories.tsx
@@ -1,6 +1,6 @@
 import { Stories, Title } from "@storybook/addon-docs";
 import { Markdown } from "@storybook/blocks";
-import { ComponentStory } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import React from "react";
 import Flex from "../Flex";
 import Spacer from "../Spacer";
@@ -36,25 +36,27 @@ export default {
   },
 };
 
-export const Example: ComponentStory<typeof Fade> = (args) => {
-  const [isOpen, setIsOpen] = React.useState(args.in);
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
-  return (
-    <Flex display="flex" flexDirection="column" alignItems="center">
-      <Spacer pt={3} />
-      <ToggleButton checked={isOpen} onChange={handleToggle} />
-      <Spacer pt={3} />
-      <Fade {...args} in={isOpen}>
-        <div
-          style={{
-            width: "100px",
-            height: "100px",
-            backgroundColor: "blue",
-          }}
-        />
-      </Fade>
-    </Flex>
-  );
+export const Example: StoryObj<typeof Fade> = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = React.useState(args.in);
+    const handleToggle = () => {
+      setIsOpen(!isOpen);
+    };
+    return (
+      <Flex display="flex" flexDirection="column" alignItems="center">
+        <Spacer pt={3} />
+        <ToggleButton checked={isOpen} onChange={handleToggle} />
+        <Spacer pt={3} />
+        <Fade {...args} in={isOpen}>
+          <div
+            style={{
+              width: "100px",
+              height: "100px",
+              backgroundColor: "blue",
+            }}
+          />
+        </Fade>
+      </Flex>
+    );
+  },
 };

--- a/src/components/Fade/Fade.stories.tsx
+++ b/src/components/Fade/Fade.stories.tsx
@@ -1,4 +1,5 @@
-import { Description, Stories, Title } from "@storybook/addon-docs";
+import { Stories, Title } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
 import { ComponentStory } from "@storybook/react";
 import React from "react";
 import Flex from "../Flex";
@@ -19,15 +20,15 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "The wrapper of `<CSSTransition />` that implemented in [react-transition-group](https://reactcommunity.org/react-transition-group).",
               "",
               "It makes easy to implement CSS transitions that uses `opacity`.",
               "",
               "Props type is same as [this](https://reactcommunity.org/react-transition-group/transition#Transition-props).",
             ].join("\n")}
-          />
+          </Markdown>
           <Stories includePrimary title="Stories" />
         </>
       ),

--- a/src/components/FixedPanel/FixedPanel.stories.tsx
+++ b/src/components/FixedPanel/FixedPanel.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Flex from "../Flex";
 import Spacer from "../Spacer";
 import Button from "../Button";
@@ -20,13 +21,13 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "It implement like ”Header/Footer” UI that is styled `position: fixed;`.",
               "",
               "Usage example is included in ”Canvas” Tab at header.",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={FixedPanel} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Flex/Flex.stories.tsx
+++ b/src/components/Flex/Flex.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Flex, { FlexProps } from "./Flex";
 
 export default {
@@ -16,11 +17,11 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={
+          <Markdown>
+            {
               "Flex can easier express CSS that related flexbox with simple props."
             }
-          />
+          </Markdown>
           <ArgsTable of={Flex} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Grow/Grow.stories.tsx
+++ b/src/components/Grow/Grow.stories.tsx
@@ -1,4 +1,5 @@
-import { Description, Stories, Title } from "@storybook/addon-docs";
+import { Stories, Title } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
 import { ComponentStory } from "@storybook/react";
 import React from "react";
 import Flex from "../Flex";
@@ -19,16 +20,15 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "The wrapper of `<CSSTransition />` that implemented in [react-transition-group](https://reactcommunity.org/react-transition-group).",
               "",
               "It makes easy to implement CSS transitions that uses `opacity`.",
               "",
               "Props type is same as [this](https://reactcommunity.org/react-transition-group/transition#Transition-props).",
             ].join("\n")}
-          />
-
+          </Markdown>
           <Stories includePrimary title="Stories" />
         </>
       ),

--- a/src/components/Grow/Grow.stories.tsx
+++ b/src/components/Grow/Grow.stories.tsx
@@ -1,6 +1,6 @@
 import { Stories, Title } from "@storybook/addon-docs";
 import { Markdown } from "@storybook/blocks";
-import { ComponentStory } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import React from "react";
 import Flex from "../Flex";
 import Spacer from "../Spacer";
@@ -36,25 +36,27 @@ export default {
   },
 };
 
-export const Example: ComponentStory<typeof Grow> = (args) => {
-  const [isOpen, setIsOpen] = React.useState(args.in);
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
-  return (
-    <Flex display="flex" flexDirection="column" alignItems="center">
-      <Spacer pt={3} />
-      <ToggleButton checked={isOpen} onChange={handleToggle} />
-      <Spacer pt={3} />
-      <Grow {...args} in={isOpen}>
-        <div
-          style={{
-            width: "100px",
-            height: "100px",
-            backgroundColor: "blue",
-          }}
-        />
-      </Grow>
-    </Flex>
-  );
+export const Example: StoryObj<typeof Grow> = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = React.useState(args.in);
+    const handleToggle = () => {
+      setIsOpen(!isOpen);
+    };
+    return (
+      <Flex display="flex" flexDirection="column" alignItems="center">
+        <Spacer pt={3} />
+        <ToggleButton checked={isOpen} onChange={handleToggle} />
+        <Spacer pt={3} />
+        <Grow {...args} in={isOpen}>
+          <div
+            style={{
+              width: "100px",
+              height: "100px",
+              backgroundColor: "blue",
+            }}
+          />
+        </Grow>
+      </Flex>
+    );
+  },
 };

--- a/src/components/LoadingBar/LoadingBar.stories.tsx
+++ b/src/components/LoadingBar/LoadingBar.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import LoadingBar from "./LoadingBar";
-import { ComponentStory } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 export default {
   title: "Components/Feedback/LoadingBar",
@@ -20,8 +20,10 @@ export default {
   },
 };
 
-export const Example: ComponentStory<typeof LoadingBar> = (args) => (
-  <div style={{ padding: "24px", backgroundColor: "silver" }}>
-    <LoadingBar {...args} />
-  </div>
-);
+export const Example: StoryObj<typeof LoadingBar> = {
+  render: (args) => (
+    <div style={{ padding: "24px", backgroundColor: "silver" }}>
+      <LoadingBar {...args} />
+    </div>
+  ),
+};

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Menu, { MenuProps } from "./Menu";
 import Button from "../Button";
 import { action } from "@storybook/addon-actions";
@@ -14,11 +15,11 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={
+          <Markdown>
+            {
               "A Menu displays a list of choices. It appears when the user interacts with a button, or other control."
             }
-          />
+          </Markdown>
           <ArgsTable of={Menu} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/MenuList/MenuList.stories.tsx
+++ b/src/components/MenuList/MenuList.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import MenuList, { MenuListProps } from "./MenuList";
 import { action } from "@storybook/addon-actions";
 
@@ -13,9 +14,9 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={`MenuList is a lower-level component that is leveraged [&lt;Menu /&gt;](${window.location.origin}/?path=/docs/components-navigation-menu--example).`}
-          />
+          <Markdown>
+            {`MenuList is a lower-level component that is leveraged [&lt;Menu /&gt;](${window.location.origin}/?path=/docs/components-navigation-menu--example).`}
+          </Markdown>
           <ArgsTable of={MenuList} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/NavigationRail/NavigationRail.stories.tsx
+++ b/src/components/NavigationRail/NavigationRail.stories.tsx
@@ -1,5 +1,6 @@
-import { ArgsTable, Description, Stories, Title } from "@storybook/addon-docs";
+import { ArgsTable, Stories, Title } from "@storybook/addon-docs";
 import { StoryObj } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import React from "react";
 import Flex from "../Flex";
 import Icon from "../Icon";
@@ -27,15 +28,15 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "It implements like Sidebar UI.",
               "",
               "It consists of multiple components.",
               "",
               "Usage example is included in ”Canvas” Tab at header.",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={NavigationRail} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import ScrollArea, { ScrollAreaProps } from "./ScrollArea";
 import Spacer from "../Spacer";
 
@@ -16,13 +17,11 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
-              "Show scroll bar.",
-              "",
-              "**※Only for Mac x Chromium**",
-            ].join("\n")}
-          />
+          <Markdown>
+            {["Show scroll bar.", "", "**※Only for Mac x Chromium**"].join(
+              "\n",
+            )}
+          </Markdown>
           <ArgsTable of={ScrollArea} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -1,5 +1,5 @@
 import { Stories, Title } from "@storybook/addon-docs";
-import { ComponentStory } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { Markdown } from "@storybook/blocks";
 import React from "react";
 import Flex from "../Flex";
@@ -45,25 +45,27 @@ export default {
   },
 };
 
-export const Example: ComponentStory<typeof Slide> = (args) => {
-  const [isOpen, setIsOpen] = React.useState(args.in);
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
-  return (
-    <Flex display="flex" flexDirection="column" alignItems="center">
-      <Spacer pt={3} />
-      <ToggleButton checked={isOpen} onChange={handleToggle} />
-      <Spacer pt={3} />
-      <Slide {...args} in={isOpen}>
-        <div
-          style={{
-            width: "100px",
-            height: "100px",
-            backgroundColor: "blue",
-          }}
-        />
-      </Slide>
-    </Flex>
-  );
+export const Example: StoryObj<typeof Slide> = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = React.useState(args.in);
+    const handleToggle = () => {
+      setIsOpen(!isOpen);
+    };
+    return (
+      <Flex display="flex" flexDirection="column" alignItems="center">
+        <Spacer pt={3} />
+        <ToggleButton checked={isOpen} onChange={handleToggle} />
+        <Spacer pt={3} />
+        <Slide {...args} in={isOpen}>
+          <div
+            style={{
+              width: "100px",
+              height: "100px",
+              backgroundColor: "blue",
+            }}
+          />
+        </Slide>
+      </Flex>
+    );
+  },
 };

--- a/src/components/Slide/Slide.stories.tsx
+++ b/src/components/Slide/Slide.stories.tsx
@@ -1,5 +1,6 @@
-import { Description, Stories, Title } from "@storybook/addon-docs";
+import { Stories, Title } from "@storybook/addon-docs";
 import { ComponentStory } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import React from "react";
 import Flex from "../Flex";
 import Spacer from "../Spacer";
@@ -28,15 +29,15 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               " The wrapper of `<CSSTransition />` that implemented in [react-transition-group](https://reactcommunity.org/react-transition-group).",
               "",
               "It makes easy to implement CSS transitions that uses `transform`.",
               "",
               "Props type is same as [this](https://reactcommunity.org/react-transition-group/transition#Transition-props).",
             ].join("\n")}
-          />
+          </Markdown>
           <Stories includePrimary title="Stories" />
         </>
       ),

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Snackbar, { SnackbarProps } from "./Snackbar";
 import Button from "../Button";
 
@@ -20,7 +21,7 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description markdown={"It express `position: fixed;` panel."} />
+          <Markdown>{"It express `position: fixed;` panel."}</Markdown>
           <ArgsTable of={Snackbar} />
           <Stories includePrimary title="Stories" />
         </>

--- a/src/components/Spacer/Spacer.stories.tsx
+++ b/src/components/Spacer/Spacer.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Title, Description, Stories, ArgsTable } from "@storybook/addon-docs";
+import { Title, Stories, ArgsTable } from "@storybook/addon-docs";
 import Spacer from "../Spacer";
 import { StoryObj } from "@storybook/react";
+import { Markdown } from "@storybook/blocks";
 import { SpacerProps } from "../../utils/spacer";
 
 export default {
@@ -17,15 +18,15 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={
+          <Markdown>
+            {
               "Spacer can easier express `margin` & `padding` with simple props."
             }
-          />
+          </Markdown>
           <ArgsTable of={Spacer} />
           <Stories includePrimary title="Stories" />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "## Configuration",
               "",
               "`Margin` and `Padding` actually rendered is dependent on the theme configuration.",
@@ -46,7 +47,7 @@ export default {
               "```",
               "",
             ].join("\n")}
-          />
+          </Markdown>
         </>
       ),
     },

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StoryObj } from "@storybook/react";
-import { Title, Description, ArgsTable, Stories } from "@storybook/addon-docs";
+import { Markdown } from "@storybook/blocks";
+import { Title, ArgsTable, Stories } from "@storybook/addon-docs";
 import Toast, { ToastProps } from "./Toast";
 import Button from "../Button";
 
@@ -19,13 +20,13 @@ export default {
       page: () => (
         <>
           <Title />
-          <Description
-            markdown={[
+          <Markdown>
+            {[
               "`<Toast />` and related methods are the wrapper of [react-toast-notifications](https://github.com/jossmac/react-toast-notifications).",
               "",
               "The toast is used to show alerts on top of an overlay. The toast will close itself when the close button is clicked, or after a timeout.",
             ].join("\n")}
-          />
+          </Markdown>
           <ArgsTable of={Toast} />
           <Stories includePrimary title="Stories" />
         </>


### PR DESCRIPTION
やったこと
- `<Description markdown=`の書き方を`<Markdown>`に変更
- `ComponentStory`を`StoryObj`に変更

close #1227