### PR TITLE
feat: ContextMenu panels in DataTable2 sould close on item change

### DIFF
--- a/.changeset/brave-bugs-sort.md
+++ b/.changeset/brave-bugs-sort.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": minor
+---
+
+DataTable2: close context menu on item change

--- a/src/components/ContextMenu2/ContextMenu2.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.tsx
@@ -157,7 +157,7 @@ export const ContextMenu2 = forwardRef<HTMLButtonElement, ContextMenu2Props>(
       setIsOpen(false);
       setIsSorting(false);
       onOpenChange?.(false);
-    }, [close, setIsOpen, setIsSorting]);
+    }, [close, setIsOpen, setIsSorting, onOpenChange]);
 
     const nodeId = useFloatingNodeId();
 

--- a/src/components/ContextMenu2/ContextMenu2.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.tsx
@@ -156,6 +156,7 @@ export const ContextMenu2 = forwardRef<HTMLButtonElement, ContextMenu2Props>(
       close();
       setIsOpen(false);
       setIsSorting(false);
+      onOpenChange?.(false);
     }, [close, setIsOpen, setIsSorting]);
 
     const nodeId = useFloatingNodeId();

--- a/src/components/ContextMenu2/ContextMenu2CheckItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2CheckItem.tsx
@@ -2,14 +2,18 @@ import React, {
   forwardRef,
   type ReactNode,
   type ButtonHTMLAttributes,
+  useContext,
+  useCallback,
 } from "react";
 import styled from "styled-components";
 import { colors } from "../../styles";
+import { ContextMenu2Context } from "./context";
 
 // 特に機能を持たない、見た目付きの入れ子メニューのボタン
 
 type ContextMenu2CheckItemProps = {
   checked?: boolean;
+  closeOnChange?: boolean;
   prepend?: ReactNode;
   children: ReactNode;
   onChange?: (checked: boolean) => void;
@@ -34,10 +38,12 @@ const CheckMark = styled(
 const InternalContextMenu2CheckItem = forwardRef<
   HTMLButtonElement,
   ContextMenu2CheckItemProps
->(({ checked, prepend, children, onChange, ...props }, ref) => {
-  const handleClick = () => {
-    if (onChange) onChange(!checked);
-  };
+>(({ checked, closeOnChange, prepend, children, onChange, ...props }, ref) => {
+  const { close } = useContext(ContextMenu2Context);
+  const handleClick = useCallback(() => {
+    onChange && onChange(!checked);
+    closeOnChange && close();
+  }, [checked, close, closeOnChange, onChange]);
 
   return (
     <button type="button" {...props} ref={ref} onClick={handleClick}>

--- a/src/components/DataTable2/DataTable2InlineEditor.tsx
+++ b/src/components/DataTable2/DataTable2InlineEditor.tsx
@@ -119,6 +119,7 @@ export const DataTable2InlineSelectEditor = ({
             {options.map((option) => (
               <ContextMenu2CheckItem
                 key={option}
+                closeOnChange
                 checked={value === option}
                 onChange={() => onChange(option)}
               >

--- a/src/components/DataTable2/DataTable2MenuCountControl.tsx
+++ b/src/components/DataTable2/DataTable2MenuCountControl.tsx
@@ -21,12 +21,7 @@ export const DataTable2MenuCountControl = () => {
     <ContextMenu2
       width={136}
       trigger={
-        <ContextMenu2TriggerItem
-          append={(() => {
-            const text = pageSizeOptions.join(", ");
-            return text.length > 16 ? `${text.slice(0, 16)}...` : text;
-          })()}
-        >
+        <ContextMenu2TriggerItem append={pageSize}>
           件数を変更
         </ContextMenu2TriggerItem>
       }
@@ -34,6 +29,7 @@ export const DataTable2MenuCountControl = () => {
       {pageSizeOptions.map((size) => (
         <ContextMenu2CheckItem
           key={size}
+          closeOnChange
           checked={pageSize === size}
           onChange={() => setPageSize(size)}
         >

--- a/src/components/DataTable2/DataTable2MenuSpaceControl.tsx
+++ b/src/components/DataTable2/DataTable2MenuSpaceControl.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import { DataTable2Context } from "./context";
 import {
   ContextMenu2,
@@ -22,6 +22,9 @@ const spacings = [
 
 export const DataTable2MenuSpaceControl = () => {
   const { rowSpacing, setRowSpacing } = useContext(DataTable2Context);
+  const currentLabel = useMemo(() => {
+    return spacings.find((s) => s.value === rowSpacing)?.label || "標準";
+  }, [rowSpacing]);
   const handleOnChange = (spacing: -2 | -1 | 0 | 1 | 2) => {
     setRowSpacing(spacing);
   };
@@ -33,7 +36,7 @@ export const DataTable2MenuSpaceControl = () => {
     <ContextMenu2
       width={168}
       trigger={
-        <ContextMenu2TriggerItem append="標準">
+        <ContextMenu2TriggerItem append={currentLabel}>
           表示密度を変更
         </ContextMenu2TriggerItem>
       }
@@ -41,6 +44,7 @@ export const DataTable2MenuSpaceControl = () => {
       {spacings.map(({ value, label }) => (
         <ContextMenu2CheckItem
           key={value}
+          closeOnChange
           checked={rowSpacing === value}
           onChange={() => handleOnChange(value)}
         >


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

@noronaoki さんからの相談で、以下をお知らせいただいたので、その対応を行う PR です。

> - 表示件数や表示密度、インライン編集（サンプルとしてステータスに用いてるもののような）の変更は選択時に即座に反映し、メニューを閉じる時は外をクリックする
>   - やはり選択したらメニューも同時に閉じて欲しい（全てにおいて共通で閉じてOK）
>   - 特に件数変更やインライン編集などはその都度API通信が発生するためカチャカチャと変更できない方が都合が良い
> - 矢印左横にサブメニューのグレーテキストを表示する
>   - 現在選択している内容を反映して欲しい
>   - カンマ区切りでの複数表示は、複数の選択肢にチェックを入れている場合にあのような表示になって欲しい

この PR により

-  インライン編集のパネルについて、項目をチェックすると自動で閉じるようになります
- 「行調整系」のパネルについて、項目をチェックすると自動で閉じるようになります
- 「行調整系」のパネルについて、「2段階め詳細パネルを表示するためのボタン」には、「現在の選択値」が併記されます


## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
