### PR TITLE
Fix types

### DIFF
--- a/.changeset/nice-kings-walk.md
+++ b/.changeset/nice-kings-walk.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix types

--- a/src/components/Calendar/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar/Calendar.tsx
@@ -15,7 +15,14 @@ import { useScroll } from "../hooks/useScroll";
 import { Action, Actions } from "../internal/Actions";
 
 export type CalendarProps = React.HTMLAttributes<HTMLDivElement> & {
+  /**
+   * 日付
+   * @default dayjs()
+   */
   date: Dayjs;
+  /**
+   * カレンダーの左に表示するアクション
+   */
   actions?: Action[];
   /**
    * 閉じるボタンを押したときの振る舞い
@@ -28,6 +35,9 @@ export type CalendarProps = React.HTMLAttributes<HTMLDivElement> & {
    * @default () => false
    */
   isOutsideRange?: (date: Dayjs) => boolean;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
   onDateChange: (value: Dayjs) => void;
 };
 

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -1,5 +1,5 @@
 import dayjs, { Dayjs } from "dayjs";
-import { Card, Icon, ScrollArea, Typography } from "../..";
+import { Card, Icon, ScrollArea, Typography, DateRange } from "../..";
 import React, { forwardRef, memo, useCallback, useRef, useState } from "react";
 import { Day } from "./internal/Day";
 import { HEIGHT, weekList } from "../constants";
@@ -15,7 +15,6 @@ import { useScroll } from "../hooks/useScroll";
 import { getDayState } from "./utils";
 import { Action, Actions } from "../internal/Actions";
 import { ClickState, ClickStateType } from "./constants";
-import { DateRange } from "./types";
 
 export type CalendarRangeProps = React.HTMLAttributes<HTMLDivElement> & {
   /**
@@ -176,4 +175,5 @@ export const CalendarRange = forwardRef<HTMLDivElement, CalendarRangeProps>(
   },
 );
 
+export type { DateRange };
 export default memo(CalendarRange);

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -50,7 +50,7 @@ export type CalendarRangeProps = React.HTMLAttributes<HTMLDivElement> & {
   /**
    * 日付が変更されたときに呼ばれる関数
    */
-  onDatesChange: ({ startDate, endDate }: DateRange) => void;
+  onDatesChange: (dates: DateRange) => void;
 };
 
 /**

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -18,8 +18,19 @@ import { ClickState, ClickStateType } from "./constants";
 import { DateRange } from "./types";
 
 export type CalendarRangeProps = React.HTMLAttributes<HTMLDivElement> & {
+  /**
+   * 開始日
+   * @default dayjs()
+   */
   startDate: Dayjs;
+  /**
+   * 終了日
+   * @default dayjs()
+   */
   endDate: Dayjs;
+  /**
+   * カレンダーの左に表示するアクション
+   */
   actions?: Action[];
   /**
    * 親コンポーネントで calendar を任意のタイミングで閉じたい場合に使用する
@@ -36,6 +47,9 @@ export type CalendarRangeProps = React.HTMLAttributes<HTMLDivElement> & {
    * @default () => false
    */
   isOutsideRange?: (date: Dayjs) => boolean;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
   onDatesChange: ({ startDate, endDate }: DateRange) => void;
 };
 

--- a/src/components/Calendar/CalendarRange/index.ts
+++ b/src/components/Calendar/CalendarRange/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./CalendarRange";
-export type { CalendarRangeProps } from "./CalendarRange";
+export type { CalendarRangeProps, DateRange } from "./CalendarRange";

--- a/src/components/Calendar/CalendarRange/types.ts
+++ b/src/components/Calendar/CalendarRange/types.ts
@@ -1,6 +1,0 @@
-import { Dayjs } from "dayjs";
-
-export type DateRange = {
-  startDate: Dayjs;
-  endDate: Dayjs;
-};

--- a/src/components/DateField/DateField/DateField.tsx
+++ b/src/components/DateField/DateField/DateField.tsx
@@ -3,7 +3,37 @@ import { ErrorText, Icon, Input, Spacer } from "../..";
 import { useDateField } from "../useDateField";
 import { useMergeRefs } from "../../../hooks/useMergeRefs";
 import { CalendarIcon, InputContainer } from "./styled";
