### PR TITLE
🥷 DualListBox で規定の Checkbox を使わないケースを実現する

### DIFF
--- a/.changeset/small-moons-crash.md
+++ b/.changeset/small-moons-crash.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": major
+---
+
+Hide Checkbox and RemoveButton in DualListBox if no handler is passed

--- a/src/components/DualListBox/DualListBox.stories.tsx
+++ b/src/components/DualListBox/DualListBox.stories.tsx
@@ -5,7 +5,7 @@ import DualListBox, {
   DualListBoxItem,
   DualListBoxProps,
 } from "./DualListBox";
-import { ActionButton, Flex, Icon, Typography } from "..";
+import { ActionButton, Flex, Icon, Spacer, Typography } from "..";
 import { useTheme } from "../../themes";
 
 export default {
@@ -174,9 +174,8 @@ export const Nested: StoryObj<DualListBoxProps> = {
 };
 
 /**
- * props に onAdd / onRemove を渡さない
  * 規定の Checkbox による選択・選択解除ではなく
- * DualListBoxItem に Button を配置して選択・選択解除を行う
+ * DualListBoxItem に配置した Button による選択・選択解除を行う
  */
 export const WithoutCheckbox: StoryObj<DualListBoxProps> = {
   render: () => {
@@ -200,12 +199,12 @@ export const WithoutCheckbox: StoryObj<DualListBoxProps> = {
       [],
     );
 
-    const [selectedIds, setSelectedIds] = React.useState<string[]>([
-      items[2].id,
-    ]);
+    const [allowedIds, setAllowedIds] = React.useState<string[]>([items[2].id]);
 
-    const handleAdd = (id: string) => {
-      setSelectedIds((prevState) => {
+    const [disallowedIds, setDisallowedIds] = React.useState<string[]>([]);
+
+    const handleAllow = (id: string) => {
+      setAllowedIds((prevState) => {
         if (prevState.includes(id)) {
           return prevState;
         }
@@ -213,58 +212,102 @@ export const WithoutCheckbox: StoryObj<DualListBoxProps> = {
       });
     };
 
-    const handleRemove = (id: string) => {
-      setSelectedIds((prevState) =>
-        prevState.filter((selectedId) => selectedId !== id),
+    const handleDisallow = (id: string) => {
+      setDisallowedIds((prevState) => {
+        if (prevState.includes(id)) {
+          return prevState;
+        }
+        return [...prevState, id];
+      });
+    };
+
+    const handleRemove = (item: DualListBoxItem) => {
+      setAllowedIds((prevState) =>
+        prevState.filter((selectedId) => selectedId !== item.id),
+      );
+      setDisallowedIds((prevState) =>
+        prevState.filter((selectedId) => selectedId !== item.id),
       );
     };
 
     const candidateItems = React.useMemo(
       () =>
         items
-          .filter((item) => !selectedIds.includes(item.id))
+          .filter(
+            (item) =>
+              !allowedIds.includes(item.id) && !disallowedIds.includes(item.id),
+          )
           .map((item) => ({
             id: item.id,
             content: (
-              <Flex alignItems="center" display="flex" gap={1}>
+              <Flex alignItems="center" display="flex" flex={1} gap={1}>
                 <Typography>{item.content}</Typography>
-                <ActionButton
-                  color="primary"
-                  onClick={() => handleAdd(item.id)}
+                <Flex
+                  alignItems="center"
+                  display="flex"
+                  flex={1}
+                  justifyContent="flex-end"
+                  gap={1}
                 >
-                  <Icon color="active" name="check_thin" />
-                </ActionButton>
+                  <ActionButton
+                    color="primary"
+                    onClick={() => handleAllow(item.id)}
+                  >
+                    <Icon color="active" name="check_thin" />
+                  </ActionButton>
+                  <ActionButton
+                    color="warning"
+                    onClick={() => handleDisallow(item.id)}
+                  >
+                    <Icon color={theme.palette.danger.main} name="forbid" />
+                  </ActionButton>
+                </Flex>
               </Flex>
             ),
           })),
-      [items, selectedIds],
+      [allowedIds, disallowedIds, items, theme.palette.danger.main],
     );
 
     const selectedItems = React.useMemo(
       () =>
         items
-          .filter((item) => selectedIds.includes(item.id))
+          .filter(
+            (item) =>
+              allowedIds.includes(item.id) || disallowedIds.includes(item.id),
+          )
           .map((item) => ({
             id: item.id,
             content: (
-              <Flex alignItems="center" display="flex" gap={1}>
+              <Flex alignItems="center" display="flex" flex={1} gap={1}>
                 <Typography>{item.content}</Typography>
-                <ActionButton
-                  color="warning"
-                  onClick={() => handleRemove(item.id)}
+                <Flex
+                  alignItems="center"
+                  display="flex"
+                  flex={1}
+                  justifyContent="flex-end"
+                  gap={1}
                 >
-                  <Icon color={theme.palette.danger.main} name="delete_bin" />
-                </ActionButton>
+                  <Spacer pr={2}>
+                    {allowedIds.includes(item.id) && (
+                      <Icon color="active" name="check_thin" />
+                    )}
+                    {disallowedIds.includes(item.id) && (
+                      <Icon color={theme.palette.danger.main} name="forbid" />
+                    )}
+                  </Spacer>
+                </Flex>
               </Flex>
             ),
           })),
-      [items, selectedIds, theme.palette.danger.main],
+      [allowedIds, disallowedIds, items, theme.palette.danger.main],
     );
 
     return (
       <DualListBox
         candidateItems={candidateItems}
+        disableCheckbox={true}
         selectedItems={selectedItems}
+        onRemove={handleRemove}
       />
     );
   },

--- a/src/components/DualListBox/DualListBox.stories.tsx
+++ b/src/components/DualListBox/DualListBox.stories.tsx
@@ -174,6 +174,7 @@ export const Nested: StoryObj<DualListBoxProps> = {
 };
 
 /**
+ * props に onAdd / onRemove を渡さない
  * 規定の Checkbox による選択・選択解除ではなく
  * DualListBoxItem に Button を配置して選択・選択解除を行う
  */

--- a/src/components/DualListBox/DualListBox.stories.tsx
+++ b/src/components/DualListBox/DualListBox.stories.tsx
@@ -5,6 +5,8 @@ import DualListBox, {
   DualListBoxItem,
   DualListBoxProps,
 } from "./DualListBox";
+import { ActionButton, Flex, Icon, Typography } from "..";
+import { useTheme } from "../../themes";
 
 export default {
   title: "Components/Data Display/DualListBox",
@@ -166,6 +168,102 @@ export const Nested: StoryObj<DualListBoxProps> = {
         selectedItems={selectedItems}
         onAdd={handleAdd}
         onRemove={handleRemove}
+      />
+    );
+  },
+};
+
+/**
+ * 規定の Checkbox による選択・選択解除ではなく
+ * DualListBoxItem に Button を配置して選択・選択解除を行う
+ */
+export const WithoutCheckbox: StoryObj<DualListBoxProps> = {
+  render: () => {
+    const theme = useTheme();
+
+    const items = React.useMemo(
+      () => [
+        {
+          id: "1",
+          content: "foo",
+        },
+        {
+          id: "2",
+          content: "bar",
+        },
+        {
+          id: "3",
+          content: "hoge",
+        },
+      ],
+      [],
+    );
+
+    const [selectedIds, setSelectedIds] = React.useState<string[]>([
+      items[2].id,
+    ]);
+
+    const handleAdd = (id: string) => {
+      setSelectedIds((prevState) => {
+        if (prevState.includes(id)) {
+          return prevState;
+        }
+        return [...prevState, id];
+      });
+    };
+
+    const handleRemove = (id: string) => {
+      setSelectedIds((prevState) =>
+        prevState.filter((selectedId) => selectedId !== id),
+      );
+    };
+
+    const candidateItems = React.useMemo(
+      () =>
+        items
+          .filter((item) => !selectedIds.includes(item.id))
+          .map((item) => ({
+            id: item.id,
+            content: (
+              <Flex alignItems="center" display="flex" gap={1}>
+                <Typography>{item.content}</Typography>
+                <ActionButton
+                  color="primary"
+                  onClick={() => handleAdd(item.id)}
+                >
+                  <Icon color="active" name="check_thin" />
+                </ActionButton>
+              </Flex>
+            ),
+          })),
+      [items, selectedIds],
+    );
+
+    const selectedItems = React.useMemo(
+      () =>
+        items
+          .filter((item) => selectedIds.includes(item.id))
+          .map((item) => ({
+            id: item.id,
+            content: (
+              <Flex alignItems="center" display="flex" gap={1}>
+                <Typography>{item.content}</Typography>
+                <ActionButton
+                  color="warning"
+                  onClick={() => handleRemove(item.id)}
+                >
+                  <Icon color={theme.palette.danger.main} name="delete_bin" />
+                </ActionButton>
+              </Flex>
+            ),
+          })),
+      [items, selectedIds, theme.palette.danger.main],
+    );
+
+    return (
+      <DualListBox
+        candidateItems={candidateItems}
+        selectedItems={selectedItems}
       />
     );
   },

--- a/src/components/DualListBox/DualListBox.tsx
+++ b/src/components/DualListBox/DualListBox.tsx
@@ -19,6 +19,7 @@ export type DualListBoxCandidateItem = DualListBoxItem & {
 export type DualListBoxProps = {
   candidateItems: DualListBoxCandidateItem[];
   selectedItems: DualListBoxItem[];
+  disableCheckbox?: boolean;
   onAdd?: (item: DualListBoxItem) => void;
   onRemove?: (item: DualListBoxItem) => void;
 };
@@ -36,6 +37,7 @@ const DualListBox = React.forwardRef<HTMLDivElement, DualListBoxProps>(
       candidateItems: candidateItemsProp,
       selectedItems,
       selectedItemTitle,
+      disableCheckbox,
       onAdd: handleAdd,
       onRemove: handleRemove,
     } = useLocaleProps({ props: inProps, name: "DualListBox" });
@@ -50,6 +52,7 @@ const DualListBox = React.forwardRef<HTMLDivElement, DualListBoxProps>(
     return (
       <Styled.Container>
         <CandidateRenderer
+          disableCheckbox={disableCheckbox}
           items={candidateItems}
           onAdd={handleAdd}
           onRemove={handleRemove}

--- a/src/components/DualListBox/DualListBox.tsx
+++ b/src/components/DualListBox/DualListBox.tsx
@@ -36,8 +36,8 @@ const DualListBox = React.forwardRef<HTMLDivElement, DualListBoxProps>(
       candidateItems: candidateItemsProp,
       selectedItems,
       selectedItemTitle,
-      onAdd,
-      onRemove,
+      onAdd: handleAdd,
+      onRemove: handleRemove,
     } = useLocaleProps({ props: inProps, name: "DualListBox" });
 
     const theme = useTheme();
@@ -47,24 +47,12 @@ const DualListBox = React.forwardRef<HTMLDivElement, DualListBoxProps>(
       [candidateItemsProp, selectedItems],
     );
 
-    const handleAdd = (item: DualListBoxItem) => {
-      if (onAdd) {
-        onAdd(item);
-      }
-    };
-
-    const handleRemove = (item: DualListBoxItem) => {
-      if (onRemove) {
-        onRemove(item);
-      }
-    };
-
     return (
       <Styled.Container>
         <CandidateRenderer
           items={candidateItems}
           onAdd={handleAdd}
-          onRemove={onRemove}
+          onRemove={handleRemove}
         />
         <Divider color={theme.palette.divider} orientation="vertical" />
         <SelectedList

--- a/src/components/DualListBox/__tests__/DualListBox.test.tsx
+++ b/src/components/DualListBox/__tests__/DualListBox.test.tsx
@@ -118,14 +118,10 @@ describe("DualListBox component testing", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("DualListBox candidateItems and selectedItems with inverse", () => {
+  test("DualListBox candidateItems and selectedItems without checkbox", () => {
     const { asFragment } = renderWithThemeProvider(
       <DualListBox
         candidateItems={[
-          {
-            id: "1",
-            content: "foo",
-          },
           {
             id: "2",
             content: "bar",
@@ -144,20 +140,8 @@ describe("DualListBox component testing", () => {
             id: "1",
             content: "foo",
           },
-          {
-            id: "2",
-            content: "bar",
-          },
-          {
-            id: "3",
-            content: "hoge",
-          },
-          {
-            id: "4",
-            content: "fuga",
-          },
         ]}
-        onAdd={jest.fn()}
+        disableCheckbox={true}
         onRemove={jest.fn()}
       />,
     );

--- a/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
+++ b/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
@@ -14,18 +14,18 @@ exports[`DualListBox component testing DualListBox 1`] = `
       orientation="vertical"
     />
     <div
-      class="sc-bjUoiL hkPZz"
+      class="sc-fEOsli hnUSIG"
     >
       <div
-        class="sc-idiyUo bKIXon"
+        class="sc-bjUoiL hVrQLb"
       >
         <p
-          class="sc-fEOsli fayFCh"
+          class="sc-kgflAQ irzJzh"
           color="#041C33"
           font-size="13px"
         >
           <span
-            class="sc-fEOsli jPgBVF"
+            class="sc-kgflAQ gHoRxB"
             color="#0B82F4"
             font-size="13px"
           >
@@ -35,7 +35,7 @@ exports[`DualListBox component testing DualListBox 1`] = `
         </p>
       </div>
       <ul
-        class="sc-dIouRR"
+        class="sc-idiyUo"
       />
     </div>
   </div>
@@ -68,13 +68,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                foo
-              </p>
+              foo
             </span>
           </label>
         </div>
@@ -97,13 +91,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                bar
-              </p>
+              bar
             </span>
           </label>
         </div>
@@ -126,13 +114,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                hoge
-              </p>
+              hoge
             </span>
           </label>
         </div>
@@ -155,13 +137,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                fuga
-              </p>
+              fuga
             </span>
           </label>
         </div>
@@ -173,18 +149,18 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
       orientation="vertical"
     />
     <div
-      class="sc-bjUoiL hkPZz"
+      class="sc-fEOsli hnUSIG"
     >
       <div
-        class="sc-idiyUo bKIXon"
+        class="sc-bjUoiL hVrQLb"
       >
         <p
-          class="sc-fEOsli fayFCh"
+          class="sc-kgflAQ irzJzh"
           color="#041C33"
           font-size="13px"
         >
           <span
-            class="sc-fEOsli jPgBVF"
+            class="sc-kgflAQ gHoRxB"
             color="#0B82F4"
             font-size="13px"
           >
@@ -194,7 +170,7 @@ exports[`DualListBox component testing DualListBox candidateItems 1`] = `
         </p>
       </div>
       <ul
-        class="sc-dIouRR"
+        class="sc-idiyUo"
       />
     </div>
   </div>
@@ -228,13 +204,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                foo
-              </p>
+              foo
             </span>
           </label>
         </div>
@@ -258,13 +228,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                bar
-              </p>
+              bar
             </span>
           </label>
         </div>
@@ -288,13 +252,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                hoge
-              </p>
+              hoge
             </span>
           </label>
         </div>
@@ -318,13 +276,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
             <span
               class="sc-fnykZs hZrbBW"
             >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                fuga
-              </p>
+              fuga
             </span>
           </label>
         </div>
@@ -336,18 +288,18 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
       orientation="vertical"
     />
     <div
-      class="sc-bjUoiL hkPZz"
+      class="sc-fEOsli hnUSIG"
     >
       <div
-        class="sc-idiyUo bKIXon"
+        class="sc-bjUoiL hVrQLb"
       >
         <p
-          class="sc-fEOsli fayFCh"
+          class="sc-kgflAQ irzJzh"
           color="#041C33"
           font-size="13px"
         >
           <span
-            class="sc-fEOsli jPgBVF"
+            class="sc-kgflAQ gHoRxB"
             color="#0B82F4"
             font-size="13px"
           >
@@ -357,17 +309,17 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
         </p>
       </div>
       <ul
-        class="sc-dIouRR"
+        class="sc-idiyUo"
       >
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           foo
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -389,14 +341,14 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
           </div>
         </li>
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           bar
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -418,14 +370,14 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
           </div>
         </li>
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           hoge
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -447,14 +399,14 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
           </div>
         </li>
         <li
-          class="sc-hHLeRK jXxJVM"
+          class="sc-dIouRR bBTgfH"
         >
           fuga
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -481,7 +433,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
 </DocumentFragment>
 `;
 
-exports[`DualListBox component testing DualListBox candidateItems and selectedItems with inverse 1`] = `
+exports[`DualListBox component testing DualListBox candidateItems and selectedItems without checkbox 1`] = `
 <DocumentFragment>
   <div
     class="sc-bczRLJ kuSbTi"
@@ -493,120 +445,30 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
         class="sc-kDDrLX sc-iqcoie kxcdly dcUJGp"
       >
         <div
-          class="sc-dkzDqf hETaFj"
+          class="sc-dkzDqf cyQQCs"
           display="flex"
         >
-          <label
-            class="sc-hAZoDl cnpnnO"
-          >
-            <input
-              checked=""
-              class="sc-ksZaOG etQTLn"
-              readonly=""
-              type="checkbox"
-            />
-            <span
-              class="sc-fnykZs hZrbBW"
-            >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                foo
-              </p>
-            </span>
-          </label>
+          bar
         </div>
       </li>
       <li
         class="sc-kDDrLX sc-iqcoie kxcdly dcUJGp"
       >
         <div
-          class="sc-dkzDqf hETaFj"
+          class="sc-dkzDqf imhdtk"
           display="flex"
         >
-          <label
-            class="sc-hAZoDl cnpnnO"
-          >
-            <input
-              checked=""
-              class="sc-ksZaOG etQTLn"
-              readonly=""
-              type="checkbox"
-            />
-            <span
-              class="sc-fnykZs hZrbBW"
-            >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                bar
-              </p>
-            </span>
-          </label>
-        </div>
-      </li>
-      <li
-        class="sc-kDDrLX sc-iqcoie kxcdly dcUJGp"
-      >
-        <div
-          class="sc-dkzDqf hETaFj"
-          display="flex"
-        >
-          <label
-            class="sc-hAZoDl cnpnnO"
-          >
-            <input
-              checked=""
-              class="sc-ksZaOG etQTLn"
-              readonly=""
-              type="checkbox"
-            />
-            <span
-              class="sc-fnykZs hZrbBW"
-            >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                hoge
-              </p>
-            </span>
-          </label>
+          hoge
         </div>
       </li>
       <li
         class="sc-kDDrLX sc-iqcoie hlbDuP dcUJGp"
       >
         <div
-          class="sc-dkzDqf hETaFj"
+          class="sc-dkzDqf kMlSag"
           display="flex"
         >
-          <label
-            class="sc-hAZoDl cnpnnO"
-          >
-            <input
-              checked=""
-              class="sc-ksZaOG etQTLn"
-              readonly=""
-              type="checkbox"
-            />
-            <span
-              class="sc-fnykZs hZrbBW"
-            >
-              <p
-                class="sc-fEOsli irbPqM"
-                color="#041C33"
-                font-size="14px"
-              >
-                fuga
-              </p>
-            </span>
-          </label>
+          fuga
         </div>
       </li>
     </ul>
@@ -616,125 +478,38 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
       orientation="vertical"
     />
     <div
-      class="sc-bjUoiL hkPZz"
+      class="sc-fEOsli hnUSIG"
     >
       <div
-        class="sc-idiyUo bKIXon"
+        class="sc-bjUoiL hVrQLb"
       >
         <p
-          class="sc-fEOsli fayFCh"
+          class="sc-kgflAQ irzJzh"
           color="#041C33"
           font-size="13px"
         >
           <span
-            class="sc-fEOsli jPgBVF"
+            class="sc-kgflAQ gHoRxB"
             color="#0B82F4"
             font-size="13px"
           >
-            4 
+            1 
           </span>
           selected
         </p>
       </div>
       <ul
-        class="sc-dIouRR"
+        class="sc-idiyUo"
       >
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR bBTgfH"
         >
           foo
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
-              type="button"
-            >
-              <span
-                class="sc-gsnTZi bkuzTp"
-                size="12"
-              >
-                <svg
-                  fill="none"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M1.45456 1.45449C2.25788 0.65117 3.5605 0.651339 4.36403 1.45487L8.0005 5.09135L11.6374 1.45446C12.4405 0.651345 13.7426 0.651345 14.5457 1.45446L14.5465 1.45522C15.3496 2.25833 15.3496 3.56044 14.5465 4.36356L10.9096 8.00044L14.5447 11.6356C15.3483 12.4391 15.3484 13.7417 14.5451 14.545C13.7418 15.3484 12.4392 15.3482 11.6356 14.5447L8.0005 10.9095L4.36427 14.5458C3.56116 15.3489 2.25905 15.3489 1.45593 14.5458L1.45518 14.545C0.652059 13.7419 0.652059 12.4398 1.45517 11.6367L5.09141 8.00044L1.45493 4.36397C0.6514 3.56043 0.651231 2.25782 1.45456 1.45449Z"
-                    fill="#041C33"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </li>
-        <li
-          class="sc-hHLeRK dPqaSF"
-        >
-          bar
-          <div
-            class="sc-kgflAQ hZAlxa"
-          >
-            <button
-              class="sc-dmRaPn mhBDH"
-              type="button"
-            >
-              <span
-                class="sc-gsnTZi bkuzTp"
-                size="12"
-              >
-                <svg
-                  fill="none"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M1.45456 1.45449C2.25788 0.65117 3.5605 0.651339 4.36403 1.45487L8.0005 5.09135L11.6374 1.45446C12.4405 0.651345 13.7426 0.651345 14.5457 1.45446L14.5465 1.45522C15.3496 2.25833 15.3496 3.56044 14.5465 4.36356L10.9096 8.00044L14.5447 11.6356C15.3483 12.4391 15.3484 13.7417 14.5451 14.545C13.7418 15.3484 12.4392 15.3482 11.6356 14.5447L8.0005 10.9095L4.36427 14.5458C3.56116 15.3489 2.25905 15.3489 1.45593 14.5458L1.45518 14.545C0.652059 13.7419 0.652059 12.4398 1.45517 11.6367L5.09141 8.00044L1.45493 4.36397C0.6514 3.56043 0.651231 2.25782 1.45456 1.45449Z"
-                    fill="#041C33"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </li>
-        <li
-          class="sc-hHLeRK dPqaSF"
-        >
-          hoge
-          <div
-            class="sc-kgflAQ hZAlxa"
-          >
-            <button
-              class="sc-dmRaPn mhBDH"
-              type="button"
-            >
-              <span
-                class="sc-gsnTZi bkuzTp"
-                size="12"
-              >
-                <svg
-                  fill="none"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M1.45456 1.45449C2.25788 0.65117 3.5605 0.651339 4.36403 1.45487L8.0005 5.09135L11.6374 1.45446C12.4405 0.651345 13.7426 0.651345 14.5457 1.45446L14.5465 1.45522C15.3496 2.25833 15.3496 3.56044 14.5465 4.36356L10.9096 8.00044L14.5447 11.6356C15.3483 12.4391 15.3484 13.7417 14.5451 14.545C13.7418 15.3484 12.4392 15.3482 11.6356 14.5447L8.0005 10.9095L4.36427 14.5458C3.56116 15.3489 2.25905 15.3489 1.45593 14.5458L1.45518 14.545C0.652059 13.7419 0.652059 12.4398 1.45517 11.6367L5.09141 8.00044L1.45493 4.36397C0.6514 3.56043 0.651231 2.25782 1.45456 1.45449Z"
-                    fill="#041C33"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </li>
-        <li
-          class="sc-hHLeRK jXxJVM"
-        >
-          fuga
-          <div
-            class="sc-kgflAQ hZAlxa"
-          >
-            <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -775,18 +550,18 @@ exports[`DualListBox component testing DualListBox selectedItems 1`] = `
       orientation="vertical"
     />
     <div
-      class="sc-bjUoiL hkPZz"
+      class="sc-fEOsli hnUSIG"
     >
       <div
-        class="sc-idiyUo bKIXon"
+        class="sc-bjUoiL hVrQLb"
       >
         <p
-          class="sc-fEOsli fayFCh"
+          class="sc-kgflAQ irzJzh"
           color="#041C33"
           font-size="13px"
         >
           <span
-            class="sc-fEOsli jPgBVF"
+            class="sc-kgflAQ gHoRxB"
             color="#0B82F4"
             font-size="13px"
           >
@@ -796,17 +571,17 @@ exports[`DualListBox component testing DualListBox selectedItems 1`] = `
         </p>
       </div>
       <ul
-        class="sc-dIouRR"
+        class="sc-idiyUo"
       >
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           foo
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -828,14 +603,14 @@ exports[`DualListBox component testing DualListBox selectedItems 1`] = `
           </div>
         </li>
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           bar
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -857,14 +632,14 @@ exports[`DualListBox component testing DualListBox selectedItems 1`] = `
           </div>
         </li>
         <li
-          class="sc-hHLeRK dPqaSF"
+          class="sc-dIouRR dpFGJS"
         >
           hoge
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span
@@ -886,14 +661,14 @@ exports[`DualListBox component testing DualListBox selectedItems 1`] = `
           </div>
         </li>
         <li
-          class="sc-hHLeRK jXxJVM"
+          class="sc-dIouRR bBTgfH"
         >
           fuga
           <div
-            class="sc-kgflAQ hZAlxa"
+            class="sc-dmRaPn fQPlCU"
           >
             <button
-              class="sc-dmRaPn mhBDH"
+              class="sc-hHLeRK ekRxkP"
               type="button"
             >
               <span

--- a/src/components/DualListBox/internal/CandidateRenderer/CandidateRenderer.tsx
+++ b/src/components/DualListBox/internal/CandidateRenderer/CandidateRenderer.tsx
@@ -8,9 +8,10 @@ import { DualListBoxCandidateItem, DualListBoxItem } from "../../DualListBox";
  */
 export const CandidateRenderer: React.FunctionComponent<{
   items: DualListBoxCandidateItem[];
+  disableCheckbox?: boolean;
   onAdd?: (item: DualListBoxItem) => void;
   onRemove?: (item: DualListBoxItem) => void;
-}> = ({ items, onAdd, onRemove }) => {
+}> = ({ disableCheckbox, items, onAdd, onRemove }) => {
   return (
     <Styled.Container>
       {items.map((item, i) => (
@@ -39,7 +40,12 @@ export const CandidateRenderer: React.FunctionComponent<{
               key={item.id}
               isLastIndex={i + 1 === items.length}
             >
-              <SelectLabel item={item} onAdd={onAdd} onRemove={onRemove}>
+              <SelectLabel
+                disableCheckbox={disableCheckbox}
+                item={item}
+                onAdd={onAdd}
+                onRemove={onRemove}
+              >
                 {item.content}
               </SelectLabel>
             </Styled.UnselectedItem>

--- a/src/components/DualListBox/internal/CandidateRenderer/internal/SelectLabel/SelectLabel.tsx
+++ b/src/components/DualListBox/internal/CandidateRenderer/internal/SelectLabel/SelectLabel.tsx
@@ -12,7 +12,7 @@ export const SelectLabel: React.FunctionComponent<{
 }> = ({ children, item, onAdd, onRemove }) => {
   return (
     <Flex display="flex" justifyContent="space-between">
-      {item.items ? (
+      {item.items || !onAdd ? (
         <Typography>{children}</Typography>
       ) : (
         <Checkbox

--- a/src/components/DualListBox/internal/CandidateRenderer/internal/SelectLabel/SelectLabel.tsx
+++ b/src/components/DualListBox/internal/CandidateRenderer/internal/SelectLabel/SelectLabel.tsx
@@ -2,18 +2,18 @@ import React from "react";
 import Flex from "../../../../../Flex/Flex";
 import { CandidateItem, DualListBoxItem } from "../../../../DualListBox";
 import Checkbox from "../../../../../Checkbox/Checkbox";
-import Typography from "../../../../../Typography/Typography";
 
 export const SelectLabel: React.FunctionComponent<{
   item: CandidateItem;
+  disableCheckbox?: boolean;
   onAdd?: (item: DualListBoxItem) => void;
   onRemove?: (item: DualListBoxItem) => void;
   children: React.ReactNode;
-}> = ({ children, item, onAdd, onRemove }) => {
+}> = ({ children, disableCheckbox = false, item, onAdd, onRemove }) => {
   return (
     <Flex display="flex" justifyContent="space-between">
-      {item.items || !onAdd ? (
-        <Typography>{children}</Typography>
+      {item.items || disableCheckbox ? (
+        children
       ) : (
         <Checkbox
           checked={item?.selected ?? false}
@@ -26,7 +26,7 @@ export const SelectLabel: React.FunctionComponent<{
             onAdd?.(item);
           }}
         >
-          <Typography>{children}</Typography>
+          {children}
         </Checkbox>
       )}
     </Flex>


### PR DESCRIPTION
## Overview
Pub Con で以下のようなデザインを実現したい。
https://www.figma.com/file/0n9zyTQSyitYzM052ch4WR/branch/Ap0srf48gimH4aI7Yip8dW/Main?type=design&node-id=8353-18815&mode=design&t=yCxrdNlkI26SNE4j-0

## Changed points
- props に onAdd を渡さなかった場合、CandidateRenderer の SelectLabel に Checkbox を表示しない
- props に onRemove を渡さなかった場合、SelectedItem に RemoveButton を表示しない

## Preview URL
https://deploy-preview-1595--ingred-ui.netlify.app/?path=/docs/components-data-display-duallistbox--docs

## Consideration
INGRED UI 内で使われている close アイコンを統一する対応は別途実施予定

例）
**AsIs**
![スクリーンショット 2024-04-11 10 49 48](https://github.com/voyagegroup/ingred-ui/assets/32066680/d55d7da9-809c-4da1-8e68-d7c9168b60ff)

**ToBe**
![image](https://github.com/voyagegroup/ingred-ui/assets/32066680/63566830-605a-4033-9ad4-0c40adeeb533)


<!-- Thanks so much for your PR️!!! -->

## Check List (If️ you added new component in this PR)
- [x] Export the component in `src/components/index.ts`
- [x] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [x] Localize added component
