### PR TITLE
Fix separate check changeset status

### DIFF
--- a/.github/actions/setup-yarn/action.yaml
+++ b/.github/actions/setup-yarn/action.yaml
@@ -1,0 +1,17 @@
+name: setup-yarn
+description: "Setup yarn"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+    - name: install
+      shell: bash
+      run: make -f ci.mk install

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -10,6 +10,7 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-yarn
       - name: install
         run: make -f ci.mk install

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-yarn
-      - name: install
-        run: make -f ci.mk install
       - name: check changesets
         run: make -f ci.mk check_changesets
         if: github.actor != 'dependabot[bot]' && github.actor != 'FluctMember'

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -1,7 +1,10 @@
-name: PR Check
+name: need changeset
 
 on:
   pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/changeset.yaml"
 
 jobs:
   test-lint-and-build:
@@ -17,9 +20,6 @@ jobs:
           node-version: 18.x
       - name: install
         run: make -f ci.mk install
-      - name: lint
-        run: make -f ci.mk lint
-      - name: test
-        run: make -f ci.mk test
-      - name: build
-        run: make -f ci.mk build
+      - name: check changesets
+        run: make -f ci.mk check_changesets
+        if: github.actor != 'dependabot[bot]' && github.actor != 'FluctMember'

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -10,14 +10,7 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
+      - uses: ./.github/actions/setup-yarn
       - name: install
         run: make -f ci.mk install
       - name: check changesets

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/changeset.yaml"
 
 jobs:
-  test-lint-and-build:
+  changeset:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,6 +7,7 @@ jobs:
   test-lint-and-build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-yarn
       - name: lint
         run: make -f ci.mk lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,16 +7,7 @@ jobs:
   test-lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - name: install
-        run: make -f ci.mk install
+      - uses: ./.github/actions/setup-yarn
       - name: lint
         run: make -f ci.mk lint
       - name: test

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -200,6 +200,7 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>(function Button(
   },
   ref,
 ) {
+  console.log("hoge");
   const theme = useTheme();
   const colorStyle = getContainerColorStyles(theme)[color];
   const {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -200,7 +200,6 @@ const Button = React.forwardRef<HTMLElement, ButtonProps>(function Button(
   },
   ref,
 ) {
-  console.log("hoge");
   const theme = useTheme();
   const colorStyle = getContainerColorStyles(theme)[color];
   const {


### PR DESCRIPTION
https://github.com/voyagegroup/ingred-ui/pull/1400#issuecomment-1704457328

changeset の CI は src 配下に変更が入ったときのみ走らせる。
本来、changeset が必要なシーンはリリースノートにログを載せたいときであり、README の変更等でいちいち走らせるべきではない。

実際、dependabot の PR は check しないという意思決定を過去に行っている。
https://github.com/voyagegroup/ingred-ui/pull/1346


**やったこと**

- changeset status を行うワークフローの分離
  - src の下に変更が入ったときのみ changeset status が落ちるように
  - 他は落ちないけど、もしリリースノートに載せたいような変更を src の外でした場合は都度 changeset コマンド叩いてくださいという感じ
- 共通部分を composite に分離
  - Node.js のセットアップ
  - yarn install