### PR TITLE
アコーディオンのタイトルの色を変更

### DIFF
--- a/.changeset/forty-plums-stare.md
+++ b/.changeset/forty-plums-stare.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": minor
+---
+
+change color of accordion title

--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Accordion component testing Accordion 1`] = `
     <div
       aria-controls="accordion-content-Accordion Title"
       aria-expanded="false"
-      class="sc-gsnTZi sc-hKMtZM jUiVsm jBPBwg"
+      class="sc-gsnTZi sc-hKMtZM jUiVsm bUQCIu"
       display="flex"
       role="button"
       tabindex="0"
@@ -65,7 +65,7 @@ exports[`Accordion component testing Disable Accordion 1`] = `
     <div
       aria-controls="accordion-content-Accordion Title"
       aria-expanded="false"
-      class="sc-gsnTZi sc-hKMtZM dfqrSd dGjGHA"
+      class="sc-gsnTZi sc-hKMtZM dfqrSd bsPabT"
       disabled=""
       display="flex"
       role="button"

--- a/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Accordion component testing Disable Accordion 1`] = `
     <div
       aria-controls="accordion-content-Accordion Title"
       aria-expanded="false"
-      class="sc-gsnTZi sc-hKMtZM dfqrSd bsPabT"
+      class="sc-gsnTZi sc-hKMtZM dfqrSd dGjGHA"
       disabled=""
       display="flex"
       role="button"

--- a/src/components/Accordion/styled.ts
+++ b/src/components/Accordion/styled.ts
@@ -10,7 +10,7 @@ export const AccordionTitle = styled(Flex)<{
   disabled?: boolean;
 }>`
   background-color: ${({ disabled, theme }) =>
-    disabled ? theme.palette.gray.light : theme.palette.gray.highlight};
+    disabled ? theme.palette.gray.main : theme.palette.gray.light};
   color: ${({ disabled, theme }) =>
     disabled ? theme.palette.text.disabled : "auto"};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};

--- a/src/components/Accordion/styled.ts
+++ b/src/components/Accordion/styled.ts
@@ -10,7 +10,7 @@ export const AccordionTitle = styled(Flex)<{
   disabled?: boolean;
 }>`
   background-color: ${({ disabled, theme }) =>
-    disabled ? theme.palette.gray.main : theme.palette.gray.light};
+    disabled ? theme.palette.gray.light : theme.palette.gray.light};
   color: ${({ disabled, theme }) =>
     disabled ? theme.palette.text.disabled : "auto"};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};

--- a/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
+++ b/src/components/DualListBox/__tests__/__snapshots__/DualListBox.test.tsx.snap
@@ -446,7 +446,7 @@ exports[`DualListBox component testing DualListBox candidateItems and selectedIt
           <div
             aria-controls="accordion-content-[object Object]"
             aria-expanded="false"
-            class="sc-dkzDqf sc-eCYdqJ bURUGj dPPTsR"
+            class="sc-dkzDqf sc-eCYdqJ bURUGj gfrOjD"
             display="flex"
             role="button"
             tabindex="0"


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->
## やったこと
アコーディオンのタイトル部分を１段濃くした

## 関連イシュー
#1623 

## 変更したコンポーネント
https://deploy-preview-1625--ingred-ui.netlify.app/?path=/docs/components-navigation-accordion--docs
![スクリーンショット 2024-05-29 14 50 44](https://github.com/voyagegroup/ingred-ui/assets/74808471/7c3ebcf4-5f9c-484c-a88a-1b48ca43e93e)


## Check List (If️ you added new component in this PR)
- [x] Export the component in `src/components/index.ts`
- [x] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [x] Localize added component
