### PR TITLE
fix: Calender コンポーネントの button 要素各種で submit を防ぐ

### DIFF
--- a/.changeset/two-frogs-guess.md
+++ b/.changeset/two-frogs-guess.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix: Calender: remove submit type from button elements to avoid from the form submitting

--- a/src/components/Calendar/Calendar/internal/Day/Day.tsx
+++ b/src/components/Calendar/Calendar/internal/Day/Day.tsx
@@ -22,10 +22,10 @@ export const Day: FC<Props> = memo(function Day({
   };
 
   return selectable ? (
-    <DayContainer selected={selected} onClick={handleClick}>
+    <DayContainer type="button" selected={selected} onClick={handleClick}>
       {children}
     </DayContainer>
   ) : (
-    <DisableDayContainer>{children}</DisableDayContainer>
+    <DisableDayContainer type="button">{children}</DisableDayContainer>
   );
 });

--- a/src/components/Calendar/CalendarRange/internal/Day/Day.tsx
+++ b/src/components/Calendar/CalendarRange/internal/Day/Day.tsx
@@ -30,18 +30,34 @@ const getDayStyle = ({
   };
 
   if (!selectable) {
-    return <DisableDayContainer>{children}</DisableDayContainer>;
+    return <DisableDayContainer type="button">{children}</DisableDayContainer>;
   }
 
   switch (state) {
     case DayState.START:
-      return <DayStart onClick={onClick}>{children}</DayStart>;
+      return (
+        <DayStart type="button" onClick={onClick}>
+          {children}
+        </DayStart>
+      );
     case DayState.END:
-      return <DayEnd onClick={onClick}>{children}</DayEnd>;
+      return (
+        <DayEnd type="button" onClick={onClick}>
+          {children}
+        </DayEnd>
+      );
     case DayState.BETWEEN:
-      return <DayBetween onClick={onClick}>{children}</DayBetween>;
+      return (
+        <DayBetween type="button" onClick={onClick}>
+          {children}
+        </DayBetween>
+      );
     default:
-      return <DayStyle onClick={onClick}>{children}</DayStyle>;
+      return (
+        <DayStyle type="button" onClick={onClick}>
+          {children}
+        </DayStyle>
+      );
   }
 };
 

--- a/src/components/Calendar/internal/Actions/Actions.tsx
+++ b/src/components/Calendar/internal/Actions/Actions.tsx
@@ -35,6 +35,7 @@ export const Actions = memo(function Actions({
           {actions.map((action, i) => (
             <Action
               key={`${action.text}-${i.toString()}`}
+              type="button"
               clicked={clickedAction === action.text}
               onClick={handleClick(action)}
             >


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

Calender コンポーネント内の `<button>` の `type` が submit になっており、form 内で利用すると送信してしまう問題がありました。
この PR ではその問題を解消します。

`<button>` 要素は、`type` 属性の既定値が submit のため、`type` 属性を明示しないと form 送信が発生してしまいます。
Calender 内のすべての button について、`type="button"` 明示しました。

対応前: type 属性が不在:
![Screenshot 2025-01-06 at 16 13 55](https://github.com/user-attachments/assets/a2120837-10ba-41b0-bacd-1c5e5ce4ed92)

対応後: type 属性が button:
<img width="1242" alt="Screenshot 2025-01-06 at 16 15 01" src="https://github.com/user-attachments/assets/edc49cd2-b693-4674-b9bc-a85b8e7893db" />

## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
