### PR TITLE
ConfirmModal のキャンセルボタンの色を secondary から clear にする

### DIFF
--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -138,7 +138,7 @@ const ConfirmModal = React.forwardRef<HTMLDivElement, ConfirmModalProps>(
                   <Flex display="flex" alignItems="center">
                     <Button
                       type="button"
-                      color="secondary"
+                      color="clear"
                       inline={true}
                       onClick={handleClose("clickCancelButton")}
                     >


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

Publisher Console の [PR](https://github.com/voyagegroup/fluct_ms/pull/8494#pullrequestreview-1521259007) にて以下コメントがあり、INGRED UI 側がアップデートされていないとのことなので対応した
> 現在secondary buttonを使っていますが、これをclear buttonを使って実装してください。（背景色がないタイプです）

## Check List (If️ you added new component in this PR)
- [x] Export the component in `src/components/index.ts`
- [x] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [x] Localize added component
