### PR TITLE
Fix viewport issue when selecting date

### DIFF
--- a/.changeset/fast-rabbits-beam.md
+++ b/.changeset/fast-rabbits-beam.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix viewport issue when selecting date

--- a/src/components/Calendar/hooks/useScrollCalendar.ts
+++ b/src/components/Calendar/hooks/useScrollCalendar.ts
@@ -37,12 +37,20 @@ export const useScrollCalendar = (
   ]);
 
   useEffect(() => {
-    // 全てのカレンダーに 2023-06 のような名前の className を振ってある
+    if (ref.current === null) return;
     const targets = document.getElementsByClassName(date.format("YYYY-MM"));
     for (const target of Array.from(targets)) {
-      target.scrollIntoView({ block: "start" });
+      const containerHeight = ref.current.clientHeight;
+      // Element には offsetTop と offsetHeight がないので、型を HTMLElement に変換する
+      const t = target as HTMLElement;
+      const targetPositionFromTop = t.offsetTop;
+      const targetHeight = t.offsetHeight;
+
+      const desiredScrollTop =
+        targetPositionFromTop - containerHeight / 2 + targetHeight / 2;
+      ref.current.scrollTop = desiredScrollTop;
     }
-  }, [date]);
+  }, [date, ref]);
 
   useEffect(() => {
     setLoaded({


### PR DESCRIPTION
ref https://github.com/voyagegroup/ingred-ui/issues/975#issuecomment-1717031499

カレンダーを選択すると viewport が行方不明になる問題を解決。

## 動作比較

### プロダクション環境

https://ingred-ui.netlify.app/?path=/docs/components-utils-localeprovider--docs　

カレンダーを表示すると、viewport のトップに行ってしまう。


https://github.com/voyagegroup/ingred-ui/assets/50351271/97fde316-4e21-42e7-888a-471889ef5c96



### 修正後

https://deploy-preview-1415--ingred-ui.netlify.app/?path=/docs/components-utils-localeprovider--docs

カレンダーを表示してもスクロール位置をキープしつつ、選択中の日付も中央に表示している。

https://github.com/voyagegroup/ingred-ui/assets/50351271/3fc14130-0f59-4c64-86b2-70d9630571cf



