### PR TITLE
Add build process on CI 

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,3 +18,5 @@ jobs:
         run: make -f ci.mk lint
       - name: test
         run: make -f ci.mk test
+      - name: build
+        run: make -f ci.mk build

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test-and-lint:
+  test-lint-and-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ci.mk
+++ b/ci.mk
@@ -21,6 +21,9 @@ test:
 lint:
 	yarn lint
 
+build:
+	yarn build
+
 release_version:
 	npm config set git-tag-version false
 	npm version ${RELEASE_VERSION}


### PR DESCRIPTION
ref https://github.com/voyagegroup/ingred-ui/pull/1269#issuecomment-1544971538

ビルド周りのワークフローが GitHub 上でうまく行ってるかわからないのでビルドもするようにした。
実際 https://github.com/voyagegroup/ingred-ui/pull/1269 ではビルドが落ちるのにも関わらず CI はパスしてる。