### PR TITLE
Improved focus experience for useDateField

### DIFF
--- a/.changeset/slow-actors-crash.md
+++ b/.changeset/slow-actors-crash.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Improved focus experience for useDateField

--- a/src/components/DateField/useDateField.ts
+++ b/src/components/DateField/useDateField.ts
@@ -50,6 +50,13 @@ export const useDateField = ({
       );
 
       setPlacement((prev) => {
+        if (!sections[currentSectionIndex].editable) {
+          return {
+            ...prev,
+            current: currentSectionIndex + 1,
+          };
+        }
+
         if (prev.current === currentSectionIndex) {
           return prev;
         }

--- a/src/components/DateField/useDateField.ts
+++ b/src/components/DateField/useDateField.ts
@@ -67,9 +67,7 @@ export const useDateField = ({
     });
   }, [sections]);
 
-  const onFocus = useCallback(() => {
-    setCurrent();
-  }, [setCurrent]);
+  const onFocus = useCallback(() => {}, []);
 
   const onBlur = useCallback(() => {
     setPlacement((prev) => ({


### PR DESCRIPTION
- DateField に最初にフォーカスした時にフォーカス位置がずれるのを修正
- editable が false の位置はフォーカスできないように

https://cartaholdings.slack.com/archives/C02Q8F3FQBC/p1693294230633149