### PR TITLE
fix: Dropdown panels should not be placed behind modals

### DIFF
--- a/.changeset/quiet-zoos-invent.md
+++ b/.changeset/quiet-zoos-invent.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+fix: Dropdown panels should not be placed behind modals

--- a/src/components/ContextMenu2/ContextMenu2.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.tsx
@@ -123,7 +123,7 @@ const flattenChildren = (children: ReactNode): ReactNode[] => {
 };
 
 const ContextMenu2Panel = styled.div`
-  z-index: ${depth.modal + 1};
+  z-index: ${depth.dropdown};
   padding: 10px 8px;
   border: 1px solid ${colors.basic[200]};
   border-radius: 6px;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -11,6 +11,7 @@ import { ClearIndicator } from "./internal/ClearIndicator";
 import { DropdownIndicator } from "./internal/DropdownIndicator";
 import { MultiValueRemove } from "./internal/MultiValueRemove";
 import * as Styled from "./styled";
+import { depth } from "../../styles/depth";
 
 export const getOverrideStyles = <OptionValue,>(
   theme: Theme,
@@ -50,6 +51,10 @@ export const getOverrideStyles = <OptionValue,>(
       borderLeft: `1px solid ${
         error ? theme.palette.danger.main : theme.palette.divider
       }`,
+    }),
+    menuPortal: (base) => ({
+      ...base,
+      zIndex: depth.dropdown,
     }),
     menuList: (base) => ({
       ...base,

--- a/src/styles/depth.ts
+++ b/src/styles/depth.ts
@@ -1,6 +1,7 @@
 export type Depth = {
   appBar: number;
   drawer: number;
+  dropdown: number;
   modal: number;
   snackbar: number;
   tooltip: number;
@@ -12,6 +13,9 @@ export type DepthOptions = Partial<Depth>;
 export const depth: Depth = {
   appBar: 1100,
   drawer: 1200,
+  // modal 内で、ポータル化したドロップダウンが、
+  // モーダルの背面に重ならないように、モーダルよりも少し大きい値を設定する
+  dropdown: 1301,
   modal: 1300,
   snackbar: 1400,
   tooltip: 1500,


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

過去に`<Select />` のドロップダウン部分をポータル化しました。
該当 PR https://github.com/voyagegroup/ingred-ui/pull/1692

これにより、副作用として、モーダルのパネルと、セレクトのドロップダウンは並列のレイヤーとして扱われるようになりました。
このとき、モーダルのほうが重なり順が上のため、以下のような状態が発生してしまいました

↓ポータルになったドロップダウンはモーダルよりも背面に表示されてしまう問題（Storybook の MultipleFilter で、項目を選んだ際に再現されます）
![image](https://github.com/user-attachments/assets/586a7e8b-da1d-4a26-9546-11b0c2687b16)

これを解消するため、ドロップダウンパーネルには、モーダルよりも僅かにz-indexを設定するようにし、問題を解消します。

↓この PR で解消した様子
![image](https://github.com/user-attachments/assets/9890f658-b7df-4663-8f02-f9eb1011045a)


## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
