### PR TITLE
feat: add FilterSelectInput

### DIFF
--- a/.changeset/large-stingrays-sort.md
+++ b/.changeset/large-stingrays-sort.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": minor
+---
+
+add FilterSelectInput component

--- a/src/components/ContextMenu2/ContextMenu2.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.tsx
@@ -95,6 +95,10 @@ type ContextMenu2Props = {
    */
   width?: number;
   /**
+   * コンテキストメニューの最小幅
+   */
+  minWidth?: number;
+  /**
    * メニュー内の項目。ContextMenu2*** のコンポーネントのみで構成する前提
    */
   children: ReactNode;
@@ -132,7 +136,7 @@ const ContextMenu2Panel = styled.div`
   }
 `;
 export const ContextMenu2 = forwardRef<HTMLButtonElement, ContextMenu2Props>(
-  ({ open, trigger, width, children, onOpenChange }, ref) => {
+  ({ open, trigger, width, minWidth, children, onOpenChange }, ref) => {
     const { isRoot, close } = useContext(ContextMenu2Context);
     const [isOpen, setIsOpen] = useState(false);
     // 通常では、パネル外にカーソルが出ると自動で自パネルを閉じる。
@@ -290,6 +294,7 @@ export const ContextMenu2 = forwardRef<HTMLButtonElement, ContextMenu2Props>(
                   style={{
                     ...floatingStyles,
                     width,
+                    minWidth,
                     // ソートによるドラッグ移動中、overflow: auto にしていると、
                     // 移動場所中にスクロール可・不可の切り替えが連続的に発生しガタツキが発生する。
                     // ソートドラッグ中は overflow: auto を抑止する。

--- a/src/components/ContextMenu2/ContextMenu2ButtonItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2ButtonItem.tsx
@@ -13,6 +13,7 @@ import { colors } from "../../styles";
 // 特に機能を持たない、見た目付きの入れ子メニューのボタン
 
 type ContextMenu2ButtonItemProps = {
+  pressed?: boolean;
   prepend?: ReactNode;
   children: ReactNode;
   closeOnClick?: boolean;
@@ -25,7 +26,7 @@ const ButtonAppend = styled.span`
 const InternalContextMenu2ButtonItem = forwardRef<
   HTMLButtonElement,
   ContextMenu2ButtonItemProps
->(({ prepend, children, closeOnClick, onClick, ...props }, ref) => {
+>(({ pressed, prepend, children, closeOnClick, onClick, ...props }, ref) => {
   const { close } = useContext(ContextMenu2Context);
 
   const handleClick = useCallback(
@@ -36,7 +37,13 @@ const InternalContextMenu2ButtonItem = forwardRef<
     [closeOnClick, close, onClick],
   );
   return (
-    <button type="button" {...props} ref={ref} onClick={handleClick}>
+    <button
+      type="button"
+      {...props}
+      ref={ref}
+      data-pressed={pressed}
+      onClick={handleClick}
+    >
       {prepend && <ButtonAppend>{prepend}</ButtonAppend>}
       {children}
     </button>
@@ -76,6 +83,7 @@ export const ContextMenu2ButtonItem = styled(
     color: ${colors.basic[400]};
   }
 
+  &[data-pressed="true"],
   &:hover:not(:disabled),
   &:focus:not(:disabled) {
     color: ${({ color }) => (color === "danger" ? "#fff" : colors.basic[900])};

--- a/src/components/ContextMenu2/__tests__/__snapshots__/ContextMenu2.test.tsx.snap
+++ b/src/components/ContextMenu2/__tests__/__snapshots__/ContextMenu2.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
       class="sc-idiyUo cCmHvy"
     />
     <button
-      class="sc-gsnTZi jJEItt"
+      class="sc-gsnTZi grkKuj"
       tabindex="-1"
       type="button"
     >
@@ -109,14 +109,14 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
       アイコンボタン
     </button>
     <button
-      class="sc-gsnTZi jJEItt"
+      class="sc-gsnTZi grkKuj"
       tabindex="-1"
       type="button"
     >
       ボタン
     </button>
     <button
-      class="sc-gsnTZi lduipB"
+      class="sc-gsnTZi cjZNsz"
       color="danger"
       tabindex="-1"
       type="button"
@@ -308,7 +308,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
       </li>
     </ul>
     <button
-      class="sc-gsnTZi jJEItt"
+      class="sc-gsnTZi grkKuj"
       tabindex="-1"
       type="button"
     >

--- a/src/components/FilterInputAbstract/FilterInputAbstract.stories.tsx
+++ b/src/components/FilterInputAbstract/FilterInputAbstract.stories.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import { FilterInputAbstract } from "./FilterInputAbstract";
+import Icon from "../Icon";
+
+const meta = {
+  title: "Components/Inputs/FilterInputAbstract",
+  component: FilterInputAbstract,
+  argTypes: {},
+} satisfies Meta<typeof FilterInputAbstract>;
+
+export default meta;
+
+/**
+ * Internal use only!
+ * このコンポーネントは内部利用専用です。プロダクトには利用しないでください。
+ */
+export const Default: StoryObj<typeof meta> = {
+  args: {
+    selectedIndex: 0,
+    selectOptions: [
+      {
+        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        label: "含む",
+      },
+      {
+        icon: (
+          <Icon
+            name="operator_does_not_match"
+            type="line"
+            color="currentColor"
+          />
+        ),
+        label: "含まない",
+      },
+      {
+        icon: (
+          <Icon name="operator_contains" type="line" color="currentColor" />
+        ),
+        label: "いずれかを含む",
+      },
+      {
+        icon: (
+          <Icon name="operator_starts_with" type="line" color="currentColor" />
+        ),
+        label: "で始まる",
+      },
+      {
+        icon: (
+          <Icon name="operator_ends_with" type="line" color="currentColor" />
+        ),
+        label: "で終わる",
+      },
+      {
+        icon: <Icon name="operator_equal" type="line" color="currentColor" />,
+        label: "同じ",
+      },
+      {
+        icon: (
+          <Icon name="operator_not_equal" type="line" color="currentColor" />
+        ),
+        label: "同じでない",
+      },
+    ],
+  },
+  render: (args) => {
+    const [, updateArgs] = useArgs();
+
+    return (
+      <>
+        <FilterInputAbstract
+          {...args}
+          onSelectChange={(newIndex) => updateArgs({ selectedIndex: newIndex })}
+        >
+          children
+        </FilterInputAbstract>
+      </>
+    );
+  },
+};

--- a/src/components/FilterInputAbstract/FilterInputAbstract.tsx
+++ b/src/components/FilterInputAbstract/FilterInputAbstract.tsx
@@ -1,0 +1,103 @@
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+  createContext,
+} from "react";
+import Icon from "../Icon";
+import {
+  ContextMenu2,
+  ContextMenu2Container,
+  ContextMenu2CheckItem,
+} from "../ContextMenu2";
+import * as styled from "./styled";
+
+export const FilterInputContext = createContext({
+  isSmall: false,
+});
+
+//
+// -----------------------------------------------------------------------------
+
+// 本体のコンポーネント
+type FilterInputAbstractProps = {
+  selectedIndex: number;
+  selectOptions: { icon: ReactElement; label: string }[];
+  children?: ReactNode;
+  onSelectChange: (index: number) => void;
+};
+export const FilterInputAbstract = ({
+  selectedIndex,
+  selectOptions,
+  onSelectChange,
+  children,
+}: FilterInputAbstractProps) => {
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  // 本来なら CSS Container Query で判定したいけれど、
+  // styled-components v6 未満では未対応
+  const [isSmall, setIsSmall] = useState(false);
+
+  const el = useRef<HTMLDivElement>(null);
+
+  const handleSelectChange = useCallback(
+    (index: number) => {
+      onSelectChange(index);
+      setIsSelectOpen(false);
+    },
+    [onSelectChange, setIsSelectOpen],
+  );
+
+  useEffect(() => {
+    if (!window.ResizeObserver) return;
+    if (!el.current) return;
+
+    const resizeObserver = new window.ResizeObserver(() => {
+      if (!el.current) return;
+      setIsSmall(el.current.clientWidth < 130);
+    });
+
+    resizeObserver.observe(el.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [setIsSmall]);
+
+  return (
+    <styled.FilterInputAbstract ref={el} data-small={isSmall}>
+      <ContextMenu2Container>
+        <ContextMenu2
+          open={isSelectOpen}
+          trigger={
+            <styled.DropDownTrigger
+              type="button"
+              aria-label="フィルターのタイプを選ぶ"
+              onClick={() => setIsSelectOpen(!isSelectOpen)}
+            >
+              {selectOptions[selectedIndex].icon}
+              <Icon name="arrow_down" color="currentColor" />
+            </styled.DropDownTrigger>
+          }
+          onOpenChange={(open) => setIsSelectOpen(open)}
+        >
+          {selectOptions.map(({ label, icon }, i) => (
+            <ContextMenu2CheckItem
+              key={label}
+              prepend={icon}
+              checked={selectedIndex === i}
+              onChange={() => handleSelectChange(i)}
+            >
+              {label}
+            </ContextMenu2CheckItem>
+          ))}
+        </ContextMenu2>
+      </ContextMenu2Container>
+      <FilterInputContext.Provider value={{ isSmall }}>
+        {children}
+      </FilterInputContext.Provider>
+    </styled.FilterInputAbstract>
+  );
+};

--- a/src/components/FilterInputAbstract/__tests__/FilterInputAbstract.test.tsx
+++ b/src/components/FilterInputAbstract/__tests__/FilterInputAbstract.test.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
+import { FilterInputAbstract } from "../FilterInputAbstract";
+import Icon from "../../Icon";
+
+describe("FileUploader component testing", () => {
+  afterEach(cleanup);
+
+  test("FileUploader", () => {
+    const { asFragment } = renderWithThemeProvider(
+      <FilterInputAbstract
+        selectedIndex={0}
+        selectOptions={[
+          {
+            icon: (
+              <Icon name="operator_match" type="line" color="currentColor" />
+            ),
+            label: "含む",
+          },
+          {
+            icon: (
+              <Icon
+                name="operator_does_not_match"
+                type="line"
+                color="currentColor"
+              />
+            ),
+            label: "含まない",
+          },
+          {
+            icon: (
+              <Icon name="operator_contains" type="line" color="currentColor" />
+            ),
+            label: "いずれかを含む",
+          },
+        ]}
+        onSelectChange={jest.fn}
+      >
+        children
+      </FilterInputAbstract>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/FilterInputAbstract/__tests__/__snapshots__/FilterInputAbstract.test.tsx.snap
+++ b/src/components/FilterInputAbstract/__tests__/__snapshots__/FilterInputAbstract.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileUploader component testing FileUploader 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-hHLeRK hmclDV"
+    data-small="false"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      aria-label="フィルターのタイプを選ぶ"
+      class="sc-dmRaPn mNXIP"
+      type="button"
+    >
+      <span
+        class="sc-bczRLJ gJuzRf"
+        size="18"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M3.9 19.1V4.9h16.2v14.2zM2 4c0-.6.4-1 1-1h18c.6 0 1 .4 1 1v16c0 .6-.4 1-1 1H3a1 1 0 0 1-1-1zm11.1 9h-2.3L12 9.7zm0-5.5H11l-3.4 9h2l.7-2h3.4l.6 2h2.1z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <span
+        class="sc-bczRLJ gJuzRf"
+        size="18"
+      >
+        <svg
+          viewBox="0 0 20 20"
+        >
+          <path
+            d="m10 10.9 4.1-4.1 1.2 1.1-5.3 5.3L4.7 8l1.2-1.1z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </button>
+    children
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/FilterInputAbstract/styled.tsx
+++ b/src/components/FilterInputAbstract/styled.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import { colors } from "../../styles";
+
+export const FilterInputAbstract = styled.div`
+  position: relative;
+  display: grid;
+  grid-template-columns: 46px 1fr;
+  align-items: center;
+  gap: 0;
+  height: 28px;
+  border-radius: 4px;
+  border: 1px solid ${colors.basic[400]};
+  background-color: #fff;
+  overflow: hidden;
+
+  &[data-small="true"] {
+    display: block;
+    border: 0;
+    background-color: transparent;
+  }
+`;
+
+export const DropDownTrigger = styled.button`
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  height: 100%;
+  padding: 0 2px 0 6px;
+  border: 0;
+  border-right: 1px solid ${colors.basic[400]};
+  outline-offset: -1px;
+  color: #000;
+  background: transparent;
+  cursor: pointer;
+
+  &:where(${FilterInputAbstract.toString()}[data-small="true"] *) {
+    display: none;
+  }
+`;

--- a/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import { FilterSelectInput } from "./index";
+import Icon from "../Icon";
+
+const meta = {
+  title: "Components/Inputs/FilterSelectInput",
+  component: FilterSelectInput,
+  argTypes: {},
+} satisfies Meta<typeof FilterSelectInput>;
+
+export default meta;
+
+/**
+ * 入力内容をリストから選択させるフィルターの入力です。
+ * 利用方法は、FilterTagInput の story 内の説明を参照してください。
+ *
+ */
+export const Default: StoryObj<typeof meta> = {
+  args: {
+    value: "項目1",
+    values: [
+      "項目1",
+      "value2",
+      "すごく長い値すごく長い値すごく長い値すごく長い値すごく長い値",
+      ...Array.from({ length: 20 }, (_, i) => `value${i + 3}`),
+    ],
+    selectedIndex: 0,
+    selectOptions: [
+      {
+        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        label: "含む",
+      },
+      {
+        icon: (
+          <Icon
+            name="operator_does_not_match"
+            type="line"
+            color="currentColor"
+          />
+        ),
+        label: "含まない",
+      },
+      {
+        icon: (
+          <Icon name="operator_contains" type="line" color="currentColor" />
+        ),
+        label: "いずれかを含む",
+      },
+      {
+        icon: (
+          <Icon name="operator_starts_with" type="line" color="currentColor" />
+        ),
+        label: "で始まる",
+      },
+      {
+        icon: (
+          <Icon name="operator_ends_with" type="line" color="currentColor" />
+        ),
+        label: "で終わる",
+      },
+      {
+        icon: <Icon name="operator_equal" type="line" color="currentColor" />,
+        label: "同じ",
+      },
+      {
+        icon: (
+          <Icon name="operator_not_equal" type="line" color="currentColor" />
+        ),
+        label: "同じでない",
+      },
+    ],
+  },
+  render: (args) => {
+    const [, updateArgs] = useArgs();
+
+    return (
+      <>
+        <FilterSelectInput
+          {...args}
+          onChange={(newValue) => updateArgs({ value: newValue })}
+          onSelectChange={(newIndex) => updateArgs({ selectedIndex: newIndex })}
+        />
+      </>
+    );
+  },
+};

--- a/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
@@ -16,6 +16,7 @@ export default meta;
  * 入力内容をリストから選択させるフィルターの入力です。
  * 利用方法は、FilterTagInput の story 内の説明を参照してください。
  *
+ * 自動で横 100% に広がります。必要に応じて、親要素の幅を指定してください。
  */
 export const Default: StoryObj<typeof meta> = {
   args: {
@@ -82,6 +83,16 @@ export const Default: StoryObj<typeof meta> = {
           onChange={(newValue) => updateArgs({ value: newValue })}
           onSelectChange={(newIndex) => updateArgs({ selectedIndex: newIndex })}
         />
+        <div style={{ maxWidth: 200 }}>
+          ↓親で幅を指定した例
+          <FilterSelectInput
+            {...args}
+            onChange={(newValue) => updateArgs({ value: newValue })}
+            onSelectChange={(newIndex) =>
+              updateArgs({ selectedIndex: newIndex })
+            }
+          />
+        </div>
       </>
     );
   },

--- a/src/components/FilterSelectInput/FilterSelectInput.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, useState, type ReactElement } from "react";
+import { FilterInputAbstract } from "../FilterInputAbstract/FilterInputAbstract";
+import {
+  ContextMenu2,
+  ContextMenu2Container,
+  ContextMenu2ButtonItem,
+} from "../ContextMenu2";
+import Icon from "../Icon";
+import * as styled from "./styled";
+
+type FilterTagInputProps = {
+  value: string;
+  values: string[];
+  selectedIndex: number;
+  selectOptions: { icon: ReactElement; label: string }[];
+  onChange: (value: string) => void;
+  onSelectChange: (index: number) => void;
+};
+export const FilterSelectInput = ({
+  value,
+  values,
+  selectedIndex,
+  selectOptions,
+  onChange,
+  onSelectChange,
+}: FilterTagInputProps) => {
+  const [width, setWidth] = useState(0);
+  const triggerEl = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!window.ResizeObserver) return;
+    if (!triggerEl.current) return;
+
+    const resizeObserver = new window.ResizeObserver(() => {
+      triggerEl.current && setWidth(triggerEl.current.offsetWidth);
+    });
+
+    resizeObserver.observe(triggerEl.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <FilterInputAbstract
+      selectedIndex={selectedIndex}
+      selectOptions={selectOptions}
+      onSelectChange={onSelectChange}
+    >
+      <styled.SelectContainer ref={triggerEl}>
+        <ContextMenu2Container>
+          <ContextMenu2
+            minWidth={width}
+            trigger={
+              <styled.Select type="button">
+                <styled.SelectLabel>{value}</styled.SelectLabel>
+                <styled.SelectIcon>
+                  <Icon name="arrow_down" color="currentColor" />
+                </styled.SelectIcon>
+              </styled.Select>
+            }
+          >
+            {values.map((v) => (
+              <ContextMenu2ButtonItem
+                key={v}
+                closeOnClick
+                pressed={v === value}
+                onClick={() => onChange(v)}
+              >
+                {v}
+              </ContextMenu2ButtonItem>
+            ))}
+          </ContextMenu2>
+        </ContextMenu2Container>
+      </styled.SelectContainer>
+    </FilterInputAbstract>
+  );
+};

--- a/src/components/FilterSelectInput/__tests__/FilterSelectInput.test.tsx
+++ b/src/components/FilterSelectInput/__tests__/FilterSelectInput.test.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { renderWithThemeProvider } from "../../../utils/renderWithThemeProvider";
+import { FilterSelectInput } from "../";
+import Icon from "../../Icon";
+
+describe("FileUploader component testing", () => {
+  afterEach(cleanup);
+
+  test("FileUploader", () => {
+    const { asFragment } = renderWithThemeProvider(
+      <FilterSelectInput
+        value="項目1"
+        values={[
+          "項目1",
+          "value2",
+          "すごく長い値すごく長い値すごく長い値すごく長い値すごく長い値",
+        ]}
+        selectedIndex={0}
+        selectOptions={[
+          {
+            icon: (
+              <Icon name="operator_match" type="line" color="currentColor" />
+            ),
+            label: "含む",
+          },
+          {
+            icon: (
+              <Icon
+                name="operator_does_not_match"
+                type="line"
+                color="currentColor"
+              />
+            ),
+            label: "含まない",
+          },
+          {
+            icon: (
+              <Icon name="operator_contains" type="line" color="currentColor" />
+            ),
+            label: "いずれかを含む",
+          },
+        ]}
+        onChange={jest.fn}
+        onSelectChange={jest.fn}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
+++ b/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileUploader component testing FileUploader 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-hHLeRK hmclDV"
+    data-small="false"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      aria-label="フィルターのタイプを選ぶ"
+      class="sc-dmRaPn mNXIP"
+      type="button"
+    >
+      <span
+        class="sc-bczRLJ gJuzRf"
+        size="18"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M3.9 19.1V4.9h16.2v14.2zM2 4c0-.6.4-1 1-1h18c.6 0 1 .4 1 1v16c0 .6-.4 1-1 1H3a1 1 0 0 1-1-1zm11.1 9h-2.3L12 9.7zm0-5.5H11l-3.4 9h2l.7-2h3.4l.6 2h2.1z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <span
+        class="sc-bczRLJ gJuzRf"
+        size="18"
+      >
+        <svg
+          viewBox="0 0 20 20"
+        >
+          <path
+            d="m10 10.9 4.1-4.1 1.2 1.1-5.3 5.3L4.7 8l1.2-1.1z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </button>
+    <div
+      class="sc-kgflAQ bncDUf"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        class="sc-fLlhyt dWTupT"
+        type="button"
+      >
+        <span
+          class="sc-bBrHrO gidTLq"
+        >
+          項目1
+        </span>
+        <span
+          class="sc-ivTmOn leeCUg"
+        >
+          <span
+            class="sc-bczRLJ gJuzRf"
+            size="18"
+          >
+            <svg
+              viewBox="0 0 20 20"
+            >
+              <path
+                d="m10 10.9 4.1-4.1 1.2 1.1-5.3 5.3L4.7 8l1.2-1.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
+++ b/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="sc-fLlhyt dWTupT"
+        class="sc-fLlhyt dEijkV"
         type="button"
       >
         <span

--- a/src/components/FilterSelectInput/index.tsx
+++ b/src/components/FilterSelectInput/index.tsx
@@ -1,0 +1,1 @@
+export { FilterSelectInput } from "./FilterSelectInput";

--- a/src/components/FilterSelectInput/styled.tsx
+++ b/src/components/FilterSelectInput/styled.tsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+import { colors } from "../../styles";
+
+export const SelectContainer = styled.div`
+  min-width: 0;
+  width: calc(100% + 46px);
+  height: 100%;
+  margin-left: -46px;
+`;
+
+export const Select = styled.button`
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 0 8px 0 54px;
+  border: 0;
+  background: transparent;
+  outline: none;
+  font-size: 13px;
+  text-align: left;
+  color: ${colors.basic[900]};
+  cursor: pointer;
+
+  &:focus {
+    isolation: isolate;
+    z-index: 1;
+  }
+`;
+
+export const SelectLabel = styled.span`
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const SelectIcon = styled.span`
+  flex-shrink: 0;
+  width: 18px;
+`;

--- a/src/components/FilterSelectInput/styled.tsx
+++ b/src/components/FilterSelectInput/styled.tsx
@@ -18,7 +18,7 @@ export const Select = styled.button`
   padding: 0 8px 0 54px;
   border: 0;
   background: transparent;
-  outline: none;
+  outline-offset: -1px;
   font-size: 13px;
   text-align: left;
   color: ${colors.basic[900]};

--- a/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
+++ b/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
@@ -3,15 +3,14 @@
 exports[`FileUploader component testing FileUploader 1`] = `
 <DocumentFragment>
   <div
-    class="sc-llJcti dKkloF"
-    data-overflowing="false"
+    class="sc-hHLeRK hmclDV"
     data-small="false"
   >
     <button
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-label="フィルターのタイプを選ぶ"
-      class="sc-iIPllB gMKXmg"
+      class="sc-dmRaPn mNXIP"
       type="button"
     >
       <span
@@ -43,7 +42,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       </span>
     </button>
     <div
-      class="sc-gicCDI fgmNOp"
+      class="sc-gicCDI iTddUZ"
     >
       <div
         class="sc-ezWOiH jbWjVW"
@@ -153,7 +152,8 @@ exports[`FileUploader component testing FileUploader 1`] = `
     </div>
     <button
       aria-label="フィルター入力パネルを開く"
-      class="sc-bZkfAO diRLzr"
+      class="sc-bZkfAO dOWdRt"
+      data-overflowing="false"
       type="button"
     >
       <span

--- a/src/components/FilterTagInput/styled.tsx
+++ b/src/components/FilterTagInput/styled.tsx
@@ -4,43 +4,7 @@ import { BreakPoint, colors } from "../../styles";
 import { palette } from "../../themes/palette";
 import { getShadow } from "../../utils/getShadow";
 
-export const FilterTagInput = styled.div`
-  position: relative;
-  display: grid;
-  grid-template-columns: 46px 1fr;
-  align-items: center;
-  gap: 0;
-  height: 28px;
-  border-radius: 4px;
-  border: 1px solid ${colors.basic[400]};
-  background-color: #fff;
-  overflow: hidden;
-
-  &[data-small="true"] {
-    display: block;
-    border: 0;
-    background-color: transparent;
-  }
-`;
-
-export const DropDownTrigger = styled.button`
-  flex-shrink: 0;
-  display: flex;
-  gap: 2px;
-  align-items: center;
-  height: 100%;
-  padding: 0 2px 0 6px;
-  border: 0;
-  border-right: 1px solid ${colors.basic[400]};
-  outline-offset: -1px;
-  color: #000;
-  background: transparent;
-  cursor: pointer;
-
-  &:where(${FilterTagInput.toString()}[data-small="true"] *) {
-    display: none;
-  }
-`;
+import { FilterInputAbstract } from "../FilterInputAbstract/styled";
 
 export const InlineField = styled.div`
   display: flex;
@@ -62,7 +26,7 @@ export const InlineField = styled.div`
     outline: auto -webkit-focus-ring-color;
   }
 
-  &:where(${FilterTagInput.toString()}[data-small="true"] *) {
+  &:where(${FilterInputAbstract}[data-small="true"] *) {
     display: none;
   }
 `;
@@ -87,11 +51,11 @@ export const OverflowIndicator = styled.button`
   box-shadow: -2px 0px 2px rgba(4, 28, 51, 0.16);
   cursor: pointer;
 
-  &:where(${FilterTagInput.toString()}[data-overflowing="true"] *) {
+  &:where([data-overflowing="true"]) {
     display: grid;
   }
 
-  &:where(${FilterTagInput.toString()}[data-small="true"] *) {
+  &:where(${FilterInputAbstract}[data-small="true"] *) {
     position: static;
     display: grid;
     width: 28px;
@@ -101,7 +65,7 @@ export const OverflowIndicator = styled.button`
     box-shadow: ${getShadow(1, 0.04, palette.action.shadowBase)};
   }
 
-  &:where(${FilterTagInput.toString()}[data-small="true"] *:active:not(:disabled)) {
+  &:where(${FilterInputAbstract}[data-small="true"] *:active:not(:disabled)) {
     padding-top: 4px;
     background: ${palette.gray.highlight};
     box-shadow: ${getShadow(2, 0.04, palette.black)};
@@ -170,6 +134,7 @@ const PanelInner = styled.div`
 
   @media ( max-width: ${BreakPoint.MEDIUM}px ) {
     grid-template:
+      "title"
       "left"
       "right"
       "bottom";


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

FilterSelectInput コンポーネントを追加する PR です。
既存の FilterTagInput と似ていますが、FilterSelectInput はリストから1項目選択できる UI です。

これに伴い、既存の FilterTagInput から FilterSelectInput との共通点を切り出し、別途 FilterTagAbstract というコンポーネントを作成しています。

FilterTagAbstract（internal use only!）
┣ FilterTagInput
┗ FilterSelectInput

https://github.com/user-attachments/assets/2ab293fa-22fc-4c03-a5be-f5b97a0b7acc




## Check List (If️ you added new component in this PR)
- [x] Export the component in `src/components/index.ts`
- [x] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