-import { DateFieldProps } from "../types";
+import { Dayjs } from "dayjs";
+
+export type DateFieldProps = {
+  /**
+   * 日付
+   * @default dayjs()
+   */
+  date: Dayjs;
+  /**
+   * 指定したい format
+   * @default YYYY-MM-DD
+   */
+  format?: string;
+  /**
+   * エラーメッセージのテキスト
+   */
+  errorText?: string;
+  /**
+   * 入力を無効にする
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
+  onDateChange?: (date: Dayjs) => void;
+  /**
+   * カレンダーアイコンをクリックした時に呼ばれる関数
+   */
+  onClick: () => void;
+};
 
 const DateField = forwardRef<HTMLInputElement, DateFieldProps>(
   function DateField(
@@ -38,5 +68,4 @@ const DateField = forwardRef<HTMLInputElement, DateFieldProps>(
   },
 );
 
-export type { DateFieldProps } from "../types";
 export default memo(DateField);

--- a/src/components/DateField/DateRangeField/DateRangeField.tsx
+++ b/src/components/DateField/DateRangeField/DateRangeField.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, memo, useMemo } from "react";
-import { ErrorText, Icon, Input, Spacer } from "../..";
+import { ErrorText, Icon, Input, Spacer, DateRange } from "../..";
 import { useMergeRefs } from "../../../hooks/useMergeRefs";
 import { CalendarIcon, InputContainer } from "./styled";
 import { Dayjs } from "dayjs";
@@ -8,12 +8,6 @@ import {
   ClickState,
   ClickStateType,
 } from "../../Calendar/CalendarRange/constants";
