### PR TITLE
Fix monthFormat default value

### DIFF
--- a/.changeset/hip-queens-wonder.md
+++ b/.changeset/hip-queens-wonder.md
@@ -2,4 +2,4 @@
 "ingred-ui": patch
 ---
 
-Fix monthFormat default value
+Fix monthFormat and weekList default value

--- a/.changeset/hip-queens-wonder.md
+++ b/.changeset/hip-queens-wonder.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Fix monthFormat default value

--- a/src/components/Calendar/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar/Calendar.tsx
@@ -46,7 +46,7 @@ export type CalendarProps = React.HTMLAttributes<HTMLDivElement> & {
 const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(
   {
     date,
-    monthFormat,
+    monthFormat = "YYYY年M月",
     weekList,
     actions,
     onClickCloseButton,

--- a/src/components/Calendar/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar/Calendar.tsx
@@ -47,7 +47,7 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(function Calendar(
   {
     date,
     monthFormat = "YYYY年M月",
-    weekList,
+    weekList = ["日", "月", "火", "水", "木", "金", "土"],
     actions,
     onClickCloseButton,
     isOutsideRange = () => false,

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -70,7 +70,7 @@ export const CalendarRange = forwardRef<HTMLDivElement, CalendarRangeProps>(
       startDate,
       endDate,
       monthFormat = "YYYY年M月",
-      weekList,
+      weekList = ["日", "月", "火", "水", "木", "金", "土"],
       actions,
       onClose,
       isOutsideRange = () => false,

--- a/src/components/Calendar/CalendarRange/CalendarRange.tsx
+++ b/src/components/Calendar/CalendarRange/CalendarRange.tsx
@@ -69,7 +69,7 @@ export const CalendarRange = forwardRef<HTMLDivElement, CalendarRangeProps>(
     {
       startDate,
       endDate,
-      monthFormat,
+      monthFormat = "YYYY年M月",
       weekList,
       actions,
       onClose,


### PR DESCRIPTION
#1398 

i18n 対応した際に、カレンダー単体としての動作が壊れてしまったので修正。
具体的な対応内容は以下。

- Calendar/CalendarRange  の monthFormat prop に初期値がなくて dayjs の初期値が入っていたので修正。
- Calendar/CalendarRange  の weekList prop に初期値がなくて曜日が表示されてなかったので修正。

**before**
![image](https://github.com/voyagegroup/ingred-ui/assets/50351271/18da5853-e2c1-4f8f-a770-1593b2e19ec5)

**after**

![image](https://github.com/voyagegroup/ingred-ui/assets/50351271/7e22a901-d9e2-49db-8da9-ed06e3d05261)