### PR TITLE
Fix DualListBox design

### DIFF
--- a/.changeset/tame-ads-juggle.md
+++ b/.changeset/tame-ads-juggle.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix duallistbox design

--- a/src/components/DualListBox/DualListBox.stories.tsx
+++ b/src/components/DualListBox/DualListBox.stories.tsx
@@ -93,6 +93,20 @@ export const Nested: StoryObj<DualListBoxProps> = {
             },
           ],
         },
+        {
+          id: "4",
+          content: "huga",
+          items: [
+            {
+              id: "23",
+              content: "huga1",
+            },
+            {
+              id: "24",
+              content: "huga2",
+            },
+          ],
+        },
       ],
       [],
     );

--- a/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
+++ b/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DualListBox component testing DualListBox 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bczRLJ jKPMRM"
+    class="sc-bczRLJ kuSbTi"
   >
     <ul
       class="sc-jqUVSM bBFcLq"
@@ -45,7 +45,7 @@ exports[`DualListBox component testing DualListBox 1`] = `
 exports[`DualListBox component testing DualListBox candidateItems 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bczRLJ jKPMRM"
+    class="sc-bczRLJ kuSbTi"
   >
     <ul
       class="sc-jqUVSM bBFcLq"
@@ -204,7 +204,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
 exports[`DualListBox component testing DualListBox candidateItems and selectedItems 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bczRLJ jKPMRM"
+    class="sc-bczRLJ kuSbTi"
   >
     <ul
       class="sc-jqUVSM bBFcLq"
@@ -484,7 +484,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
 exports[`DualListBox component testing DualListBox candidateItems and selectedItems with inverse 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bczRLJ jKPMRM"
+    class="sc-bczRLJ kuSbTi"
   >
     <ul
       class="sc-jqUVSM bBFcLq"
@@ -764,7 +764,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
 exports[`DualListBox component testing DualListBox selectedItems 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bczRLJ jKPMRM"
+    class="sc-bczRLJ kuSbTi"
   >
     <ul
       class="sc-jqUVSM bBFcLq"

--- a/src/components/DualListBox/internal/CandidateRenderer/styled.ts
+++ b/src/components/DualListBox/internal/CandidateRenderer/styled.ts
@@ -19,7 +19,7 @@ export const UnselectedItem = styled(UnselectedItemBase)`
 `;
 
 export const AccordionWrapper = styled(UnselectedItemBase)`
-border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
+  border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
 `;
 
 export const AccordionComponent = styled(Accordion)`

--- a/src/components/DualListBox/internal/CandidateRenderer/styled.ts
+++ b/src/components/DualListBox/internal/CandidateRenderer/styled.ts
@@ -19,7 +19,7 @@ export const UnselectedItem = styled(UnselectedItemBase)`
 `;
 
 export const AccordionWrapper = styled(UnselectedItemBase)`
-  border-bottom: none;
+border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
 `;
 
 export const AccordionComponent = styled(Accordion)`

--- a/src/components/DualListBox/styled.ts
+++ b/src/components/DualListBox/styled.ts
@@ -6,6 +6,5 @@ export const Container = styled.div`
   border-radius: ${({ theme }) => theme.radius}px;
   display: flex;
   height: 512px;
-  max-width: 1056px;
   overflow: hidden;
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

以下に対応
- Dual listboxの左右の要素の一番下に下線を付ける（アコーディオンのみ）
- Dual listboxのmax-widthを取っ払う

## Check List (If️ you added new component in this PR)
- [x] Export the component in `src/components/index.ts`
- [x] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [x] Localize added component
