### PR TITLE
MultipleFilterの入力ステップをスキップしたい

### DIFF
--- a/.changeset/red-peas-prove.md
+++ b/.changeset/red-peas-prove.md
@@ -1,5 +1,5 @@
 ---
-"ingred-ui": patch
+"ingred-ui": minor
 ---
 
 Fix MultipleFilter bug and MultipleFilter options can be skipped.

--- a/.changeset/red-peas-prove.md
+++ b/.changeset/red-peas-prove.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Fix MultipleFilter bug and MultipleFilter options can be skipped.

--- a/src/components/MultipleFilter/MultipleFilter.stories.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.stories.tsx
@@ -116,20 +116,20 @@ const skipFilterPacksExample: FilterPackType[] = [
     ],
   },
   {
-        categoryName: "Status",
-        sectionTitle: "",
-        shouldSkipConditionSelecting: true,
-        filters: [
-          {
-            filterName: "",
-            conditionTitle: "",
-            control: {
-              type: "select",
-              options: ["valid", "invalid"],
-            },
-          },
-        ],
+    categoryName: "Status",
+    sectionTitle: "",
+    shouldSkipConditionSelecting: true,
+    filters: [
+      {
+        filterName: "",
+        conditionTitle: "",
+        control: {
+          type: "select",
+          options: ["valid", "invalid"],
+        },
       },
+    ],
+  },
   {
     categoryName: "Condition",
     shouldSkipConditionSelecting: true,
@@ -152,7 +152,6 @@ const skipFilterPacksExample: FilterPackType[] = [
   },
 ];
 
-
 export const Example: StoryObj<MultipleFilterProps> = {
   render: (args) => {
     const [, setFilters] = React.useState<ReferredFilterType[]>([]);
@@ -167,13 +166,13 @@ export const Example: StoryObj<MultipleFilterProps> = {
           filterPacks={filterPacksExample}
           inputErrorText={"Input error text can be customized"}
           formPlaceholder={"Placeholder can be customized"}
-          onChange={handleChange} />
-          <Spacer mb={24} />
-        </>
+          onChange={handleChange}
+        />
+        <Spacer mb={24} />
+      </>
     );
   },
 };
