### PR TITLE
Feature/Duallistbox2 の各種機能追加

### DIFF
--- a/.changeset/witty-turkeys-press.md
+++ b/.changeset/witty-turkeys-press.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Enhance UX with infinite scroll, sticky headers, and page size control

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -258,7 +258,7 @@ export const Either: StoryObj<typeof DualListBox2> = {
         id: "unique-4",
         groupName: "アコーディオン2",
         label:
-          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
+          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
       },
     ]);
 
@@ -531,11 +531,9 @@ export const NestedAccordion: StoryObj<typeof DualListBox2> = {
         {Object.entries(hierarchy).map(([prefecture, districts]) => (
           <DualListBox2Accordion key={prefecture} label={prefecture}>
             <NestedContainer>
-              {/* 区ごとのアコーディオン */}
               {Object.entries(districts).map(([district, cityItems]) => (
                 <StyledNestedAccordion key={district} label={district}>
                   <NestedContainer>
-                    {/* 市町村のアイテム */}
                     {cityItems.map(item => (
                       <StyledNestedItem key={item.id} id={item.id}>
                         {item.label}

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -111,6 +111,7 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
     const [isLoading, setIsLoading] = useState(false);
     const [loadedGroups, setLoadedGroups] = useState<Set<string>>(new Set());
     const [pageSize, setPageSize] = useState(50);
+    const [loadingGroup, setLoadingGroup] = useState<string | null>(null);
 
     // アコーディオンのグループ定義
     const groups = [
@@ -120,8 +121,9 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
 
     const handleAccordionOpen = useCallback(
       (groupName: string) => {
-        if (loadedGroups.has(groupName)) return;
+        if (loadedGroups.has(groupName) || loadingGroup) return;
 
+        setLoadingGroup(groupName);
         setIsLoading(true);
         setTimeout(() => {
           setItems((prev) => [
@@ -137,10 +139,31 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
             return newSet;
           });
           setIsLoading(false);
+          setLoadingGroup(null);
         }, 1000);
       },
-      [loadedGroups, pageSize],
+      [loadedGroups, pageSize, loadingGroup],
     );
+
+    const handleLoadMore = useCallback(() => {
+      // すでにロード中の場合は何もしない
+      if (isLoading || loadingGroup) return;
+
+      // group2に対する追加データロード
+      if (loadedGroups.has("group2")) {
+        setIsLoading(true);
+        setTimeout(() => {
+          setItems((prev) => [
+            ...prev,
+            ...generateItems(prev.length, pageSize).map((item) => ({
+              ...item,
+              groupName: "グループ2",
+            })),
+          ]);
+          setIsLoading(false);
+        }, 1000);
+      }
+    }, [isLoading, loadedGroups, pageSize, loadingGroup]);
 
     return (
       <DualListBox2
@@ -174,19 +197,7 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
         onExcludedChange={(ids: string[]) =>
           setExcluded(items.filter((item) => ids.includes(item.id)))
         }
-        onLoadMore={() => {
-          setIsLoading(true);
-          setTimeout(() => {
-            setItems((prev) => [
-              ...prev,
-              ...generateItems(prev.length, pageSize).map((item) => ({
-                ...item,
-                groupName: "アコーディオン2",
-              })),
-            ]);
-            setIsLoading(false);
-          }, 1000);
-        }}
+        onLoadMore={handleLoadMore}
       >
         {groups.map((group) => (
           <DualListBox2Accordion
@@ -236,7 +247,7 @@ export const Either: StoryObj<typeof DualListBox2> = {
         id: "unique-4",
         groupName: "アコーディオン2",
         label:
-          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
+          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
       },
     ]);
 

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -42,6 +42,9 @@ const generateItems = (start: number, count: number) => {
  *
  * children には、左パネル用の選択できる項目を渡します。右パネルの内容は状態に応じて自動で表示管理されます。
  *
+ * モバイルサイズでは、タブで左右パネルの表示を切り替える
+ *
+ * included はフラットな配列。アコーディオンやセクションの group ごとに分けて配置する
  */
 export const Default: StoryObj<typeof meta> = {
   args: {

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -54,35 +54,28 @@ export const Default: StoryObj<typeof meta> = {
     disableExclude: false,
     loading: false,
     children: null,
-    menuButtons: (
-      <>
-        <ContextMenu2ButtonItem onClick={() => {}}>
-          メニュー項目1
-        </ContextMenu2ButtonItem>
-        <ContextMenu2SwitchItem onChange={() => {}}>
-          メニュー項目2
-        </ContextMenu2SwitchItem>
-      </>
-    ),
+    pageSize: 50,
+    pageSizeOptions: [10, 50, 100, 200],
   },
   render: (args) => {
-    const [{ included, excluded, loading }, updateArgs] = useArgs<{
+    const [{ included, excluded, loading, pageSize }, updateArgs] = useArgs<{
       included: Item[];
       excluded: Item[];
       loading: boolean;
+      pageSize: number;
     }>();
-    const [items, setItems] = useState(() => generateItems(0, 50));
+    const [items, setItems] = useState(() => generateItems(0, pageSize));
 
     const handleLoadMore = useCallback(() => {
       updateArgs({ loading: true });
       setTimeout(() => {
         setItems((prev) => [
           ...prev,
-          ...generateItems(prev.length, 50),
+          ...generateItems(prev.length, pageSize),
         ]);
         updateArgs({ loading: false });
       }, 1000);
-    }, [updateArgs]);
+    }, [updateArgs, pageSize]);
 
     return (
       <>
@@ -91,6 +84,11 @@ export const Default: StoryObj<typeof meta> = {
           included={included}
           excluded={excluded}
           loading={loading}
+          pageSize={pageSize}
+          onPageSizeChange={(newPageSize) => {
+            updateArgs({ pageSize: newPageSize });
+            setItems(generateItems(0, newPageSize));
+          }}
           onIncludedChange={(ids: string[]) =>
             updateArgs({
               included: items.filter((item) => ids.includes(item.id)),

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -1,7 +1,5 @@
-import React, { useState, useCallback, useMemo } from "react";
-import { Meta, StoryObj } from "@storybook/react";
-import { useArgs } from "@storybook/client-api";
-import styled from "styled-components";
+import React, { useState, useCallback } from "react";
+import { Meta, StoryObj, ComponentStory } from "@storybook/react";
 import {
   type Item,
   DualListBox2,
@@ -15,7 +13,6 @@ import {
   ContextMenu2SwitchItem,
 } from "../ContextMenu2";
 import Checkbox from "../Checkbox";
-import { ComponentStory } from "@storybook/react";
 
 const meta = {
   title: "Components/Data Display/DualListBox2",
@@ -59,10 +56,7 @@ export const Default: ComponentStory<typeof DualListBox2> = (args) => {
   const handleLoadMore = useCallback(() => {
     setLoading(true);
     setTimeout(() => {
-      setItems((prev) => [
-        ...prev,
-        ...generateItems(prev.length, pageSize),
-      ]);
+      setItems((prev) => [...prev, ...generateItems(prev.length, pageSize)]);
       setLoading(false);
     }, 1000);
   }, [pageSize]);
@@ -124,26 +118,29 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
       { id: "group2", name: "アコーディオン2" },
     ];
 
-    const handleAccordionOpen = useCallback((groupName: string) => {
-      if (loadedGroups.has(groupName)) return;
+    const handleAccordionOpen = useCallback(
+      (groupName: string) => {
+        if (loadedGroups.has(groupName)) return;
 
-      setIsLoading(true);
-      setTimeout(() => {
-        setItems((prev) => [
-          ...prev,
-          ...generateItems(prev.length, pageSize).map(item => ({
-            ...item,
-            groupName,
-          })),
-        ]);
-        setLoadedGroups(prev => {
-          const newSet = new Set(prev);
-          newSet.add(groupName);
-          return newSet;
-        });
-        setIsLoading(false);
-      }, 1000);
-    }, [loadedGroups, pageSize]);
+        setIsLoading(true);
+        setTimeout(() => {
+          setItems((prev) => [
+            ...prev,
+            ...generateItems(prev.length, pageSize).map((item) => ({
+              ...item,
+              groupName,
+            })),
+          ]);
+          setLoadedGroups((prev) => {
+            const newSet = new Set(prev);
+            newSet.add(groupName);
+            return newSet;
+          });
+          setIsLoading(false);
+        }, 1000);
+      },
+      [loadedGroups, pageSize],
+    );
 
     return (
       <DualListBox2
@@ -152,11 +149,6 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
         excluded={excluded}
         pageSize={pageSize}
         pageSizeOptions={[10, 50, 100, 200]}
-        onPageSizeChange={(newPageSize) => {
-          setPageSize(newPageSize);
-          setItems([]);
-          setLoadedGroups(new Set());
-        }}
         menuButtons={
           <>
             <ContextMenu2ButtonItem
@@ -166,11 +158,16 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
             >
               好きなボタンを
             </ContextMenu2ButtonItem>
-            <ContextMenu2SwitchItem disabled onChange={() => { }}>
+            <ContextMenu2SwitchItem disabled onChange={() => {}}>
               入れて使う
             </ContextMenu2SwitchItem>
           </>
         }
+        onPageSizeChange={(newPageSize) => {
+          setPageSize(newPageSize);
+          setItems([]);
+          setLoadedGroups(new Set());
+        }}
         onIncludedChange={(ids: string[]) =>
           setIncluded(items.filter((item) => ids.includes(item.id)))
         }
@@ -182,7 +179,7 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
           setTimeout(() => {
             setItems((prev) => [
               ...prev,
-              ...generateItems(prev.length, pageSize).map(item => ({
+              ...generateItems(prev.length, pageSize).map((item) => ({
                 ...item,
                 groupName: "アコーディオン2",
               })),
@@ -195,12 +192,12 @@ export const Accordion: StoryObj<typeof DualListBox2> = {
           <DualListBox2Accordion
             key={group.id}
             label={group.name}
-            onOpen={() => handleAccordionOpen(group.name)}
             disableInclude={!loadedGroups.has(group.name)}
             disableExclude={!loadedGroups.has(group.name)}
+            onOpen={() => handleAccordionOpen(group.name)}
           >
             {items
-              .filter(item => item.groupName === group.name)
+              .filter((item) => item.groupName === group.name)
               .map((item) => (
                 <DualListBox2Item key={item.id} id={item.id}>
                   {item.label}
@@ -279,7 +276,7 @@ export const Either: StoryObj<typeof DualListBox2> = {
               >
                 好きなボタンを
               </ContextMenu2ButtonItem>
-              <ContextMenu2SwitchItem disabled onChange={() => { }}>
+              <ContextMenu2SwitchItem disabled onChange={() => {}}>
                 入れて使う
               </ContextMenu2SwitchItem>
             </>
@@ -376,15 +373,6 @@ export const Section: StoryObj<typeof DualListBox2> = {
         excluded={excluded}
         pageSize={pageSize}
         pageSizeOptions={[10, 50, 100, 200]}
-        onPageSizeChange={(newPageSize) => {
-          setPageSize(newPageSize);
-          setItems([
-            // 初期アイテムを保持
-            ...items.slice(0, 4),
-            // 新しいページサイズに基づいて追加アイテムを生成
-            ...generateItems(4, newPageSize - 4),
-          ]);
-        }}
         menuButtons={
           <>
             <ContextMenu2ButtonItem
@@ -394,11 +382,20 @@ export const Section: StoryObj<typeof DualListBox2> = {
             >
               好きなボタンを
             </ContextMenu2ButtonItem>
-            <ContextMenu2SwitchItem disabled onChange={() => { }}>
+            <ContextMenu2SwitchItem disabled onChange={() => {}}>
               入れて使う
             </ContextMenu2SwitchItem>
           </>
         }
+        onPageSizeChange={(newPageSize) => {
+          setPageSize(newPageSize);
+          setItems([
+            // 初期アイテムを保持
+            ...items.slice(0, 4),
+            // 新しいページサイズに基づいて追加アイテムを生成
+            ...generateItems(4, newPageSize - 4),
+          ]);
+        }}
         onIncludedChange={(ids: string[]) =>
           setIncluded(items.filter((item) => ids.includes(item.id)))
         }

--- a/src/components/DualListBox2/DualListBox2.stories.tsx
+++ b/src/components/DualListBox2/DualListBox2.stories.tsx
@@ -33,25 +33,6 @@ const generateItems = (start: number, count: number, groupName?: string) => {
   }));
 };
 
-// ネストされたコンポーネント用のスタイル
-const NestedContainer = styled.div`
-  /* 配下の要素にパディングを適用 */
-  & > * {
-    padding-left: 24px;
-  }
-`;
-
-const StyledNestedAccordion = styled(DualListBox2Accordion)`
-  /* アコーディオンヘッダー部分のスタイル */
-  & > div:first-child {
-    padding-left: 24px;
-  }
-`;
-
-const StyledNestedItem = styled(DualListBox2Item)`
-  padding-left: 48px;
-`;
-
 /**
  * #### ベーシックなタイプ
  *
@@ -258,7 +239,7 @@ export const Either: StoryObj<typeof DualListBox2> = {
         id: "unique-4",
         groupName: "アコーディオン2",
         label:
-          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
+          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
       },
     ]);
 
@@ -378,7 +359,7 @@ export const Section: StoryObj<typeof DualListBox2> = {
         id: "unique-4",
         groupName: "セクション2",
         label:
-          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
+          "長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム",
       },
     ]);
 
@@ -455,109 +436,4 @@ export const Section: StoryObj<typeof DualListBox2> = {
       </DualListBox2>
     );
   },
-};
-
-/**
- * #### 階層構造のアコーディオンタイプ
- * 
- * アコーディオンをネストして、都道府県 > 区 > 市のような階層構造を表現する例です。
- * 実装者が独自に組み立てる方法を使用しています。
- */
-export const NestedAccordion: StoryObj<typeof DualListBox2> = {
-  render: () => {
-    // 階層構造を持つデータの例
-    const [items] = useState<Item[]>([
-      // 埼玉県
-      {
-        id: "saitama-omiya-urawa",
-        label: "浦和市",
-        prefecture: "埼玉県",
-        district: "大宮区"
-      },
-      {
-        id: "saitama-omiya-nishi",
-        label: "西区",
-        prefecture: "埼玉県",
-        district: "大宮区"
-      },
-      {
-        id: "saitama-kawaguchi-honcho",
-        label: "本町",
-        prefecture: "埼玉県",
-        district: "川口市"
-      },
-      // 東京都
-      {
-        id: "tokyo-shinjuku-kabukicho",
-        label: "歌舞伎町",
-        prefecture: "東京都",
-        district: "新宿区"
-      },
-      {
-        id: "tokyo-shinjuku-okubo",
-        label: "大久保",
-        prefecture: "東京都",
-        district: "新宿区"
-      },
-      {
-        id: "tokyo-shibuya-harajuku",
-        label: "原宿",
-        prefecture: "東京都",
-        district: "渋谷区"
-      }
-    ]);
-
-    const [included, setIncluded] = useState<Item[]>([]);
-    const [excluded, setExcluded] = useState<Item[]>([]);
-
-    // データを階層構造に変換
-    const hierarchy = useMemo(() => {
-      const result: Record<string, Record<string, Item[]>> = {};
-
-      items.forEach(item => {
-        if (!item.prefecture || !item.district) return;
-
-        if (!result[item.prefecture]) {
-          result[item.prefecture] = {};
-        }
-        if (!result[item.prefecture][item.district]) {
-          result[item.prefecture][item.district] = [];
-        }
-        result[item.prefecture][item.district].push(item);
-      });
-
-      return result;
-    }, [items]);
-
-    return (
-      <DualListBox2
-        included={included}
-        excluded={excluded}
-        onIncludedChange={(ids) =>
-          setIncluded(items.filter(item => ids.includes(item.id)))
-        }
-        onExcludedChange={(ids) =>
-          setExcluded(items.filter(item => ids.includes(item.id)))
-        }
-      >
-        {Object.entries(hierarchy).map(([prefecture, districts]) => (
-          <DualListBox2Accordion key={prefecture} label={prefecture}>
-            <NestedContainer>
-              {Object.entries(districts).map(([district, cityItems]) => (
-                <StyledNestedAccordion key={district} label={district}>
-                  <NestedContainer>
-                    {cityItems.map(item => (
-                      <StyledNestedItem key={item.id} id={item.id}>
-                        {item.label}
-                      </StyledNestedItem>
-                    ))}
-                  </NestedContainer>
-                </StyledNestedAccordion>
-              ))}
-            </NestedContainer>
-          </DualListBox2Accordion>
-        ))}
-      </DualListBox2>
-    );
-  }
 };

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -407,6 +407,11 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
     );
 
     useEffect(() => {
+      // テスト環境ではIntersectionObserverが利用できないため、処理をスキップ
+      if (typeof IntersectionObserver === 'undefined') {
+        return;
+      }
+
       const observer = new IntersectionObserver(handleIntersection, {
         root: null,
         rootMargin: "100px",

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -149,12 +149,14 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
     },
     ref,
   ) => {
+    // モバイルサイズでは、タブで左右パネルの表示を切り替える    
     const [tabIndex, setTabIndex] = useState<0 | 1>(0);
     const [filter, setFilter] = useState("");
+    // セクションの排他表示監理用。セクションが選択されている場合はそのセクションのみ表示する。
     const [activeSection, setActiveSection] = useState<string | null>(null);
     const [isLoadingMore, setIsLoadingMore] = useState(false);
     const loadMoreRef = useRef<HTMLDivElement>(null);
-
+    // children にセクションが含まれているかどうか
     const hasSection = useMemo(() => {
       let hasSection = false;
       traverseChildren(children, (child) => {
@@ -168,7 +170,8 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       });
       return hasSection;
     }, [children]);
-
+    
+    // フィルター文字列をスペース区切りで単語の配列に分割
     const filterWords = useMemo(() => {
       const trimmed = filter.trim();
       return trimmed ? trimmed.split(/\s+/) : [];
@@ -184,10 +187,13 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       [excluded],
     );
 
+    // DualListBox2 に配置された、全 DualListBox2Item を抽象化したオブジェクトの配列
     const allItems = useMemo(() => extractAllItems(children), [children]);
 
+    // DualListBox2 に配置された、全 DualListBox2Item の id の配列
     const allIds = useMemo(() => allItems.map((item) => item.id), [allItems]);
 
+    // 検索フィルタ適用後の全 id
     const allIdsFiltered = useMemo(() => {
       if (filterWords.length === 0) return allIds;
 
@@ -211,7 +217,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
         ) {
           return;
         }
-
+        // ここまでの結果、child はセクション
         if (child.props.label !== activeSection) return;
 
         traverseChildren(child.props.children, (grandChild) => {
@@ -228,6 +234,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       return ids;
     }, [activeSection, children, hasSection]);
 
+    // 検索フィルタ適用後の、選択中のセクションのみに含まれる全 id
     const allIdsInActiveSectionFiltered = useMemo(() => {
       if (filterWords.length === 0) return allIdsInActiveSection;
 
@@ -238,6 +245,9 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       });
     }, [allIdsInActiveSection, allItems, filterWords]);
 
+    // 「すべて追加」ボタンを非活性にするかどうか
+    // セクション型の DualListBox の場合、セクション選択中のみ「すべて〜」ボタンは有効。
+    // それ以外は、追加選択できる項目があれば有効（すべて選択済みの場合、無効）
     const disableIncludeAllButton = useMemo(() => {
       if (hasSection) {
         if (activeSection === null) return true;
@@ -260,6 +270,8 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       includedIds,
     ]);
 
+    // 「すべて除外」ボタンを非活性にするかどうか
+    // 「すべて追加」ボタン非活性化の判定の逆。
     const disableExcludeAllButton = useMemo(() => {
       if (hasSection) {
         if (activeSection === null) return true;
@@ -282,6 +294,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       excludedIds,
     ]);
 
+    // 検索フィルターのテキスト入力変更に state に反映
     const handleFilterChange = useCallback(
       (event: ChangeEvent<HTMLInputElement>) => {
         setFilter(event.target?.value);
@@ -289,13 +302,18 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       [setFilter],
     );
 
+    // 選択をクリアする
     const handleClearButtonClick = useCallback(() => {
       included.length && onIncludedChange([]);
       excluded.length && onExcludedChange([]);
     }, [included, excluded, onIncludedChange, onExcludedChange]);
 
+    // 「すべて追加」ボタンが押されたときの処理
+    // 検索フィルタで絞り込まれた項目のみが選択の対象になる
+    // さらに、セクションの場合は、選択しているセクション内の項目のみが対象になる
     const handleIncludeAllButtonClick = useCallback(() => {
       if (hasSection) {
+        // セクションの場合は特別
         if (activeSection === null) return;
         onIncludedChange(
           Array.from(
@@ -326,8 +344,12 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       allIdsInActiveSectionFiltered,
     ]);
 
+    // 「すべて除外」ボタンが押されたときの処理
+    // 検索フィルタで絞り込まれた項目のみが選択の対象になる
+    // さらに、セクションの場合は、選択しているセクション内の項目のみが対象になる
     const handleExcludeAllButtonClick = useCallback(() => {
       if (hasSection) {
+        // セクションの場合は特別
         if (activeSection === null) return;
         onExcludedChange(
           Array.from(

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -157,7 +157,6 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       loading,
       onIncludedChange,
       onExcludedChange,
-      onActiveSectionChange,
       onLoadMore,
       pageSize = 50,
       pageSizeOptions = [10, 50, 100, 200],
@@ -165,7 +164,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
     },
     ref,
   ) => {
-    // モバイルサイズでは、タブで左右パネルの表示を切り替える    
+    // モバイルサイズでは、タブで左右パネルの表示を切り替える
     const [tabIndex, setTabIndex] = useState<0 | 1>(0);
     const [filter, setFilter] = useState("");
     // セクションの排他表示監理用。セクションが選択されている場合はそのセクションのみ表示する。
@@ -186,7 +185,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       });
       return hasSection;
     }, [children]);
-    
+
     // フィルター文字列をスペース区切りで単語の配列に分割
     const filterWords = useMemo(() => {
       const trimmed = filter.trim();
@@ -414,13 +413,15 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
         threshold: 0.1,
       });
 
-      if (loadMoreRef.current) {
-        observer.observe(loadMoreRef.current);
+      const currentLoadMoreRef = loadMoreRef.current;
+
+      if (currentLoadMoreRef) {
+        observer.observe(currentLoadMoreRef);
       }
 
       return () => {
-        if (loadMoreRef.current) {
-          observer.unobserve(loadMoreRef.current);
+        if (currentLoadMoreRef) {
+          observer.unobserve(currentLoadMoreRef);
         }
       };
     }, [handleIntersection]);
@@ -556,7 +557,11 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
               <styled.LeftPanelBody>
                 {children}
                 <div ref={loadMoreRef} style={{ height: "20px" }}>
-                  {loading && <styled.LoadingIndicator>読み込み中...</styled.LoadingIndicator>}
+                  {loading && (
+                    <styled.LoadingIndicator>
+                      読み込み中...
+                    </styled.LoadingIndicator>
+                  )}
                 </div>
               </styled.LeftPanelBody>
             </styled.LeftPanel>

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -406,7 +406,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
           }
         }
       },
-      [isLoadingMore, onLoadMore]
+      [isLoadingMore, onLoadMore],
     );
 
     useEffect(() => {

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -21,6 +21,7 @@ import { type Item } from "./types";
 import { DualListBox2Context, traverseChildren, extractAllItems } from "./lib";
 import { DualListBox2Item } from "./DualListBox2Item";
 import { DualListBox2Section } from "./DualListBox2Section";
+import { DualListBox2MenuCountControl } from "./DualListBox2MenuCountControl";
 
 type DualListBox2Props = {
   /**
@@ -67,6 +68,18 @@ type DualListBox2Props = {
    * 「さらに読み込む」ボタンが押されたときのハンドラ
    **/
   onLoadMore?: () => void;
+  /**
+   * 1ページあたりの表示件数
+   **/
+  pageSize?: number;
+  /**
+   * 1ページあたりの表示件数の選択肢
+   **/
+  pageSizeOptions?: number[];
+  /**
+   * 1ページあたりの表示件数が変更されたときのハンドラ
+   **/
+  onPageSizeChange?: (pageSize: number) => void;
 };
 
 const toGrouped = (items: Item[]) => {
@@ -146,6 +159,9 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
       onExcludedChange,
       onActiveSectionChange,
       onLoadMore,
+      pageSize = 50,
+      pageSizeOptions = [10, 50, 100, 200],
+      onPageSizeChange,
     },
     ref,
   ) => {
@@ -458,19 +474,24 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     onChange={handleFilterChange}
                   />
                 </styled.HeaderSearch>
-                {menuButtons && (
-                  <ContextMenu2Container>
-                    <ContextMenu2
-                      trigger={
-                        <styled.HeaderMenuButton type="button">
-                          <Icon name="more_vert" color={colors.basic[900]} />
-                        </styled.HeaderMenuButton>
-                      }
-                    >
-                      {menuButtons}
-                    </ContextMenu2>
-                  </ContextMenu2Container>
-                )}
+                <ContextMenu2Container>
+                  <ContextMenu2
+                    trigger={
+                      <styled.HeaderMenuButton type="button">
+                        <Icon name="more_vert" color={colors.basic[900]} />
+                      </styled.HeaderMenuButton>
+                    }
+                  >
+                    {onPageSizeChange && (
+                      <DualListBox2MenuCountControl
+                        pageSize={pageSize}
+                        pageSizeOptions={pageSizeOptions}
+                        onPageSizeChange={onPageSizeChange}
+                      />
+                    )}
+                    {menuButtons}
+                  </ContextMenu2>
+                </ContextMenu2Container>
                 <styled.HeaderCount>
                   {loading ? (
                     <Spinner width="16px" />

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -408,7 +408,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
 
     useEffect(() => {
       // テスト環境ではIntersectionObserverが利用できないため、処理をスキップ
-      if (typeof IntersectionObserver === 'undefined') {
+      if (typeof IntersectionObserver === "undefined") {
         return;
       }
 

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -65,7 +65,7 @@ type DualListBox2Props = {
    **/
   onActiveSectionChange?: (activeSection: string | null) => void;
   /**
-   * 「さらに読み込む」ボタンが押されたときのハンドラ
+   * スクロールによって追加データの読み込みが必要になったときに呼び出されるハンドラ
    **/
   onLoadMore?: () => void;
   /**
@@ -396,14 +396,17 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
     ]);
 
     const handleIntersection = useCallback(
-      (entries: IntersectionObserverEntry[]) => {
-        const [entry] = entries;
-        if (entry.isIntersecting && !isLoadingMore && !loading && onLoadMore) {
+      async (entries: IntersectionObserverEntry[]) => {
+        if (entries[0].isIntersecting && !isLoadingMore && onLoadMore) {
           setIsLoadingMore(true);
-          onLoadMore();
+          try {
+            await onLoadMore();
+          } finally {
+            setIsLoadingMore(false); // ローディング状態を必ずリセット
+          }
         }
       },
-      [isLoadingMore, loading, onLoadMore],
+      [isLoadingMore, onLoadMore]
     );
 
     useEffect(() => {

--- a/src/components/DualListBox2/DualListBox2Accordion.tsx
+++ b/src/components/DualListBox2/DualListBox2Accordion.tsx
@@ -15,6 +15,7 @@ type DualListBox2AccordionProps = {
   disableInclude?: boolean;
   disableExclude?: boolean;
   children: ReactNode;
+  onOpen?: () => void;
 };
 
 export const DualListBox2Accordion = ({
@@ -22,11 +23,16 @@ export const DualListBox2Accordion = ({
   disableInclude,
   disableExclude,
   children,
+  onOpen,
 }: DualListBox2AccordionProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const handleButtonClick = useCallback(() => {
-    setIsOpen((prev) => !prev);
-  }, [setIsOpen]);
+    const newIsOpen = !isOpen;
+    setIsOpen(newIsOpen);
+    if (newIsOpen && onOpen) {
+      onOpen();
+    }
+  }, [isOpen, onOpen]);
 
   //
   const { includedIds, excludedIds, onIncludedChange, onExcludedChange } =

--- a/src/components/DualListBox2/DualListBox2Item.tsx
+++ b/src/components/DualListBox2/DualListBox2Item.tsx
@@ -77,7 +77,7 @@ export const DualListBox2Item = ({
   }
 
   return (
-    <styled.DualListBox2Item>
+    <styled.StyledDualListBox2Item>
       <div>{children}</div>
       <styled.ItemActions>
         <li>
@@ -105,7 +105,7 @@ export const DualListBox2Item = ({
           </button>
         </li>
       </styled.ItemActions>
-    </styled.DualListBox2Item>
+    </styled.StyledDualListBox2Item>
   );
 };
 DualListBox2Item.displayName = "DualListBox2Item";

--- a/src/components/DualListBox2/DualListBox2Item.tsx
+++ b/src/components/DualListBox2/DualListBox2Item.tsx
@@ -76,36 +76,52 @@ export const DualListBox2Item = ({
     return null;
   }
 
+  const getIconColor = (
+    isDisabled: boolean | undefined,
+    isActive: boolean,
+    activeColor: string,
+  ) => {
+    if (isDisabled) return colors.basic[400];
+    if (isActive) return activeColor;
+    return colors.basic[900];
+  };
+
   return (
-    <styled.StyledDualListBox2Item>
-      <div>{children}</div>
+    <styled.DualListBox2Item>
+      {children}
       <styled.ItemActions>
         <li>
           <button
             type="button"
-            style={{ "--color": colors.blue[500] } as CSSProperties}
             disabled={disableInclude}
-            aria-label="追加"
             aria-pressed={isIncluded}
+            aria-label="追加"
+            style={{ "--color": colors.blue[500] } as CSSProperties}
             onClick={handleAddButtonClick}
           >
-            <Icon name="check_thin" color="currentColor" />
+            <Icon
+              name="check_thin"
+              color={getIconColor(disableInclude, isIncluded, colors.blue[500])}
+            />
           </button>
         </li>
         <li>
           <button
             type="button"
-            style={{ "--color": colors.red[500] } as CSSProperties}
             disabled={disableExclude}
-            aria-label="除外"
             aria-pressed={isExcluded}
+            aria-label="除外"
+            style={{ "--color": colors.red[500] } as CSSProperties}
             onClick={handleExcludeButtonClick}
           >
-            <Icon name="forbid" color="currentColor" />
+            <Icon
+              name="forbid"
+              color={getIconColor(disableExclude, isExcluded, colors.red[500])}
+            />
           </button>
         </li>
       </styled.ItemActions>
-    </styled.StyledDualListBox2Item>
+    </styled.DualListBox2Item>
   );
 };
 DualListBox2Item.displayName = "DualListBox2Item";

--- a/src/components/DualListBox2/DualListBox2MenuCountControl.tsx
+++ b/src/components/DualListBox2/DualListBox2MenuCountControl.tsx
@@ -25,9 +25,7 @@ export const DualListBox2MenuCountControl = ({
     <ContextMenu2
       width={136}
       trigger={
-        <StyledTriggerItem append={pageSize}>
-          件数を変更
-        </StyledTriggerItem>
+        <StyledTriggerItem append={pageSize}>件数を変更</StyledTriggerItem>
       }
     >
       {pageSizeOptions.map((size) => (
@@ -42,4 +40,4 @@ export const DualListBox2MenuCountControl = ({
       ))}
     </ContextMenu2>
   );
-}; 
+};

--- a/src/components/DualListBox2/DualListBox2MenuCountControl.tsx
+++ b/src/components/DualListBox2/DualListBox2MenuCountControl.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  ContextMenu2,
+  ContextMenu2TriggerItem,
+  ContextMenu2CheckItem,
+} from "../ContextMenu2";
+
+const StyledTriggerItem = styled(ContextMenu2TriggerItem)`
+  margin-right: 16px;
+`;
+
+type DualListBox2MenuCountControlProps = {
+  pageSize: number;
+  pageSizeOptions: number[];
+  onPageSizeChange: (pageSize: number) => void;
+};
+
+export const DualListBox2MenuCountControl = ({
+  pageSize,
+  pageSizeOptions,
+  onPageSizeChange,
+}: DualListBox2MenuCountControlProps) => {
+  return (
+    <ContextMenu2
+      width={136}
+      trigger={
+        <StyledTriggerItem append={pageSize}>
+          件数を変更
+        </StyledTriggerItem>
+      }
+    >
+      {pageSizeOptions.map((size) => (
+        <ContextMenu2CheckItem
+          key={size}
+          closeOnChange
+          checked={pageSize === size}
+          onChange={() => onPageSizeChange(size)}
+        >
+          {size}件
+        </ContextMenu2CheckItem>
+      ))}
+    </ContextMenu2>
+  );
+}; 

--- a/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
+++ b/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
@@ -149,12 +149,6 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
               </button>
             </li>
           </ul>
-          <button
-            class="sc-bjUoiL cBvklr"
-            type="button"
-          >
-            さらに読み込む
-          </button>
         </div>
         <div
           class="sc-evZas dnjCJp"
@@ -407,13 +401,16 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
               </li>
             </div>
           </div>
+          <div
+            style="height: 20px;"
+          />
         </div>
       </div>
       <div
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-idiyUo cnsYRW"
+          class="sc-idiyUo igFzWG"
         >
           <div
             class="sc-dIouRR eIIatV"
@@ -480,7 +477,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           class="sc-evZas dnjCJp"
         >
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -508,7 +505,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
             />
           </div>
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -614,6 +611,32 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
               value=""
             />
           </div>
+          <button
+            aria-expanded="false"
+            aria-haspopup="dialog"
+            class="sc-hAZoDl huRFLl"
+            type="button"
+          >
+            <span
+              class="sc-eCYdqJ iymozk"
+              size="18"
+            >
+              <svg
+                viewBox="0 0 18 18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h18v18H0z"
+                  fill="none"
+                />
+                <path
+                  d="M11.5,3A1.5,1.5,0,1,0,13,4.5,1.5,1.5,0,0,0,11.5,3Zm0,10.5A1.5,1.5,0,1,0,13,15,1.5,1.5,0,0,0,11.5,13.5Zm0-5.25A1.5,1.5,0,1,0,13,9.75,1.5,1.5,0,0,0,11.5,8.25Z"
+                  fill="#041C33"
+                  transform="translate(-2.5 -0.75)"
+                />
+              </svg>
+            </span>
+          </button>
           <div
             class="sc-fnykZs ziGk"
           >
@@ -670,12 +693,6 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
               </button>
             </li>
           </ul>
-          <button
-            class="sc-bjUoiL cBvklr"
-            type="button"
-          >
-            さらに読み込む
-          </button>
         </div>
         <div
           class="sc-evZas dnjCJp"
@@ -840,13 +857,16 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
               </span>
             </div>
           </div>
+          <div
+            style="height: 20px;"
+          />
         </div>
       </div>
       <div
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-idiyUo cnsYRW"
+          class="sc-idiyUo igFzWG"
         >
           <div
             class="sc-dIouRR eIIatV"
@@ -913,7 +933,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
           class="sc-evZas dnjCJp"
         >
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -946,7 +966,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
             />
           </div>
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -1058,6 +1078,32 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
               value=""
             />
           </div>
+          <button
+            aria-expanded="false"
+            aria-haspopup="dialog"
+            class="sc-hAZoDl huRFLl"
+            type="button"
+          >
+            <span
+              class="sc-eCYdqJ iymozk"
+              size="18"
+            >
+              <svg
+                viewBox="0 0 18 18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h18v18H0z"
+                  fill="none"
+                />
+                <path
+                  d="M11.5,3A1.5,1.5,0,1,0,13,4.5,1.5,1.5,0,0,0,11.5,3Zm0,10.5A1.5,1.5,0,1,0,13,15,1.5,1.5,0,0,0,11.5,13.5Zm0-5.25A1.5,1.5,0,1,0,13,9.75,1.5,1.5,0,0,0,11.5,8.25Z"
+                  fill="#041C33"
+                  transform="translate(-2.5 -0.75)"
+                />
+              </svg>
+            </span>
+          </button>
           <div
             class="sc-fnykZs ziGk"
           >
@@ -1208,13 +1254,16 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
               </span>
             </span>
           </button>
+          <div
+            style="height: 20px;"
+          />
         </div>
       </div>
       <div
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-idiyUo cnsYRW"
+          class="sc-idiyUo igFzWG"
         >
           <div
             class="sc-dIouRR eIIatV"
@@ -1281,7 +1330,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
           class="sc-evZas dnjCJp"
         >
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -1314,7 +1363,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
             />
           </div>
           <p
-            class="sc-fLlhyt wjBJR"
+            class="sc-fLlhyt eWPZUA"
           >
             <span
               class="sc-eCYdqJ iymozk"

--- a/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
+++ b/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
@@ -156,9 +156,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           <div
             class="sc-ivTmOn cXxcYC"
           >
-            <div>
-              リストアイテム1
-            </div>
+            リストアイテム1
             <div
               class="sc-bBrHrO dFvZQD"
             >
@@ -179,7 +177,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                     >
                       <path
                         d="M9.99999 15.172L19.192 5.979L20.607 7.393L9.99999 18L3.63599 11.636L5.04999 10.222L9.99999 15.172Z"
-                        fill="currentColor"
+                        fill="#0B82F4"
                       />
                     </svg>
                   </span>
@@ -206,7 +204,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                       />
                       <path
                         d="M6523,4625a7,7,0,1,1,7,7A7.008,7.008,0,0,1,6523,4625Zm7,5.6a5.6,5.6,0,0,0,4.422-9.033l-7.854,7.854A5.573,5.573,0,0,0,6530,4630.6Zm-5.6-5.6a5.572,5.572,0,0,0,1.178,3.433l7.854-7.855A5.6,5.6,0,0,0,6524.4,4625Z"
-                        fill="currentColor"
+                        fill="#041C33"
                         transform="translate(-6521.011 -4616.011)"
                       />
                     </svg>
@@ -218,9 +216,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           <div
             class="sc-ivTmOn cXxcYC"
           >
-            <div>
-              リストアイテム2
-            </div>
+            リストアイテム2
             <div
               class="sc-bBrHrO dFvZQD"
             >
@@ -241,7 +237,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                     >
                       <path
                         d="M9.99999 15.172L19.192 5.979L20.607 7.393L9.99999 18L3.63599 11.636L5.04999 10.222L9.99999 15.172Z"
-                        fill="currentColor"
+                        fill="#041C33"
                       />
                     </svg>
                   </span>
@@ -268,7 +264,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                       />
                       <path
                         d="M6523,4625a7,7,0,1,1,7,7A7.008,7.008,0,0,1,6523,4625Zm7,5.6a5.6,5.6,0,0,0,4.422-9.033l-7.854,7.854A5.573,5.573,0,0,0,6530,4630.6Zm-5.6-5.6a5.572,5.572,0,0,0,1.178,3.433l7.854-7.855A5.6,5.6,0,0,0,6524.4,4625Z"
-                        fill="currentColor"
+                        fill="#041C33"
                         transform="translate(-6521.011 -4616.011)"
                       />
                     </svg>
@@ -280,9 +276,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           <div
             class="sc-ivTmOn cXxcYC"
           >
-            <div>
-              リストアイテム3
-            </div>
+            リストアイテム3
             <div
               class="sc-bBrHrO dFvZQD"
             >
@@ -303,7 +297,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                     >
                       <path
                         d="M9.99999 15.172L19.192 5.979L20.607 7.393L9.99999 18L3.63599 11.636L5.04999 10.222L9.99999 15.172Z"
-                        fill="currentColor"
+                        fill="#041C33"
                       />
                     </svg>
                   </span>
@@ -330,7 +324,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                       />
                       <path
                         d="M6523,4625a7,7,0,1,1,7,7A7.008,7.008,0,0,1,6523,4625Zm7,5.6a5.6,5.6,0,0,0,4.422-9.033l-7.854,7.854A5.573,5.573,0,0,0,6530,4630.6Zm-5.6-5.6a5.572,5.572,0,0,0,1.178,3.433l7.854-7.855A5.6,5.6,0,0,0,6524.4,4625Z"
-                        fill="currentColor"
+                        fill="#041C33"
                         transform="translate(-6521.011 -4616.011)"
                       />
                     </svg>
@@ -342,9 +336,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           <div
             class="sc-ivTmOn cXxcYC"
           >
-            <div>
-              長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム
-            </div>
+            長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い名前のリストアイテム
             <div
               class="sc-bBrHrO dFvZQD"
             >
@@ -365,7 +357,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                     >
                       <path
                         d="M9.99999 15.172L19.192 5.979L20.607 7.393L9.99999 18L3.63599 11.636L5.04999 10.222L9.99999 15.172Z"
-                        fill="currentColor"
+                        fill="#041C33"
                       />
                     </svg>
                   </span>
@@ -392,7 +384,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
                       />
                       <path
                         d="M6523,4625a7,7,0,1,1,7,7A7.008,7.008,0,0,1,6523,4625Zm7,5.6a5.6,5.6,0,0,0,4.422-9.033l-7.854,7.854A5.573,5.573,0,0,0,6530,4630.6Zm-5.6-5.6a5.572,5.572,0,0,0,1.178,3.433l7.854-7.855A5.6,5.6,0,0,0,6524.4,4625Z"
-                        fill="currentColor"
+                        fill="#EB0A4E"
                         transform="translate(-6521.011 -4616.011)"
                       />
                     </svg>

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -253,11 +253,15 @@ export const HeaderLoadButton = styled.button`
 export const RightPanel = LeftPanel;
 
 export const RightPanelHeader = styled.div`
+  position: sticky;
+  top: -1px;
+  z-index: 2;
   display: flex;
   justify-content: space-between;
   padding: 8px 16px;
   border-top-right-radius: 6px;
   border-bottom: 1px solid ${colors.basic[400]};
+  border-left: 1px solid ${colors.basic[400]};
   background: ${colors.basic[100]};
 `;
 
@@ -297,12 +301,16 @@ export const SelectedClearButton = styled.div`
 `;
 
 export const SelectedPanelHeading = styled.p`
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  margin: -1px 0 0;
-  border-block: 1px solid ${colors.basic[400]};
+  margin: 0;
+  border-bottom: 1px solid ${colors.basic[400]};
+  border-left: 1px solid ${colors.basic[400]};
   /* UI/Text 13 */
   font-size: 13px;
   line-height: 16px;
@@ -579,4 +587,14 @@ export const SectionButton = styled.button`
     margin-right: -20px;
     opacity: 0;
   }
+`;
+
+export const LoadingIndicator = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  color: ${colors.basic[600]};
+  font-size: 13px;
+  line-height: 16px;
 `;

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -2,6 +2,8 @@ import styled from "styled-components";
 import { colors } from "../../styles";
 import { palette } from "../../themes/palette";
 import { getShadow } from "../../utils/getShadow";
+import { DualListBox2Accordion } from "./DualListBox2Accordion";
+import { DualListBox2Item } from "./DualListBox2Item";
 
 const actionButton = `
   display: flex;
@@ -597,4 +599,12 @@ export const LoadingIndicator = styled.div`
   color: ${colors.basic[600]};
   font-size: 13px;
   line-height: 16px;
+`;
+
+export const NestedAccordion = styled(DualListBox2Accordion)`
+  padding-left: 24px;
+`;
+
+export const NestedItem = styled(DualListBox2Item)`
+  padding-left: 48px;
 `;

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -359,7 +359,7 @@ export const ItemActions = styled.div`
   }
 `;
 
-export const StyledDualListBox2Item = styled.div`
+export const DualListBox2Item = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -462,7 +462,7 @@ export const AccordionHeader = styled.div`
     background: ${colors.basic[100]};
   }
 
-  ${StyledDualListBox2Item} + & {
+  ${DualListBox2Item} + & {
     margin-top: -1px;
   }
 `;
@@ -604,6 +604,6 @@ export const NestedAccordion = styled(DualListBox2Accordion)`
   padding-left: 24px;
 `;
 
-export const NestedItem = styled(StyledDualListBox2Item)`
+export const NestedItem = styled(DualListBox2Item)`
   padding-left: 48px;
 `;

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -3,7 +3,6 @@ import { colors } from "../../styles";
 import { palette } from "../../themes/palette";
 import { getShadow } from "../../utils/getShadow";
 import { DualListBox2Accordion } from "./DualListBox2Accordion";
-import { DualListBox2Item } from "./DualListBox2Item";
 
 const actionButton = `
   display: flex;
@@ -360,7 +359,7 @@ export const ItemActions = styled.div`
   }
 `;
 
-export const DualListBox2Item = styled.div`
+export const StyledDualListBox2Item = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -463,7 +462,7 @@ export const AccordionHeader = styled.div`
     background: ${colors.basic[100]};
   }
 
-  ${DualListBox2Item} + & {
+  ${StyledDualListBox2Item} + & {
     margin-top: -1px;
   }
 `;
@@ -605,6 +604,6 @@ export const NestedAccordion = styled(DualListBox2Accordion)`
   padding-left: 24px;
 `;
 
-export const NestedItem = styled(DualListBox2Item)`
+export const NestedItem = styled(StyledDualListBox2Item)`
   padding-left: 48px;
 `;

--- a/src/components/DualListBox2/types.ts
+++ b/src/components/DualListBox2/types.ts
@@ -6,6 +6,6 @@ export type Item = {
   // 項目のラベル
   label: string;
   // 階層構造のための追加プロパティ
-  prefecture?: string;
-  district?: string;
-};
+  parentNode?: string;
+  childNode?: string;
+}; 

--- a/src/components/DualListBox2/types.ts
+++ b/src/components/DualListBox2/types.ts
@@ -5,4 +5,7 @@ export type Item = {
   groupName?: string;
   // 項目のラベル
   label: string;
+  // 階層構造のための追加プロパティ
+  prefecture?: string;
+  district?: string;
 };

--- a/src/components/DualListBox2/types.ts
+++ b/src/components/DualListBox2/types.ts
@@ -8,4 +8,4 @@ export type Item = {
   // 階層構造のための追加プロパティ
   parentNode?: string;
   childNode?: string;
-}; 
+};


### PR DESCRIPTION
# DualListBox2: 無限スクロール、固定ヘッダー、表示件数制御によるユーザビリティ改善

## 変更内容

### 1. 無限スクロールの実装
- 「さらに読み込む」ボタンを削除し、Intersection Observerによる自動読み込みを実装
- `loadMoreRef`を使用した監視要素（高さ20px）を追加
- `handleIntersection`コールバックの実装
  - 画面下端から100px手前で検知（`rootMargin: "100px"`）
  - 要素の10%表示で発火（`threshold: 0.1`）
- ローディング状態管理用の`isLoadingMore`ステートを追加

### 2. 固定ヘッダーの実装
- `RightPanelHeader`に`position: sticky`を追加
- `top: -1px`で上部に固定
- `z-index: 2`で他の要素より前面に表示
- `SelectedPanelHeading`（「追加」/「除外」のヘッダー）も固定表示に
- スクロール時の視認性向上のため背景色とボーダーを追加

### 3. 表示件数制御機能
- storybookのサンプルにデフォルトの表示件数を50件に設定
- 表示件数オプション：[10, 50, 100, 200]を追加
- `pageSize`と`onPageSizeChange`プロパティを追加
- `DualListBox2MenuCountControl`コンポーネントを実装

## テスト
- 無限スクロール機能のテストを追加
- 固定ヘッダーの動作テストを追加
- 表示件数制御のテストを追加
- スナップショットの更新

## ドキュメント
- Storybookの例を更新
- 新規プロパティのドキュメントを追加
- 新機能の使用例を追加

## スクリーンショット

https://github.com/user-attachments/assets/12c5aaf4-ec8e-4894-ad27-b7880c06d0d0

## チェックリスト
- [x] changesetの追加
- [x] テストの追加
- [x] ドキュメントの更新
- [x] Storybookの更新
- [x] 各ブラウザでの動作確認
- [x] アクセシビリティの確認

## レビュアーへの注意点
1. Intersection Observerの実装について
   - スクロール検知のタイミングが適切か
   - パフォーマンスへの影響

2. 固定ヘッダーについて
   - スクロール時の視認性
   - モバイル表示での動作

3. 表示件数制御について
   - 件数変更時のUXが適切か
   - 初期表示のパフォーマンス

## 動作確認項目
- [x] 無限スクロールが適切なタイミングで発火するか
- [x] ヘッダーが正しく固定されるか
- [x] 表示件数の変更が正しく反映されるか
- [x] モバイル表示で問題ないか
- [ ] 大量データ時のパフォーマンス

## 関連Issue
[関連するIssue番号]