### PR TITLE
Bugfix: Tooltipの型情報を修正

### DIFF
--- a/.changeset/unlucky-dogs-dream.md
+++ b/.changeset/unlucky-dogs-dream.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix the type information for the Tooltip component

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,7 +22,7 @@ import {
 import { useTheme } from "../../themes";
 import { AutoPlacement, usePlacement } from "../../hooks/usePlacement";
 
-export type TooltipProps = React.ComponentPropsWithoutRef<"div"> & {
+export type TooltipProps = Omit<React.ComponentPropsWithoutRef<"div">, "content"> & {
   content: React.ReactNode;
   open?: boolean;
   disableHoverListener?: boolean;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,7 +22,10 @@ import {
 import { useTheme } from "../../themes";
 import { AutoPlacement, usePlacement } from "../../hooks/usePlacement";
 
-export type TooltipProps = Omit<React.ComponentPropsWithoutRef<"div">, "content"> & {
+export type TooltipProps = Omit<
+  React.ComponentPropsWithoutRef<"div">,
+  "content"
+> & {
   content: React.ReactNode;
   open?: boolean;
   disableHoverListener?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

# 概要

HTML要素のattributesにはcontentが元々存在していることで、TooltipのPropsであるconentと競合が発生しており、誤った型情報となっている

`&`を用いた交差型ではプロパティが競合した場合に型同士の積を取るので、本来的にはReactNode型を許容するはずのcontentが string のみを許容するようになってしまっている

# やったこと

Tooltipにおける競合するプロパティをomitした上で、交差を取るように