-
 
 export const SkipExample: StoryObj<MultipleFilterProps> = {
   render: (args) => {
@@ -184,15 +183,15 @@ export const SkipExample: StoryObj<MultipleFilterProps> = {
 
     return (
       <>
-      <MultipleFilter
-        {...args}
-        filterPacks={skipFilterPacksExample}
-        inputErrorText={"Input error text can be customized"}
-        formPlaceholder={"Placeholder can be customized"}
-        onChange={handleChange}
-      />
-      <Spacer mb={24} />
-        </>
+        <MultipleFilter
+          {...args}
+          filterPacks={skipFilterPacksExample}
+          inputErrorText={"Input error text can be customized"}
+          formPlaceholder={"Placeholder can be customized"}
+          onChange={handleChange}
+        />
+        <Spacer mb={24} />
+      </>
     );
   },
 };

--- a/src/components/MultipleFilter/MultipleFilter.stories.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { StoryObj } from "@storybook/react";
 import MultipleFilter, { MultipleFilterProps } from "./MultipleFilter";
+import Spacer from "../Spacer";
 import { FilterPackType, ReferredFilterType } from "./types";
 
 export default {
@@ -99,6 +100,59 @@ const filterPacksExample: FilterPackType[] = [
   },
 ];
 
+const skipFilterPacksExample: FilterPackType[] = [
+  {
+    categoryName: "Row name",
+    shouldSkipConditionSelecting: true,
+    sectionTitle: "",
+    filters: [
+      {
+        filterName: "",
+        conditionTitle: "Arbitrary text input",
+        control: {
+          type: "text",
+        },
+      },
+    ],
+  },
+  {
+        categoryName: "Status",
+        sectionTitle: "",
+        shouldSkipConditionSelecting: true,
+        filters: [
+          {
+            filterName: "",
+            conditionTitle: "",
+            control: {
+              type: "select",
+              options: ["valid", "invalid"],
+            },
+          },
+        ],
+      },
+  {
+    categoryName: "Condition",
+    shouldSkipConditionSelecting: true,
+    filters: [
+      {
+        filterName: "",
+        conditionTitle: "",
+        control: {
+          type: "boolean",
+        },
+      },
+      {
+        filterName: "",
+        conditionTitle: "",
+        control: {
+          type: "boolean",
+        },
+      },
+    ],
+  },
+];
+
+
 export const Example: StoryObj<MultipleFilterProps> = {
   render: (args) => {
     const [, setFilters] = React.useState<ReferredFilterType[]>([]);
@@ -107,13 +161,38 @@ export const Example: StoryObj<MultipleFilterProps> = {
     };
 
     return (
+      <>
+        <MultipleFilter
+          {...args}
+          filterPacks={filterPacksExample}
+          inputErrorText={"Input error text can be customized"}
+          formPlaceholder={"Placeholder can be customized"}
+          onChange={handleChange} />
+          <Spacer mb={24} />
+        </>
+    );
+  },
+};
+
+
+export const SkipExample: StoryObj<MultipleFilterProps> = {
+  render: (args) => {
+    const [, setFilters] = React.useState<ReferredFilterType[]>([]);
+    const handleChange = (referredFilters: ReferredFilterType[]) => {
+      setFilters(referredFilters);
+    };
+
+    return (
+      <>
       <MultipleFilter
         {...args}
-        filterPacks={filterPacksExample}
+        filterPacks={skipFilterPacksExample}
         inputErrorText={"Input error text can be customized"}
         formPlaceholder={"Placeholder can be customized"}
         onChange={handleChange}
       />
+      <Spacer mb={24} />
+        </>
     );
   },
 };

--- a/src/components/MultipleFilter/MultipleFilter.stories.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.stories.tsx
@@ -103,8 +103,6 @@ const filterPacksExample: FilterPackType[] = [
 const skipFilterPacksExample: FilterPackType[] = [
   {
     categoryName: "Row name",
-    shouldSkipConditionSelecting: true,
-    sectionTitle: "",
     filters: [
       {
         filterName: "",
@@ -117,12 +115,9 @@ const skipFilterPacksExample: FilterPackType[] = [
   },
   {
     categoryName: "Status",
-    sectionTitle: "",
-    shouldSkipConditionSelecting: true,
     filters: [
       {
         filterName: "",
-        conditionTitle: "",
         control: {
           type: "select",
           options: ["valid", "invalid"],
@@ -132,18 +127,9 @@ const skipFilterPacksExample: FilterPackType[] = [
   },
   {
     categoryName: "Condition",
-    shouldSkipConditionSelecting: true,
     filters: [
       {
         filterName: "",
-        conditionTitle: "",
-        control: {
-          type: "boolean",
-        },
-      },
-      {
-        filterName: "",
-        conditionTitle: "",
         control: {
           type: "boolean",
         },

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -175,14 +175,14 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
           if (filterPack.shouldSkipConditionSelecting) {
             return !currentReferredFilters.some(
               (referredFilter) =>
-                referredFilter.categoryName === filterPack.categoryName
+                referredFilter.categoryName === filterPack.categoryName,
             );
           } else {
             return (
               filterPack.filters.length >
               currentReferredFilters.filter(
                 (referredFilter) =>
-                  referredFilter.categoryName === filterPack.categoryName
+                  referredFilter.categoryName === filterPack.categoryName,
               ).length
             );
           }

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -37,7 +37,6 @@ export type MultipleFilterProps = {
   inputErrorText?: string;
   formPlaceholder?: string;
   width?: string;
-  // skipFilterSection?: boolean;
 };
 
 const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
@@ -52,7 +51,6 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       inputErrorText,
       formPlaceholder,
       width,
-      // skipFilterSection,
     } = props;
 
     const [isClick, setIsClick] = React.useState<boolean>(false);

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -139,6 +139,10 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
         (filterPack) => filterPack.categoryName === referredFilter.categoryName,
       );
       if (willEditFilterPack) {
+        if (willEditFilterPack.filters.length === 1) {
+          willEditFilterPack.filters[0].filterName =
+            willEditFilterPack.categoryName;
+        }
         setEditingLabelElement(event.currentTarget);
         setIsClick(true);
         setSelectedFilterPack(willEditFilterPack);
@@ -171,22 +175,14 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
 
     const getMenuOption = () => {
       return filterPacks
-        ?.filter((filterPack) => {
-          if (filterPack.shouldSkipConditionSelecting) {
-            return !currentReferredFilters.some(
+        ?.filter(
+          (filterPack) =>
+            filterPack.filters.length !==
+            currentReferredFilters.filter(
               (referredFilter) =>
                 referredFilter.categoryName === filterPack.categoryName,
-            );
-          } else {
-            return (
-              filterPack.filters.length >
-              currentReferredFilters.filter(
-                (referredFilter) =>
-                  referredFilter.categoryName === filterPack.categoryName,
-              ).length
-            );
-          }
-        })
+            ).length,
+        )
         .map((filterOption) => ({
           onClick: handleSelect(filterOption),
           text: filterOption.categoryName,

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -222,10 +222,6 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
               />
             </Styled.InputContainer>
             {currentStatus === Status.FilterSelecting && (
-              /* 
-                ポップアップ表示後、外側をクリックしても閉じないので要修正
-                Popoverで表示しているMenuの中でPopoverを使用して表示しているので、そこが原因かもしれない
-              */
               <Popover baseElement={inputElement}>
                 <Menu
                   contents={getMenuOption()}

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -55,7 +55,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       // skipFilterSection,
     } = props;
 
-    const [isFocus, setIsFocus] = React.useState<boolean>(false);
+    const [isClick, setIsClick] = React.useState<boolean>(false);
     const [selectedFilterPack, setSelectedFilterPack] =
       React.useState<FilterPackType | null>(null);
     const theme = useTheme();
@@ -67,7 +67,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
     const [willEditFilter, setWillEditFilter] =
       React.useState<ReferredFilterType | null>(null);
     const currentStatus = getCurrentStatus(
-      isFocus,
+      isClick,
       selectedFilterPack,
       willEditFilter,
     );
@@ -75,8 +75,8 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       ReferredFilterType[]
     >([]);
 
-    const handleOnFocus = () => {
-      setIsFocus(true);
+    const handleOnClick = () => {
+      setIsClick(true);
     };
 
     const handleSelect = (elem: FilterPackType) => () => {
@@ -85,7 +85,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
 
     const handleClose = () => {
       setSelectedFilterPack(null);
-      setIsFocus(false);
+      setIsClick(false);
       setWillEditFilter(null);
     };
 
@@ -94,7 +94,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       reason: "backdropClick" | "clickMenuList",
     ) => {
       if (reason === "backdropClick") {
-        setIsFocus(false);
+        setIsClick(false);
       }
     };
 
@@ -108,7 +108,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       }
 
       setSelectedFilterPack(null);
-      setIsFocus(false);
+      setIsClick(false);
     };
 
     const handleRemove = (removedFilter: ReferredFilterType) => {
@@ -142,7 +142,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       );
       if (willEditFilterPack) {
         setEditingLabelElement(event.currentTarget);
-        setIsFocus(true);
+        setIsClick(true);
         setSelectedFilterPack(willEditFilterPack);
         setWillEditFilter(referredFilter);
       }
@@ -166,7 +166,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
         }
       }
 
-      setIsFocus(false);
+      setIsClick(false);
       setSelectedFilterPack(null);
       setWillEditFilter(null);
     };
@@ -212,7 +212,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
                 readOnly
                 type="text"
                 placeholder={placeholder}
-                onFocus={handleOnFocus}
+                onClick={handleOnClick}
               />
             </Styled.InputContainer>
             {currentStatus === Status.FilterSelecting && (

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -37,6 +37,7 @@ export type MultipleFilterProps = {
   inputErrorText?: string;
   formPlaceholder?: string;
   width?: string;
+  // skipFilterSection?: boolean;
 };
 
 const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
@@ -51,6 +52,7 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
       inputErrorText,
       formPlaceholder,
       width,
+      // skipFilterSection,
     } = props;
 
     const [isFocus, setIsFocus] = React.useState<boolean>(false);
@@ -214,6 +216,10 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
               />
             </Styled.InputContainer>
             {currentStatus === Status.FilterSelecting && (
+              /* 
+                ポップアップ表示後、外側をクリックしても閉じないので要修正
+                Popoverで表示しているMenuの中でPopoverを使用して表示しているので、そこが原因かもしれない
+              */
               <Popover baseElement={inputElement}>
                 <Menu
                   contents={getMenuOption()}

--- a/src/components/MultipleFilter/MultipleFilter.tsx
+++ b/src/components/MultipleFilter/MultipleFilter.tsx
@@ -171,14 +171,22 @@ const MultipleFilter = React.forwardRef<HTMLDivElement, MultipleFilterProps>(
 
     const getMenuOption = () => {
       return filterPacks
-        ?.filter(
-          (filterPack) =>
-            filterPack.filters.length !==
-            currentReferredFilters.filter(
+        ?.filter((filterPack) => {
+          if (filterPack.shouldSkipConditionSelecting) {
+            return !currentReferredFilters.some(
               (referredFilter) =>
-                referredFilter.categoryName === filterPack.categoryName,
-            ).length,
-        )
+                referredFilter.categoryName === filterPack.categoryName
+            );
+          } else {
+            return (
+              filterPack.filters.length >
+              currentReferredFilters.filter(
+                (referredFilter) =>
+                  referredFilter.categoryName === filterPack.categoryName
+              ).length
+            );
+          }
+        })
         .map((filterOption) => ({
           onClick: handleSelect(filterOption),
           text: filterOption.categoryName,

--- a/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
+++ b/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
@@ -44,7 +44,7 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
     inputErrorText = "Please input",
     formPlaceholder = "search",
     sectionTitle = "Section",
-    conditionTitle = "Condition",
+    conditionTitle = "",
     width,
   } = props;
   const theme = useTheme();
@@ -164,12 +164,12 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
             <Spacer py={0.5} />
             <TextField readOnly value={willEditFilter?.filterName} />
             <Spacer py={1} />
-            <Typography weight="bold" size="lg">
-              {filter?.conditionTitle || conditionTitle}
-            </Typography>
-            <Spacer py={0.5} />
           </>
         )}
+        <Typography weight="bold" size="lg">
+          {filter?.conditionTitle || conditionTitle}
+        </Typography>
+        <Spacer py={0.5} />
         {filter && getInputField(filter)}
         <Spacer py={1} />
         <Divider

--- a/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
+++ b/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
@@ -54,9 +54,9 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
   const [textFieldErrorText, setTextFieldErrorText] =
     React.useState<string>("");
 
-  const filter = selectedFilterPack?.filters.find((filter) => {
-    return filter.filterName === willEditFilter?.filterName;
-  });
+  const filter = selectedFilterPack?.filters.find(
+    (filter) => filter.filterName === willEditFilter?.filterName,
+  );
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTextFieldErrorText("");

--- a/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
+++ b/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
@@ -154,17 +154,16 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        {selectedFilterPack?.filters &&
-          selectedFilterPack?.filters.length > 1 && (
-            <>
-              <Typography weight="bold" size="lg">
-                {selectedFilterPack?.sectionTitle || sectionTitle}
-              </Typography>
-              <Spacer py={0.5} />
-              <TextField readOnly value={willEditFilter?.filterName} />
-              <Spacer py={1} />
-            </>
-          )}
+        {(selectedFilterPack?.filters?.length ?? 0) > 1 && (
+          <>
+            <Typography weight="bold" size="lg">
+              {selectedFilterPack?.sectionTitle || sectionTitle}
+            </Typography>
+            <Spacer py={0.5} />
+            <TextField readOnly value={willEditFilter?.filterName} />
+            <Spacer py={1} />
+          </>
+        )}
         <Typography weight="bold" size="lg">
           {filter?.conditionTitle || conditionTitle}
         </Typography>

--- a/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
+++ b/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
@@ -54,9 +54,11 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
   const [textFieldErrorText, setTextFieldErrorText] =
     React.useState<string>("");
 
-  const filter = selectedFilterPack?.filters.find(
-    (filter) => filter.filterName === willEditFilter?.filterName,
-  );
+  const filter = selectedFilterPack?.shouldSkipConditionSelecting
+    ? selectedFilterPack.filters[0]
+    : selectedFilterPack?.filters.find(
+        (filter) => filter.filterName === willEditFilter?.filterName,
+      );
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTextFieldErrorText("");
@@ -154,16 +156,20 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        <Typography weight="bold" size="lg">
-          {selectedFilterPack?.sectionTitle || sectionTitle}
-        </Typography>
-        <Spacer py={0.5} />
-        <TextField readOnly value={willEditFilter?.filterName} />
-        <Spacer py={1} />
-        <Typography weight="bold" size="lg">
-          {filter?.conditionTitle || conditionTitle}
-        </Typography>
-        <Spacer py={0.5} />
+        {!selectedFilterPack?.shouldSkipConditionSelecting && (
+          <>
+            <Typography weight="bold" size="lg">
+              {selectedFilterPack?.sectionTitle || sectionTitle}
+            </Typography>
+            <Spacer py={0.5} />
+            <TextField readOnly value={willEditFilter?.filterName} />
+            <Spacer py={1} />
+            <Typography weight="bold" size="lg">
+              {filter?.conditionTitle || conditionTitle}
+            </Typography>
+            <Spacer py={0.5} />
+          </>
+        )}
         {filter && getInputField(filter)}
         <Spacer py={1} />
         <Divider

--- a/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
+++ b/src/components/MultipleFilter/internal/EditFilterCard/EditFilterCard.tsx
@@ -54,11 +54,9 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
   const [textFieldErrorText, setTextFieldErrorText] =
     React.useState<string>("");
 
-  const filter = selectedFilterPack?.shouldSkipConditionSelecting
-    ? selectedFilterPack.filters[0]
-    : selectedFilterPack?.filters.find(
-        (filter) => filter.filterName === willEditFilter?.filterName,
-      );
+  const filter = selectedFilterPack?.filters.find((filter) => {
+    return filter.filterName === willEditFilter?.filterName;
+  });
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTextFieldErrorText("");
@@ -156,16 +154,17 @@ export const EditFilterCard: React.FunctionComponent<EditFilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        {!selectedFilterPack?.shouldSkipConditionSelecting && (
-          <>
-            <Typography weight="bold" size="lg">
-              {selectedFilterPack?.sectionTitle || sectionTitle}
-            </Typography>
-            <Spacer py={0.5} />
-            <TextField readOnly value={willEditFilter?.filterName} />
-            <Spacer py={1} />
-          </>
-        )}
+        {selectedFilterPack?.filters &&
+          selectedFilterPack?.filters.length > 1 && (
+            <>
+              <Typography weight="bold" size="lg">
+                {selectedFilterPack?.sectionTitle || sectionTitle}
+              </Typography>
+              <Spacer py={0.5} />
+              <TextField readOnly value={willEditFilter?.filterName} />
+              <Spacer py={1} />
+            </>
+          )}
         <Typography weight="bold" size="lg">
           {filter?.conditionTitle || conditionTitle}
         </Typography>

--- a/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
+++ b/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
@@ -48,22 +48,14 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   } = props;
 
   const theme = useTheme();
+  const isMultipleFilters = (selectedFilterPack?.filters?.length ?? 0) > 1;
   const [section, setSection] = React.useState<string | undefined>();
   const [condition, setCondition] = React.useState<string | undefined>();
   const [selectedFilter, setSelectedFilter] = React.useState<
     FilterType | undefined
-  >(
-    selectedFilterPack?.filters.length === 1
-      ? selectedFilterPack.filters[0]
-      : undefined,
-  );
+  >(isMultipleFilters ? undefined : selectedFilterPack?.filters[0]);
   const [textFieldErrorText, setTextFieldErrorText] =
     React.useState<string>("");
-  const isMultipleFilters = selectedFilterPack?.filters.length !== 1;
-  const isSectionSelected = !!section;
-  const isConditionSet = !!condition;
-  const isApplyButtonDisabled =
-    (isMultipleFilters && !isSectionSelected) || !isConditionSet;
 
   const filter = selectedFilterPack?.filters.find(
     (filter) => filter.filterName === selectedFilter?.filterName,
@@ -145,11 +137,10 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   const handleSubmit = () => {
     const newFilter = {
       categoryName: selectedFilterPack?.categoryName as string,
-      filterName:
-        selectedFilterPack?.filters.length === 1
-          ? selectedFilterPack.categoryName
-          : (selectedFilter?.filterName as string),
-      filterType: filter?.control.type as Types,
+      filterName: isMultipleFilters
+        ? (selectedFilter?.filterName as string)
+        : (selectedFilterPack?.categoryName as string),
+      filterType: selectedFilter?.control.type as Types,
       filterCondition: condition,
     };
     onApply(newFilter);
@@ -195,22 +186,21 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        {selectedFilterPack?.filters &&
-          selectedFilterPack.filters.length > 1 && (
-            <>
-              <Typography weight="bold" size="lg">
-                {selectedFilterPack?.sectionTitle || sectionTitle}
-              </Typography>
-              <Spacer py={0.5} />
-              <Select
-                maxMenuHeight={250}
-                options={getUnSelectedOption(options)}
-                autoFocus={true}
-                onChange={handleFilterChange}
-              />
-              <Spacer py={1} />
-            </>
-          )}
+        {isMultipleFilters && (
+          <>
+            <Typography weight="bold" size="lg">
+              {selectedFilterPack?.sectionTitle || sectionTitle}
+            </Typography>
+            <Spacer py={0.5} />
+            <Select
+              maxMenuHeight={250}
+              options={getUnSelectedOption(options)}
+              autoFocus={true}
+              onChange={handleFilterChange}
+            />
+            <Spacer py={1} />
+          </>
+        )}
         {selectedFilter && (
           <div>
             <Typography weight="bold" size="lg">
@@ -231,7 +221,7 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
           <Button
             size="small"
             inline={true}
-            disabled={isApplyButtonDisabled}
+            disabled={(isMultipleFilters && !section) || !condition}
             onClick={handleSubmit}
           >
             {applyButtonTitle}

--- a/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
+++ b/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
@@ -44,7 +44,7 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
     width,
     currentReferredFilters,
     sectionTitle = "Section",
-    conditionTitle = "Condition",
+    conditionTitle = "",
   } = props;
 
   const theme = useTheme();
@@ -185,12 +185,12 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        <Typography weight="bold" size="lg">
-          {selectedFilterPack?.sectionTitle || sectionTitle}
-        </Typography>
-        <Spacer py={0.5} />
         {!selectedFilterPack?.shouldSkipConditionSelecting && (
           <>
+            <Typography weight="bold" size="lg">
+              {selectedFilterPack?.sectionTitle || sectionTitle}
+            </Typography>
+            <Spacer py={0.5} />
             <Select
               maxMenuHeight={250}
               options={getUnSelectedOption(options)}

--- a/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
+++ b/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
@@ -65,6 +65,24 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTextFieldErrorText("");
     setCondition(e.target.value);
+    /* 
+        以下の点から、setSectionにselectedFilterPack.categoryName, setSelectedFilterには、categoryNameと同様のfilterNameを持つfilterを設定
+        1. ステップ省略する際、getUnSelectedOptionを使用して、選択されていないオプションに反映させるため、
+        2. applyButtonのdisabledを活性化する場合、sectionをスキップする時は明示的に設定する必要があるため
+      入力textの場合のデータ構造イメージ
+      {
+        categoryName: "タイトル",
+        filters: [
+            {
+              filterName: "タイトル", 
+              conditionTitle: "任意の文字列",
+              control: {
+              type: "text",
+            },
+          },
+        ],
+      },
+    */ 
   };
 
   const handleBlurInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -134,6 +152,7 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   const handleSubmit = () => {
     const newFilter = {
       categoryName: selectedFilterPack?.categoryName as string,
+      // ここもsectionスキップする場合は、firstFilterNameにcategoryNameを設定
       filterName: selectedFilter?.filterName as string,
       filterType: selectedFilter?.control.type as Types,
       filterCondition: condition,
@@ -182,16 +201,29 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
         <Typography weight="bold" size="lg">
-          {selectedFilterPack?.sectionTitle || sectionTitle}
-        </Typography>
-        <Spacer py={0.5} />
-        <Select
-          maxMenuHeight={250}
-          options={getUnSelectedOption(options)}
-          autoFocus={true}
-          onChange={handleFilterChange}
-        />
-        <Spacer py={1} />
+              {selectedFilterPack?.sectionTitle || sectionTitle}
+            </Typography>
+            <Spacer py={0.5} />
+          {/* selectedFilterPackにステップ省略するskipSectionSelectionがある場合、 以下のSelect表示せず、直接getInputFieldを使用して入力項目表示*/}
+          {/* 
+            {!skipSectionSelection && (
+                <Select
+                  options={getUnSelectedOption(options)}
+                  autoFocus={true}
+                  onChange={handleFilterChange}
+                />
+              )}
+              {(skipSectionSelection || selectedFilter) && (
+                // 条件入力フィールドの表示
+              )}
+          */}
+            <Select
+              maxMenuHeight={250}
+              options={getUnSelectedOption(options)}
+              autoFocus={true}
+              onChange={handleFilterChange}
+            />
+            <Spacer py={1} />
         {selectedFilter && (
           <div>
             <Typography weight="bold" size="lg">

--- a/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
+++ b/src/components/MultipleFilter/internal/FilterCard/FilterCard.tsx
@@ -50,15 +50,24 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   const theme = useTheme();
   const [section, setSection] = React.useState<string | undefined>();
   const [condition, setCondition] = React.useState<string | undefined>();
-  const [selectedFilter, setSelectedFilter] = React.useState<FilterType>();
+  const [selectedFilter, setSelectedFilter] = React.useState<
+    FilterType | undefined
+  >(
+    selectedFilterPack?.filters.length === 1
+      ? selectedFilterPack.filters[0]
+      : undefined,
+  );
   const [textFieldErrorText, setTextFieldErrorText] =
     React.useState<string>("");
+  const isMultipleFilters = selectedFilterPack?.filters.length !== 1;
+  const isSectionSelected = !!section;
+  const isConditionSet = !!condition;
+  const isApplyButtonDisabled =
+    (isMultipleFilters && !isSectionSelected) || !isConditionSet;
 
-  const filter = selectedFilterPack?.shouldSkipConditionSelecting
-    ? selectedFilterPack.filters[0]
-    : selectedFilterPack?.filters.find(
-        (filter) => filter.filterName === selectedFilter?.filterName,
-      );
+  const filter = selectedFilterPack?.filters.find(
+    (filter) => filter.filterName === selectedFilter?.filterName,
+  );
   const options = selectedFilterPack?.filters.map((filter) => ({
     label: filter.filterName,
     value: filter.filterName,
@@ -136,9 +145,10 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
   const handleSubmit = () => {
     const newFilter = {
       categoryName: selectedFilterPack?.categoryName as string,
-      filterName: selectedFilterPack?.shouldSkipConditionSelecting
-        ? selectedFilterPack.categoryName
-        : (selectedFilter?.filterName as string),
+      filterName:
+        selectedFilterPack?.filters.length === 1
+          ? selectedFilterPack.categoryName
+          : (selectedFilter?.filterName as string),
       filterType: filter?.control.type as Types,
       filterCondition: condition,
     };
@@ -185,23 +195,23 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
         </Styled.CloseIconContainer>
       </Styled.FilterCardHeader>
       <Styled.FilterContent>
-        {!selectedFilterPack?.shouldSkipConditionSelecting && (
-          <>
-            <Typography weight="bold" size="lg">
-              {selectedFilterPack?.sectionTitle || sectionTitle}
-            </Typography>
-            <Spacer py={0.5} />
-            <Select
-              maxMenuHeight={250}
-              options={getUnSelectedOption(options)}
-              autoFocus={true}
-              onChange={handleFilterChange}
-            />
-            <Spacer py={1} />
-          </>
-        )}
-        {(selectedFilterPack?.shouldSkipConditionSelecting ||
-          selectedFilter) && (
+        {selectedFilterPack?.filters &&
+          selectedFilterPack.filters.length > 1 && (
+            <>
+              <Typography weight="bold" size="lg">
+                {selectedFilterPack?.sectionTitle || sectionTitle}
+              </Typography>
+              <Spacer py={0.5} />
+              <Select
+                maxMenuHeight={250}
+                options={getUnSelectedOption(options)}
+                autoFocus={true}
+                onChange={handleFilterChange}
+              />
+              <Spacer py={1} />
+            </>
+          )}
+        {selectedFilter && (
           <div>
             <Typography weight="bold" size="lg">
               {filter?.conditionTitle || conditionTitle}
@@ -221,10 +231,7 @@ export const FilterCard: React.FunctionComponent<FilterCardProps> = (
           <Button
             size="small"
             inline={true}
-            disabled={
-              (!selectedFilterPack?.shouldSkipConditionSelecting && !section) ||
-              !condition
-            }
+            disabled={isApplyButtonDisabled}
             onClick={handleSubmit}
           >
             {applyButtonTitle}

--- a/src/components/MultipleFilter/internal/Label/Label.tsx
+++ b/src/components/MultipleFilter/internal/Label/Label.tsx
@@ -38,8 +38,7 @@ export const Label: React.FunctionComponent<Props> = ({
     <Styled.Container>
       <Styled.LeftContainer onClick={handleClick}>
         <Typography size="sm" component="span">
-          {`${filter.filterName}:`}
-          &nbsp;
+          {filter.filterName}: &nbsp;
         </Typography>
         <Typography size="sm" component="span" weight="bold">
           {boolToString(filter.filterCondition)}

--- a/src/components/MultipleFilter/internal/Label/Label.tsx
+++ b/src/components/MultipleFilter/internal/Label/Label.tsx
@@ -38,6 +38,10 @@ export const Label: React.FunctionComponent<Props> = ({
     <Styled.Container>
       <Styled.LeftContainer onClick={handleClick}>
         <Typography size="sm" component="span">
+          {/* 
+            「カテゴリ: 強調文字（コンディション）」 のように表示するよう変更
+            強調文字はstrongタグ使用予定
+          */}
           {filter.filterName}
           &nbsp;
           {boolToString(filter.filterCondition)}

--- a/src/components/MultipleFilter/internal/Label/Label.tsx
+++ b/src/components/MultipleFilter/internal/Label/Label.tsx
@@ -38,12 +38,10 @@ export const Label: React.FunctionComponent<Props> = ({
     <Styled.Container>
       <Styled.LeftContainer onClick={handleClick}>
         <Typography size="sm" component="span">
-          {/* 
-            「カテゴリ: 強調文字（コンディション）」 のように表示するよう変更
-            強調文字はstrongタグ使用予定
-          */}
-          {filter.filterName}
+          {`${filter.filterName}:`}
           &nbsp;
+        </Typography>
+        <Typography size="sm" component="span" weight="bold">
           {boolToString(filter.filterCondition)}
         </Typography>
       </Styled.LeftContainer>

--- a/src/components/MultipleFilter/types/index.ts
+++ b/src/components/MultipleFilter/types/index.ts
@@ -2,6 +2,8 @@ export type FilterPackType = {
   categoryName: string;
   sectionTitle?: string;
   filters: FilterType[];
+  // categoryごとにステップを省略するためのフラグ(skipFilterSelection?: boolean)
+  skipFilterSection?: boolean;
 };
 
 export type Types = "text" | "select" | "boolean";

--- a/src/components/MultipleFilter/types/index.ts
+++ b/src/components/MultipleFilter/types/index.ts
@@ -2,8 +2,7 @@ export type FilterPackType = {
   categoryName: string;
   sectionTitle?: string;
   filters: FilterType[];
-  // categoryごとにステップを省略するためのフラグ(skipFilterSelection?: boolean)
-  skipFilterSection?: boolean;
+  shouldSkipConditionSelecting?: boolean;
 };
 
 export type Types = "text" | "select" | "boolean";

--- a/src/components/MultipleFilter/types/index.ts
+++ b/src/components/MultipleFilter/types/index.ts
@@ -2,7 +2,6 @@ export type FilterPackType = {
   categoryName: string;
   sectionTitle?: string;
   filters: FilterType[];
-  shouldSkipConditionSelecting?: boolean;
 };
 
 export type Types = "text" | "select" | "boolean";


### PR DESCRIPTION
## 今回実現したいこと
- オプションでセクションを選択せず、直接コンディションを入力できるようにしたい。
- カテゴリ選択で表示されるPopoverが選択肢を選択せずとも閉じるようにしたい。
- 選択後のフィルター条件を見やすく「hoge: **fuga**」の形式で表示したい。

<!-- Thanks so much for your PR️!!! -->

## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component

## 確認して欲しい箇所
- [x] フィルタリングした値が「test: **hoge**」の形式で表示されているか
- [x] カテゴリ表示後、カテゴリ未選択でも閉じることができているか
- [x] filtersの要素数を元に選択肢をスキップできているか（filtersの要素が1つのみの場合、選択肢をスキップし最初から絞り込める）
