### PR TITLE
Androidでエンターキーでの決定が実行できない問題の修正

### DIFF
--- a/.changeset/light-dodos-behave.md
+++ b/.changeset/light-dodos-behave.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Fix: Enter key behavior on Android devices in FilterTagInput component

--- a/src/components/FilterTagInput/FilterTagInput.tsx
+++ b/src/components/FilterTagInput/FilterTagInput.tsx
@@ -300,6 +300,7 @@ export const FilterTagInput = ({
       if (trimmedValue === "" || values.includes(trimmedValue)) return;
 
       if (event.key === "Enter") {
+        event.preventDefault();
         onChange([...values, trimmedValue]);
         setInputValue("");
         requestAnimationFrame(() => {

--- a/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
+++ b/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
           </button>
         </span>
         <div
-          class="sc-jIZahH diZQGd"
+          class="sc-jIZahH jTtTje"
         >
           <div
             class="sc-himrzO aScQJ"

--- a/src/components/FilterTagInput/styled.tsx
+++ b/src/components/FilterTagInput/styled.tsx
@@ -96,8 +96,10 @@ export const InlineInput = styled.div`
 
     @media (max-width: ${BreakPoint.MEDIUM}px) {
       font-size: 16px; /* Prevent iOS zoom */
-      transform: scale(0.8125); /* Scale down to look like 13px (13/16) */
+      /*
+      transform: scale(0.8125); 
       transform-origin: left center;
+      */
     }
 
     &:focus {

--- a/src/components/FilterTagInput/styled.tsx
+++ b/src/components/FilterTagInput/styled.tsx
@@ -94,6 +94,12 @@ export const InlineInput = styled.div`
     background: transparent;
     outline: none;
 
+    @media (max-width: ${BreakPoint.MEDIUM}px) {
+      font-size: 16px; /* Prevent iOS zoom */
+      transform: scale(0.8125); /* Scale down to look like 13px (13/16) */
+      transform-origin: left center;
+    }
+
     &:focus {
       isolation: isolate;
       z-index: 1;
@@ -295,6 +301,12 @@ export const PanelInput = styled.div`
     font: inherit;
     outline: none;
     background: transparent;
+
+    @media (max-width: ${BreakPoint.MEDIUM}px) {
+      font-size: 16px; /* Prevent iOS zoom */
+      transform: scale(0.8125); /* Scale down to look like 13px (13/16) */
+      transform-origin: left center;
+    }
   }
 `;
 export const PanelInputSpacer = styled.div`

--- a/src/components/FilterTagInput/styled.tsx
+++ b/src/components/FilterTagInput/styled.tsx
@@ -96,10 +96,6 @@ export const InlineInput = styled.div`
 
     @media (max-width: ${BreakPoint.MEDIUM}px) {
       font-size: 16px; /* Prevent iOS zoom */
-      /*
-      transform: scale(0.8125); 
-      transform-origin: left center;
-      */
     }
 
     &:focus {


### PR DESCRIPTION
# 原因
Android系のOSでこの問題が発生する主な理由は、デフォルトのブラウザの動作として、Androidではエンターキーを押すとフォームのサブミットやフォーカスの移動が優先される場合があります。
現在のコードではevent.preventDefault()が呼ばれていないため、ブラウザのデフォルトの動作（フォーカスの移動）が実行されてしまいます。

# 解決策
エンターキーが押された時にevent.preventDefault()を呼び出すことで、ブラウザのデフォルトの動作（フォーカスの移動）を防ぎます。
その後、意図した動作（タグの追加）を実行します。

デフォルト動作を奪うことにはなるが、フォーカスをこの挙動の中に限定しているので問題はない。