### PR TITLE
Fix Release PR actions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,7 +19,7 @@ jobs:
         run: make -f ci.mk install
       - name: check changesets
         run: make -f ci.mk check_changesets
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'FluctMember'
       - name: lint
         run: make -f ci.mk lint
       - name: test


### PR DESCRIPTION
リリース用の PR #1360 の CI が落ちてる。
理由は changeset がないから。

FluctMember が作った PR は changeset のチェックをしない。