-import { DateRange } from "../../Calendar/CalendarRange/types";
-
-type Range = {
-  startDate: Dayjs;
-  endDate: Dayjs;
-};
 
 export type DateRangeFieldProps = {
   /**
@@ -42,7 +36,7 @@ export type DateRangeFieldProps = {
   /**
    * 日付が変更されたときに呼ばれる関数
    */
-  onDatesChange?: (date: Range) => void;
+  onDatesChange?: (date: DateRange) => void;
 };
 
 const DateRangeField = forwardRef<HTMLInputElement, DateRangeFieldProps>(

--- a/src/components/DateField/DateRangeField/DateRangeField.tsx
+++ b/src/components/DateField/DateRangeField/DateRangeField.tsx
@@ -8,6 +8,7 @@ import {
   ClickState,
   ClickStateType,
 } from "../../Calendar/CalendarRange/constants";
+import { DateRange } from "../../Calendar/CalendarRange/types";
 
 type Range = {
   startDate: Dayjs;
@@ -15,15 +16,32 @@ type Range = {
 };
 
 export type DateRangeFieldProps = {
-  date: Range;
+  /**
+   * 日付
+   * @default { startDate: dayjs(), endDate: dayjs() }
+   */
+  date: DateRange;
+  /**
+   * 指定したい format
+   * @default YYYY-MM-DD
+   */
   format?: string;
+  /**
+   * エラーメッセージのテキスト
+   */
   errorText?: string;
   /**
    * 入力を無効にする
    * @default false
    */
   disabled?: boolean;
+  /**
+   * カレンダーアイコンをクリックした時に呼ばれる関数
+   */
   onClickCalendarIcon?: () => void;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
   onDatesChange?: (date: Range) => void;
 };
 

--- a/src/components/DateField/types.ts
+++ b/src/components/DateField/types.ts
@@ -1,34 +1,4 @@
-import { Dayjs } from "dayjs";
-
-export type DateFieldProps = {
-  /**
-   * 日付
-   * @default dayjs()
-   */
-  date: Dayjs;
-  /**
-   * 指定したい format
-   * @default YYYY-MM-DD
-   */
-  format?: string;
-  /**
-   * エラーメッセージのテキスト
-   */
-  errorText?: string;
-  /**
-   * 入力を無効にする
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * 日付が変更されたときに呼ばれる関数
-   */
-  onDateChange?: (date: Dayjs) => void;
-  /**
-   * カレンダーアイコンをクリックした時に呼ばれる関数
-   */
-  onClick: () => void;
-};
+import { DateFieldProps } from "./DateField/DateField";
 
 export type UseDateFieldProps = Omit<DateFieldProps, "onClick">;
 

--- a/src/components/NewDatePicker/NewDatePicker.tsx
+++ b/src/components/NewDatePicker/NewDatePicker.tsx
@@ -12,10 +12,28 @@ import {
 } from "@floating-ui/react";
 
 export type NewDatePickerProps = {
+  /**
+   * 日付
+   * @default dayjs()
+   */
   date: Dayjs;
+  /**
+   * カレンダーの左に表示するアクション
+   */
   actions?: Action[];
+  /**
+   * 指定したい format
+   * @default YYYY-MM-DD
+   */
   format?: string;
+  /**
+   * エラーメッセージのテキスト
+   */
   errorText?: string;
+  /**
+   * 入力を無効にする
+   * @default false
+   */
   disabled?: boolean;
   /**
    * 選択可能なカレンダーの領域を制限する
@@ -23,6 +41,9 @@ export type NewDatePickerProps = {
    * @default () => false
    */
   isOutsideRange?: (date: Dayjs) => boolean;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
   onDateChange: (date: Dayjs) => void;
 };
 

--- a/src/components/NewDateRangePicker/NewDateRangePicker.tsx
+++ b/src/components/NewDateRangePicker/NewDateRangePicker.tsx
@@ -50,7 +50,7 @@ export type NewDateRangePickerProps = {
   /**
    * 日付が変更されたときに呼ばれる関数
    */
-  onDatesChange: (date: DateRange) => void;
+  onDatesChange: (dates: DateRange) => void;
 };
 
 /**

--- a/src/components/NewDateRangePicker/NewDateRangePicker.tsx
+++ b/src/components/NewDateRangePicker/NewDateRangePicker.tsx
@@ -15,7 +15,11 @@ import {
   ClickState,
   ClickStateType,
 } from "../Calendar/CalendarRange/constants";
-import { DateRange } from "../Calendar/CalendarRange/types";
+
+export type DateRange = {
+  startDate: Dayjs;
+  endDate: Dayjs;
+};
 
 export type NewDateRangePickerProps = {
   /**

--- a/src/components/NewDateRangePicker/NewDateRangePicker.tsx
+++ b/src/components/NewDateRangePicker/NewDateRangePicker.tsx
@@ -18,10 +18,28 @@ import {
 import { DateRange } from "../Calendar/CalendarRange/types";
 
 export type NewDateRangePickerProps = {
+  /**
+   * 開始日
+   * @default dayjs()
+   */
   startDate: Dayjs;
+  /**
+   * 終了日
+   * @default dayjs()
+   */
   endDate: Dayjs;
+  /**
+   * エラーメッセージのテキスト
+   */
   errorText?: string;
+  /**
+   * カレンダーの左に表示するアクション
+   */
   actions?: Action[];
+  /**
+   * 入力を無効にする
+   * @default false
+   */
   disabled?: boolean;
   /**
    * 選択可能なカレンダーの領域を制限する
@@ -29,6 +47,9 @@ export type NewDateRangePickerProps = {
    * @default () => false
    */
   isOutsideRange?: (date: Dayjs) => boolean;
+  /**
+   * 日付が変更されたときに呼ばれる関数
+   */
   onDatesChange: (date: DateRange) => void;
 };
 

--- a/src/components/NewDateRangePicker/index.ts
+++ b/src/components/NewDateRangePicker/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./NewDateRangePicker";
+export type { NewDateRangePickerProps, DateRange } from "./NewDateRangePicker";


### PR DESCRIPTION
#975 

型定義の整理。

- `DateRange` を `NewDateRangePicker` から export するように
- Doc コメントの追加
- `DateFieldProps` の移動（コンポーネントと同じファイルに置くように）