### PR TITLE
chore(github): update actions/checkout and actions/setup-node versions

### DIFF
--- a/.github/actions/setup-yarn/action.yaml
+++ b/.github/actions/setup-yarn/action.yaml
@@ -4,12 +4,12 @@ description: "Setup yarn"
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 20.x
     - name: install

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -10,7 +10,7 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-yarn
       - name: check changesets
         run: make -f ci.mk check_changesets

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ jobs:
   test-lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-yarn
       - name: lint
         run: make -f ci.mk lint

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,19 @@
+name: Pinact
+on:
+  pull_request:
+    paths:
+      - .github/**/*.ya?ml
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@b8eaad3a978e0571224d05c24308297cf2c9edc1 # v0.1.3
+        with:
+          skip_push: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.ref }}
           token: ${{ secrets.FLUCT_MEMBER_GITHUB_TOKEN }}
       - name: Unshallow
         run: git fetch --prune --unshallow --tags
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 18.x
       - name: install
@@ -29,7 +29,7 @@ jobs:
         run: make -f ci.mk build
       - name: Create Release Pull Request or Publish to npm
         id: check_changesets
-        uses: changesets/action@v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
## 概要
- GitHub Actionsで使用している`actions/checkout`と`actions/setup-node`を特定のバージョンに更新しました
- すべてのワークフローで一貫したバージョンを使用することで、安定性と信頼性を向上させています

## テスト計画
- CIが正常に実行されることを確認する
- 変更はGitHub Actionsの設定のみなので、アプリケーションの動作に影響はありません

🤖 Generated with [Claude Code](https://claude.ai/code)