### PR TITLE
Fix navidation rail's tyle

### DIFF
--- a/.changeset/spotty-cycles-enjoy.md
+++ b/.changeset/spotty-cycles-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix navigation rail's style

--- a/src/components/NavigationRail/ExpansionMenu/styled.ts
+++ b/src/components/NavigationRail/ExpansionMenu/styled.ts
@@ -7,7 +7,7 @@ export const Container = styled.div<{ isActive: boolean }>`
   display: flex;
   align-items: center;
   padding: ${({ theme }) =>
-    `${theme.spacing * 2}px 0 ${theme.spacing * 2}px ${theme.spacing * 3}px`};
+    `${theme.spacing * 2}px 0 ${theme.spacing * 2}px ${theme.spacing * 2}px`};
   background-color: ${({ isActive, theme }) =>
     isActive ? theme.palette.background.hint : "none"};
 

--- a/src/components/NavigationRail/ExpansionMenuItem/styled.ts
+++ b/src/components/NavigationRail/ExpansionMenuItem/styled.ts
@@ -7,7 +7,7 @@ export const Container = styled.div`
   align-items: center;
   padding: ${({ theme }) =>
     `${theme.spacing * 1.5}px ${theme.spacing * 2}px ${theme.spacing * 1.5}px ${
-      theme.spacing * 7.75
+      theme.spacing * 6.5
     }px`};
 
   &:hover {

--- a/src/components/NavigationRail/Menu/styled.ts
+++ b/src/components/NavigationRail/Menu/styled.ts
@@ -6,10 +6,7 @@ export const Container = styled.div<{ isActive: boolean }>`
   cursor: pointer;
   display: flex;
   align-items: center;
-  padding: ${({ theme }) =>
-    `${theme.spacing * 2}px ${theme.spacing * 2}px ${theme.spacing * 2}px ${
-      theme.spacing * 3
-    }px`};
+  padding: ${({ theme }) => `${theme.spacing * 2}px`};
   background-color: ${({ isActive, theme }) =>
     isActive ? theme.palette.background.hint : "none"};
 

--- a/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
+++ b/src/components/NavigationRail/__tests__/__snapshots__/NavigationRail.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
       >
         <div>
           <div
-            class="sc-hAZoDl byaWhK"
+            class="sc-hAZoDl fUXwKb"
           >
             <div
               class="sc-evZas edbJfk"
@@ -87,7 +87,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
             height="auto"
           >
             <div
-              class="sc-dIouRR bhDYLr"
+              class="sc-dIouRR gWBgmg"
             >
               <div
                 class="sc-jqUVSM jjrUoV sc-hHLeRK cHEVa"
@@ -105,7 +105,7 @@ exports[`NavigationRail component testing NavigationRail 1`] = `
           </div>
         </div>
         <div
-          class="sc-kDDrLX bLjgCb"
+          class="sc-kDDrLX eUrGXR"
         >
           <div
             class="sc-evZas edbJfk"


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
以下を修正
- 大メニューのpadding-leftを16pxにする
- 中メニューのpadding-leftを52pxにする

## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
