### PR TITLE
Auto decrement of time

### DIFF
--- a/.changeset/poor-news-behave.md
+++ b/.changeset/poor-news-behave.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Fix automatic decrement of time

--- a/src/components/DateField/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField/DateField.stories.tsx
@@ -17,7 +17,7 @@ export const Example: StoryObj<DateFieldProps> = {
 
 export const Custom: StoryObj<DateFieldProps> = {
   args: {
-    format: "MM/DD/YYYY",
+    format: "MM/DD/YYYY HH:mm:ss",
   },
   render: (args) => {
     const [date, setDate] = useState(dayjs());

--- a/src/components/DateField/plugin/index.ts
+++ b/src/components/DateField/plugin/index.ts
@@ -9,7 +9,7 @@ const match1 = /\d/; // 0 - 9
 const match2 = /\d\d/; // 00 - 99
 const match3 = /\d{3}/; // 000 - 999
 const match4 = /\d{4}/; // 0000 - 9999
-const match1to2 = /\d\d?/; // 0 - 99
+const match1to2 = /-?\d\d?/; // -99 - 99
 const matchSigned = /[+-]?\d+/; // -inf - inf
 const matchOffset = /[+-]\d\d:?(\d\d)?|Z/; // +00:00 -00:00 +0000 or -0000 +00 or Z
 const matchWord = /\d*[^-_:/,()\s\d]+/; // Word
@@ -220,6 +220,7 @@ const parseFormattedInput = (input, format, utc) => {
     const parser = makeParser(format);
     const { year, month, day, hours, minutes, seconds, milliseconds, zone } =
       parser(input);
+
     const now = new Date();
     const y = year || now.getFullYear();
     // Date オブジェクトに渡す month は 0 から始まるため、ここで -1 する


### PR DESCRIPTION
元々の挙動として、存在しない日付（例えば 0月）を入力した際、自動で演算を行い存在する日付に修正されていた。
しかし、時間と分と秒の「下に溢れた時」のみそれが対応されていなかったのでした。

例：2020年12月10日00時00分00秒から時間の部分をデクリメントしたら2020年12月9日23時00分00秒になる）

https://github.com/voyagegroup/ingred-ui/assets/50351271/c16db895-8cf4-46d7-951d-4f77e4389e15

