### PR TITLE
fix: Select のドロップダウンが背面に表示されてしまう問題

### DIFF
--- a/.changeset/good-rice-live.md
+++ b/.changeset/good-rice-live.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix: select dropdown was placed behind other elements

--- a/src/components/CreatableSelect/CreatableSelect.tsx
+++ b/src/components/CreatableSelect/CreatableSelect.tsx
@@ -72,6 +72,7 @@ const CreatableSelect = <T,>(
           MenuList: Styled.ReactSelectMenuList,
           ...rest.components,
         }}
+        menuPortalTarget={document.body}
         onInputChange={handleInputChange}
       />
     </Styled.Container>

--- a/src/components/CreatableSelect/__tests__/__snapshots__/CreatableSelect.test.tsx.snap
+++ b/src/components/CreatableSelect/__tests__/__snapshots__/CreatableSelect.test.tsx.snap
@@ -142,22 +142,6 @@ exports[`CreatableSelect component testing Disable multiple CreatableSelected 1`
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-7-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -254,37 +238,6 @@ exports[`CreatableSelect component testing Disable not CreatableSelected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-5-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-5-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-5-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -376,37 +329,6 @@ exports[`CreatableSelect component testing Disable one CreatableSelected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-6-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-6-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-6-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -578,22 +500,6 @@ exports[`CreatableSelect component testing Error multiple CreatableSelected 1`] 
           </div>
         </div>
       </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-10-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -685,37 +591,6 @@ exports[`CreatableSelect component testing Error not CreatableSelected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-8-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-8-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-8-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -831,37 +706,6 @@ exports[`CreatableSelect component testing Error one CreatableSelected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-9-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-9-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-9-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -1033,22 +877,6 @@ exports[`CreatableSelect component testing Normal multiple CreatableSelected 1`]
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-4-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -1140,37 +968,6 @@ exports[`CreatableSelect component testing Normal not CreatableSelected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-2-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-2-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-2-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -1286,37 +1083,6 @@ exports[`CreatableSelect component testing Normal one CreatableSelected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-gsnTZi inqBSZ css-1jcex0u-MenuList"
-          id="react-select-3-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-3-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-3-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -214,6 +214,7 @@ const Select = <OptionValue, IsMulti extends boolean>(
           MenuList: Styled.ReactSelectMenuList,
           ...rest.components,
         }}
+        menuPortalTarget={document.body}
         onInputChange={handleInputChange}
       />
     </Styled.Container>

--- a/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -142,22 +142,6 @@ exports[`Select component testing Disable multiple selected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-7-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -254,37 +238,6 @@ exports[`Select component testing Disable not selected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-5-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-5-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-5-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -376,37 +329,6 @@ exports[`Select component testing Disable one selected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-6-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-6-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-6-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -578,22 +500,6 @@ exports[`Select component testing Error multiple selected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-10-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -685,37 +591,6 @@ exports[`Select component testing Error not selected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-8-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-8-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-8-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -831,37 +706,6 @@ exports[`Select component testing Error one selected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-vcx9vk-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-9-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-9-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-9-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -1033,22 +877,6 @@ exports[`Select component testing Normal multiple selected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="true"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-4-listbox"
-          role="listbox"
-        >
-          <div
-            class=" css-1ufqtev-NoOptionsMessage"
-          >
-            Not found
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -1140,37 +968,6 @@ exports[`Select component testing Normal not selected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-2-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-2-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-2-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>
@@ -1286,37 +1083,6 @@ exports[`Select component testing Normal one selected 1`] = `
                 </svg>
               </span>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class=" css-fqzh9e-menu"
-      >
-        <div
-          aria-multiselectable="false"
-          class="sc-jSMfEi kaCdOG css-1jcex0u-MenuList"
-          id="react-select-3-listbox"
-          role="listbox"
-        >
-          <div
-            aria-disabled="false"
-            aria-selected="true"
-            class=" css-1hd25el-option"
-            id="react-select-3-option-0"
-            role="option"
-            tabindex="-1"
-          >
-            hoge
-          </div>
-          <div
-            aria-disabled="false"
-            aria-selected="false"
-            class=" css-1mw1c1j-option"
-            id="react-select-3-option-1"
-            role="option"
-            tabindex="-1"
-          >
-            huga
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

Select コンポーネントについて、条件によってはドロップダウン部分が、他の要素の背面に表示されてしまったり、見切れたりします。
- 他の要素の背面に表示されてる場合: 祖先要素のスタッキングコンテキストで負ける（z-index）
- 見切れる場合: 祖先要素に overflow: hidden が設定されている場合、それに合わせてクリップされてしまう

この PR は、ドロップダウン部分をポータルにしてこれらの挙動を解消します。
幸い、relact-select にはポータル化するオプションが存在しました。

対応前:

https://github.com/user-attachments/assets/86847fcb-084f-4b42-9c02-5ac6e9fa7e64

対応後:

https://github.com/user-attachments/assets/9d0d7090-03fa-4d5b-9cf8-d6172718c5d9

ポータルにより、ドロップダウン部分の DOM が分離され、見た目は同じものの、React のレンダリング結果に差が出ることになります（Jest のスナップショットに差分が出ています）


## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
