### PR TITLE
Dual listbox2のサブメニューが強制表示だったのを修正

### DIFF
--- a/.changeset/lazy-humans-collect.md
+++ b/.changeset/lazy-humans-collect.md
@@ -1,0 +1,10 @@
+---
+"ingred-ui": patch
+---
+
+Dual listbox2で件数変更メニューが不要な場合でも強制的に表示されてしまう状態だったのを修正したもの。
+
+- menuButtons propsを判定する表示制御を組み込んだ
+- その他細かい修正
+  - 不要なwidthの削除
+  - css gridの動的な変更

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -634,8 +634,9 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
-                {/* 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする */}
-                {/* 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする */}
+                {/** 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
+                  * 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
+                  */}
                 {(menuButtons || onPageSizeChange) && (
                   <ContextMenu2Container>
                     <ContextMenu2

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -615,7 +615,7 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
               role="tabpanel"
               aria-labelledby="list-items-tab"
             >
-              <styled.LeftPanelHeader>
+              <styled.LeftPanelHeader hasMenu={!!(menuButtons || onPageSizeChange)}>
                 <styled.HeaderSearch>
                   <Icon name="search" size="sm" color={colors.basic[600]} />
                   <input
@@ -634,25 +634,26 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
-                <ContextMenu2Container>
-                  <ContextMenu2
-                    width={136}
-                    trigger={
-                      <styled.HeaderMenuButton type="button">
-                        <Icon name="more_vert" color={colors.basic[900]} />
-                      </styled.HeaderMenuButton>
-                    }
-                  >
-                    {onPageSizeChange && (
-                      <DualListBox2MenuCountControl
-                        pageSize={pageSize}
-                        pageSizeOptions={pageSizeOptions}
-                        onPageSizeChange={onPageSizeChange}
-                      />
-                    )}
-                    {menuButtons}
-                  </ContextMenu2>
-                </ContextMenu2Container>
+                {(menuButtons || onPageSizeChange) && (
+                  <ContextMenu2Container>
+                    <ContextMenu2
+                      trigger={
+                        <styled.HeaderMenuButton type="button">
+                          <Icon name="more_vert" color={colors.basic[900]} />
+                        </styled.HeaderMenuButton>
+                      }
+                    >
+                      {onPageSizeChange && (
+                        <DualListBox2MenuCountControl
+                          pageSize={pageSize}
+                          pageSizeOptions={pageSizeOptions}
+                          onPageSizeChange={onPageSizeChange}
+                        />
+                      )}
+                      {menuButtons}
+                    </ContextMenu2>
+                  </ContextMenu2Container>
+                )}
                 <styled.HeaderCount>
                   {loading ? (
                     <Spinner width="16px" />

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -615,7 +615,9 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
               role="tabpanel"
               aria-labelledby="list-items-tab"
             >
-              <styled.LeftPanelHeader hasMenu={!!(menuButtons || onPageSizeChange)}>
+              <styled.LeftPanelHeader
+                hasMenu={!!(menuButtons || onPageSizeChange)}
+              >
                 <styled.HeaderSearch>
                   <Icon name="search" size="sm" color={colors.basic[600]} />
                   <input
@@ -634,10 +636,10 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
-                {/** 
-                  * 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
-                  * 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
-                **/}
+                {/**
+                 * 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
+                 * 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
+                 **/}
                 {(menuButtons || onPageSizeChange) && (
                   <ContextMenu2Container>
                     <ContextMenu2

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -634,9 +634,10 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
-                {/** 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
+                {/** 
+                  * 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
                   * 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
-                  */}
+                **/}
                 {(menuButtons || onPageSizeChange) && (
                   <ContextMenu2Container>
                     <ContextMenu2

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -634,6 +634,8 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
+                 // 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
+                 // 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
                 {(menuButtons || onPageSizeChange) && (
                   <ContextMenu2Container>
                     <ContextMenu2

--- a/src/components/DualListBox2/DualListBox2.tsx
+++ b/src/components/DualListBox2/DualListBox2.tsx
@@ -634,8 +634,8 @@ export const DualListBox2 = forwardRef<HTMLDivElement, DualListBox2Props>(
                     />
                   )}
                 </styled.HeaderSearch>
-                 // 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする
-                 // 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする
+                {/* 件数変更メニューを利用する、もしくはその他のメニューを表示する場合に条件付きレンダリングをする */}
+                {/* 将来的には、メニューを表示するかどうかをコンテキストメニューの表示によって切り替えるようにする */}
                 {(menuButtons || onPageSizeChange) && (
                   <ContextMenu2Container>
                     <ContextMenu2

--- a/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
+++ b/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD bBhWi"
+          class="sc-breuTD jaTTxd"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -600,7 +600,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD bBhWi"
+          class="sc-breuTD ha-dJAk"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -631,32 +631,6 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
               value=""
             />
           </div>
-          <button
-            aria-expanded="false"
-            aria-haspopup="dialog"
-            class="sc-fnykZs elYlne"
-            type="button"
-          >
-            <span
-              class="sc-eCYdqJ iymozk"
-              size="18"
-            >
-              <svg
-                viewBox="0 0 18 18"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h18v18H0z"
-                  fill="none"
-                />
-                <path
-                  d="M11.5,3A1.5,1.5,0,1,0,13,4.5,1.5,1.5,0,0,0,11.5,3Zm0,10.5A1.5,1.5,0,1,0,13,15,1.5,1.5,0,0,0,11.5,13.5Zm0-5.25A1.5,1.5,0,1,0,13,9.75,1.5,1.5,0,0,0,11.5,8.25Z"
-                  fill="#041C33"
-                  transform="translate(-2.5 -0.75)"
-                />
-              </svg>
-            </span>
-          </button>
           <div
             class="sc-fEOsli diBZUB"
           >
@@ -1080,7 +1054,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD bBhWi"
+          class="sc-breuTD ha-dJAk"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -1112,32 +1086,6 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
               value=""
             />
           </div>
-          <button
-            aria-expanded="false"
-            aria-haspopup="dialog"
-            class="sc-fnykZs elYlne"
-            type="button"
-          >
-            <span
-              class="sc-eCYdqJ iymozk"
-              size="18"
-            >
-              <svg
-                viewBox="0 0 18 18"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h18v18H0z"
-                  fill="none"
-                />
-                <path
-                  d="M11.5,3A1.5,1.5,0,1,0,13,4.5,1.5,1.5,0,0,0,11.5,3Zm0,10.5A1.5,1.5,0,1,0,13,15,1.5,1.5,0,0,0,11.5,13.5Zm0-5.25A1.5,1.5,0,1,0,13,9.75,1.5,1.5,0,0,0,11.5,8.25Z"
-                  fill="#041C33"
-                  transform="translate(-2.5 -0.75)"
-                />
-              </svg>
-            </span>
-          </button>
           <div
             class="sc-fEOsli diBZUB"
           >

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -142,12 +142,16 @@ export const LeftPanelBody = styled.div`
   overflow-y: auto;
 `;
 
-export const LeftPanelHeader = styled.div`
+export const LeftPanelHeader = styled.div<{ hasMenu?: boolean }>`
   display: grid;
   grid-template:
-    "search search search search menu"
-    "count buttons . load load" /
-    auto auto 1fr auto;
+    ${({ hasMenu = false }) =>
+      hasMenu
+        ? `"search search menu"
+           "count buttons buttons"`
+        : `"search search search"
+           "count buttons buttons"`} /
+    auto 1fr auto;
   align-items: center;
   gap: 8px;
   padding: 16px;


### PR DESCRIPTION
# 概要
Dual listbox2で件数変更メニューが不要な場合でも強制的に表示されてしまう状態だったのを修正したもの。

- menuButtons propsを判定する表示制御を組み込んだ
- その他細かい修正
  - 不要なwidthの削除
  - css gridの動的な変更

<img width="263" alt="image" src="https://github.com/user-attachments/assets/1f7a4c48-46d0-45c0-aa44-18ab59ee659a" />
