### PR TITLE
Fix date and daterange type to `Dayjs | null`

### DIFF
--- a/.changeset/tall-sheep-call.md
+++ b/.changeset/tall-sheep-call.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix date and daterange type to `Dayjs | null`

--- a/src/components/Calendar/CalendarRange/CalendarRange.stories.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj } from "@storybook/react";
 
 import CalendarRange, { CalendarRangeProps } from "./CalendarRange";
 import dayjs from "dayjs";
+import { DateRange } from "./types";
 
 export default {
   title: "Components/Inputs/CalendarRange",
@@ -11,15 +12,12 @@ export default {
 
 export const Default: StoryObj<CalendarRangeProps> = {
   render: () => {
-    const [date, setDate] = React.useState({
+    const [date, setDate] = React.useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "week"),
     });
 
-    const handleDatesChange = (date: {
-      startDate: dayjs.Dayjs;
-      endDate: dayjs.Dayjs;
-    }) => {
+    const handleDatesChange = (date: DateRange) => {
       setDate(date);
     };
 
@@ -35,7 +33,7 @@ export const Default: StoryObj<CalendarRangeProps> = {
 
 export const WithActions: StoryObj<CalendarRangeProps> = {
   render: () => {
-    const [date, setDate] = React.useState({
+    const [date, setDate] = React.useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "week"),
     });
@@ -58,10 +56,7 @@ export const WithActions: StoryObj<CalendarRangeProps> = {
       },
     ];
 
-    const handleDatesChange = (date: {
-      startDate: dayjs.Dayjs;
-      endDate: dayjs.Dayjs;
-    }) => {
+    const handleDatesChange = (date: DateRange) => {
       setDate(date);
     };
 

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -18,8 +18,8 @@ import { ClickState, ClickStateType } from "./constants";
 import { DateRange } from "./types";
 
 export type CalendarRangeProps = React.HTMLAttributes<HTMLDivElement> & {
-  startDate: Dayjs;
-  endDate: Dayjs;
+  startDate: Dayjs | null;
+  endDate: Dayjs | null;
   actions?: Action[];
   /**
    * 親コンポーネントで calendar を任意のタイミングで閉じたい場合に使用する
@@ -58,7 +58,7 @@ export const CalendarRange = forwardRef<HTMLDivElement, CalendarRangeProps>(
     );
 
     const handleDateChange = useCallback(
-      (value: Dayjs) => {
+      (value: Dayjs | null) => {
         onClose && onClose(clickState);
         switch (clickState) {
           case ClickState.START:

--- a/src/components/Calendar/CalendarRange/internal/Day/Day.tsx
+++ b/src/components/Calendar/CalendarRange/internal/Day/Day.tsx
@@ -5,8 +5,8 @@ import { DayState, DayStateType } from "../../constants";
 
 type Props = {
   state: DayStateType;
-  value: Dayjs;
-  onClickDate?: (value: Dayjs) => void;
+  value: Dayjs | null;
+  onClickDate?: (value: Dayjs | null) => void;
   children: ReactNode;
 };
 

--- a/src/components/Calendar/CalendarRange/types.ts
+++ b/src/components/Calendar/CalendarRange/types.ts
@@ -1,6 +1,6 @@
 import { Dayjs } from "dayjs";
 
 export type DateRange = {
-  startDate: Dayjs;
-  endDate: Dayjs;
+  startDate: Dayjs | null;
+  endDate: Dayjs | null;
 };

--- a/src/components/DateField/DateRangeField/DateRangeField.stories.tsx
+++ b/src/components/DateField/DateRangeField/DateRangeField.stories.tsx
@@ -2,6 +2,7 @@ import { StoryObj } from "@storybook/react";
 import DateRangeField, { DateRangeFieldProps } from "./DateRangeField";
 import dayjs from "dayjs";
 import React, { useState } from "react";
+import { DateRange } from "../../Calendar/CalendarRange/types";
 
 export default {
   title: "Components/Inputs/DateRangeField",
@@ -10,7 +11,7 @@ export default {
 
 export const Example: StoryObj<DateRangeFieldProps> = {
   render: (args) => {
-    const [date, setDate] = useState({
+    const [date, setDate] = useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "day"),
     });
@@ -23,7 +24,7 @@ export const Custom: StoryObj<DateRangeFieldProps> = {
     format: "MM/DD/YYYY",
   },
   render: (args) => {
-    const [date, setDate] = useState({
+    const [date, setDate] = useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "day"),
     });

--- a/src/components/DateField/DateRangeField/DateRangeField.tsx
+++ b/src/components/DateField/DateRangeField/DateRangeField.tsx
@@ -8,17 +8,13 @@ import {
   ClickState,
   ClickStateType,
 } from "../../Calendar/CalendarRange/constants";
-
-type Range = {
-  startDate: Dayjs;
-  endDate: Dayjs;
-};
+import { DateRange } from "../../Calendar/CalendarRange/types";
 
 export type DateRangeFieldProps = {
-  date: Range;
+  date: DateRange;
   format?: string;
   onClickCalendarIcon?: () => void;
-  onDatesChange?: (date: Range) => void;
+  onDatesChange?: (date: DateRange) => void;
 };
 
 const DateRangeField = forwardRef<HTMLInputElement, DateRangeFieldProps>(

--- a/src/components/NewDateRangePicker/NewDateRangePicker.stories.tsx
+++ b/src/components/NewDateRangePicker/NewDateRangePicker.stories.tsx
@@ -4,6 +4,7 @@ import NewDateRangePicker, {
 } from "./NewDateRangePicker";
 import dayjs from "dayjs";
 import React, { useState } from "react";
+import { DateRange } from "../Calendar/CalendarRange/types";
 
 export default {
   title: "Components/Inputs/NewDateRangePicker",
@@ -15,7 +16,7 @@ export default {
 
 export const Example: StoryObj<NewDateRangePickerProps> = {
   render: (args) => {
-    const [date, setDate] = useState({
+    const [date, setDate] = useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "week"),
     });
@@ -33,7 +34,7 @@ export const Example: StoryObj<NewDateRangePickerProps> = {
 
 export const WithActions: StoryObj<NewDateRangePickerProps> = {
   render: (args) => {
-    const [date, setDate] = useState({
+    const [date, setDate] = useState<DateRange>({
       startDate: dayjs(),
       endDate: dayjs().add(1, "week"),
     });

--- a/src/components/NewDateRangePicker/NewDateRangePicker.tsx
+++ b/src/components/NewDateRangePicker/NewDateRangePicker.tsx
@@ -18,8 +18,8 @@ import {
 import { DateRange } from "../Calendar/CalendarRange/types";
 
 export type NewDateRangePickerProps = {
-  startDate: Dayjs;
-  endDate: Dayjs;
+  startDate: Dayjs | null;
+  endDate: Dayjs | null;
   actions?: Action[];
   onDatesChange: (date: DateRange) => void;
 };


### PR DESCRIPTION
#975

date prop は null 許容にする。

- 確かに現状の社内のユースケース的には null なくてもいいんだけど、含める方向に倒したい
- なぜなら dayjs の一部の関数の戻り値が null を含むから
  - null が来る可能性があることを明示したい
  - dayjs 関数自体は null こないはず
    - https://github.com/iamkun/dayjs/blob/dev/types/index.d.ts#L5-L9 
  - min/max とかは null がくる
    - https://github.com/iamkun/dayjs/blob/a9d7d0398d22ebd4bfc3812ca0134a97606d54d9/types/plugin/minMax.d.ts#L7-L10 
- DatePicker は汎用かつスケールするようにある程度の状態管理や locale 等の値の扱いはユーザーに委ねるようにしている、そのためこういう null が来る可能性がある場合を十分に吸収し切れる形にしておきたい
- date prop が `Dayjs | null` なのであれば onDateChange prop は `(value: Dayjs | null ) => void` になるべきなのでそこに寄せている
