### PR TITLE
Update/styled component v6

### DIFF
--- a/.changeset/evil-masks-turn.md
+++ b/.changeset/evil-masks-turn.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": minor
+---
+
+styled-components v6へのアップデート対応

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "@floating-ui/react": "^0.26.0",
     "dayjs": "^1.11.6",
     "react-select": "^5.7.0",
-    "react-transition-group": "^4.4.1"
+    "react-transition-group": "^4.4.1",
+    "styled-components": "^6.1.17",
+    "stylis": "^4.3.6"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "styled-components": ">= 5.X"
+    "styled-components": "^6.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.4",
@@ -66,7 +68,6 @@
     "@types/react-dom": "18.0.5",
     "@types/react-transition-group": "4.4.4",
     "@types/rollup-plugin-peer-deps-external": "2.2.1",
-    "@types/styled-components": "5.1.25",
     "@types/unist": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.10.0",
@@ -90,7 +91,6 @@
     "rollup-plugin-peer-deps-external": "2.2.4",
     "scaffdog": "3.0.0",
     "storybook": "8.6.12",
-    "styled-components": "5.3.5",
     "ts-jest": "29.1.0",
     "typescript": "5.2.2",
     "vite": "4.5.13"

--- a/src/components/ContextMenu2/ContextMenu2HeadingItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2HeadingItem.tsx
@@ -9,9 +9,11 @@ type HeadingItemProps = {
   children: React.ReactNode;
 };
 
-export const ContextMenu2HeadingItem = styled(({ className, children }: HeadingItemProps) => {
-  return <p className={className}>{children}</p>;
-})`
+export const ContextMenu2HeadingItem = styled(
+  ({ className, children }: HeadingItemProps) => {
+    return <p className={className}>{children}</p>;
+  },
+)`
   border-radius: 4px;
   padding: 4px 8px;
   margin-bottom: 8px;

--- a/src/components/ContextMenu2/ContextMenu2HeadingItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2HeadingItem.tsx
@@ -4,7 +4,12 @@ import { colors } from "../../styles";
 
 // 特に機能を持たない、見た目付きの ContextMenu2 用の「見出し」
 
-export const ContextMenu2HeadingItem = styled(({ className, children }) => {
+type HeadingItemProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+export const ContextMenu2HeadingItem = styled(({ className, children }: HeadingItemProps) => {
   return <p className={className}>{children}</p>;
 })`
   border-radius: 4px;

--- a/src/components/ContextMenu2/ContextMenu2SeparatorItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2SeparatorItem.tsx
@@ -8,9 +8,11 @@ type SeparatorItemProps = {
   className?: string;
 };
 
-export const ContextMenu2SeparatorItem = styled(({ className }: SeparatorItemProps) => {
-  return <hr className={className} />;
-})`
+export const ContextMenu2SeparatorItem = styled(
+  ({ className }: SeparatorItemProps) => {
+    return <hr className={className} />;
+  },
+)`
   margin: 8px 0;
   color: ${colors.basic[200]};
   border-top: 1px solid currentColor;

--- a/src/components/ContextMenu2/ContextMenu2SeparatorItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2SeparatorItem.tsx
@@ -4,7 +4,11 @@ import { colors } from "../../styles";
 
 // 特に機能を持たない、見た目付きの ContextMenu2 用の区切り線
 
-export const ContextMenu2SeparatorItem = styled(({ className }) => {
+type SeparatorItemProps = {
+  className?: string;
+};
+
+export const ContextMenu2SeparatorItem = styled(({ className }: SeparatorItemProps) => {
   return <hr className={className} />;
 })`
   margin: 8px 0;

--- a/src/components/DataTable2/DataTable2.stories.tsx
+++ b/src/components/DataTable2/DataTable2.stories.tsx
@@ -262,12 +262,7 @@ export const Default: StoryObj<typeof meta> = {
               >
                 アーカイブする
               </ContextMenu2ButtonItem>
-              <ContextMenu2HeadingItem
-                closeOnClick
-                onClick={() => alert("任意機能")}
-              >
-                操作
-              </ContextMenu2HeadingItem>
+              <ContextMenu2HeadingItem>操作</ContextMenu2HeadingItem>
               <ContextMenu2ButtonItem
                 closeOnClick
                 onClick={() => alert("任意機能")}

--- a/src/components/Fade/Fade.tsx
+++ b/src/components/Fade/Fade.tsx
@@ -12,7 +12,7 @@ const Fade: React.FunctionComponent<CSSTransitionProps> = ({
 
   return (
     <Styled.CSSTransition
-      nodeRef={nodeRef}
+      nodeRef={nodeRef as React.RefObject<unknown>}
       appear={true}
       mountOnEnter={true}
       timeout={timeout}

--- a/src/components/FilterTagInput/styled.tsx
+++ b/src/components/FilterTagInput/styled.tsx
@@ -177,7 +177,12 @@ const PanelInner = styled.div`
   }
 `;
 
-export const Panel = styled(({ className, children }) => {
+type PanelProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+export const Panel = styled(({ className, children }: PanelProps) => {
   return (
     <div className={className}>
       <PanelInner>{children}</PanelInner>

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -7,7 +7,7 @@ type Props = {
   children: React.ReactNode;
 };
 const ThemeProvider: React.FunctionComponent<Props> = ({ children, theme }) => (
-  <StyleSheetManager enableVendorPrefixes>
+  <StyleSheetManager disableVendorPrefixes={false}>
     <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
   </StyleSheetManager>
 );

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ThemeContext } from "styled-components";
+import { ThemeContext, StyleSheetManager } from "styled-components";
 import { Theme } from "./createTheme";
 
 type Props = {
@@ -7,7 +7,9 @@ type Props = {
   children: React.ReactNode;
 };
 const ThemeProvider: React.FunctionComponent<Props> = ({ children, theme }) => (
-  <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  <StyleSheetManager enableVendorPrefixes>
+    <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  </StyleSheetManager>
 );
 
 export { ThemeProvider };

--- a/src/utils/spacer.ts
+++ b/src/utils/spacer.ts
@@ -1,4 +1,3 @@
-import { ThemedStyledProps } from "styled-components";
 import { Theme } from "../themes";
 
 export type SpacerProps = {
@@ -33,7 +32,9 @@ export type SpacerProps = {
   py?: number;
 };
 
-export const getMargin = (payload: ThemedStyledProps<SpacerProps, Theme>) => {
+type StyledProps<P> = P & { theme: Theme };
+
+export const getMargin = (payload: StyledProps<SpacerProps>) => {
   const space = payload.theme.spacing;
   const mt = payload.mt || payload.my || payload.m || 0;
   const mr = payload.mr || payload.mx || payload.m || 0;
@@ -44,7 +45,7 @@ export const getMargin = (payload: ThemedStyledProps<SpacerProps, Theme>) => {
   }px`;
 };
 
-export const getPadding = (payload: ThemedStyledProps<SpacerProps, Theme>) => {
+export const getPadding = (payload: StyledProps<SpacerProps>) => {
   const space = payload.theme.spacing;
   const pt = payload.pt || payload.py || payload.p || 0;
   const pr = payload.pr || payload.px || payload.p || 0;
@@ -55,7 +56,7 @@ export const getPadding = (payload: ThemedStyledProps<SpacerProps, Theme>) => {
   }px`;
 };
 
-export const spacer = (payload: ThemedStyledProps<SpacerProps, Theme>) => {
+export const spacer = (payload: StyledProps<SpacerProps>) => {
   return `
     ${getMargin(payload)};
     ${getPadding(payload)};

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,7 +61,7 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.22.5", "@babel/helper-annotate-as-pure@^7.27.1":
+"@babel/helper-annotate-as-pure@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz#4345d81a9a46a6486e24d069469f13e60445c05d"
   integrity sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==
@@ -120,7 +120,7 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.5", "@babel/helper-module-imports@^7.27.1":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
   integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
@@ -314,7 +314,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.7.2":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz#2f9beb5eff30fa507c5532d107daac7b888fa34c"
   integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
@@ -958,7 +958,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse@^7.18.9", "@babel/traverse@^7.27.1", "@babel/traverse@^7.4.5":
+"@babel/traverse@^7.18.9", "@babel/traverse@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
   integrity sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==
@@ -1274,12 +1274,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
   integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
-"@emotion/is-prop-valid@^1.1.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz#8d5cf1132f836d7adbe42cf0b49df7816fc88240"
-  integrity sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==
+"@emotion/is-prop-valid@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz#d4175076679c6a26faa92b03bb786f9e52612337"
+  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
   dependencies:
-    "@emotion/memoize" "^0.9.0"
+    "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
 "@emotion/memoize@^0.9.0":
   version "0.9.0"
@@ -1316,20 +1321,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
   integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
-"@emotion/stylis@^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+"@emotion/unitless@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
+  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
 
 "@emotion/unitless@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
   integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
-
-"@emotion/unitless@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/use-insertion-effect-with-fallbacks@^1.2.0":
   version "1.2.0"
@@ -2690,14 +2690,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@*":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz#6bba74383cdab98e8db4e20ce5b4a6b98caed010"
-  integrity sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/http-cache-semantics@^4.0.2":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -2861,14 +2853,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/styled-components@5.1.25":
-  version "5.1.25"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.25.tgz#0177c4ab5fa7c6ed0565d36f597393dae3f380ad"
-  integrity sha512-fgwl+0Pa8pdkwXRoVPP9JbqF0Ivo9llnmsm+7TCI330kbPIFd9qv1Lrhr37shf4tnxCOSu+/IgqM7uJXLWZZNQ==
-  dependencies:
-    "@types/hoist-non-react-statics" "*"
-    "@types/react" "*"
-    csstype "^3.0.2"
+"@types/stylis@4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
+  integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
 
 "@types/tough-cookie@*":
   version "4.0.5"
@@ -3517,17 +3505,6 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   integrity sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.4"
-
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
-  integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-module-imports" "^7.22.5"
-    "@babel/plugin-syntax-jsx" "^7.22.5"
-    lodash "^4.17.21"
-    picomatch "^2.3.1"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.1.0"
@@ -4207,7 +4184,7 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-to-react-native@^3.0.0:
+css-to-react-native@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
   integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
@@ -4258,7 +4235,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
+csstype@3.1.3, csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
@@ -5905,11 +5882,6 @@ has-bigints@^1.0.2:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
   integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
 
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -5973,7 +5945,7 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7799,7 +7771,7 @@ mute-stream@1.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
 
-nanoid@^3.3.8:
+nanoid@^3.3.7, nanoid@^3.3.8:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -8376,6 +8348,15 @@ postcss-value-parser@^4.0.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@8.4.49:
+  version "8.4.49"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postcss@^8.4.27:
   version "8.5.3"
@@ -9140,7 +9121,7 @@ set-proto@^1.0.0:
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
 
-shallowequal@^1.1.0:
+shallowequal@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -9543,33 +9524,35 @@ strnum@^1.1.1:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
-styled-components@5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.5.tgz#a750a398d01f1ca73af16a241dec3da6deae5ec4"
-  integrity sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==
+styled-components@^6.0.0:
+  version "6.1.17"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.1.17.tgz#59032edd7efa59e114ddbc41165f0984d0fa4fb7"
+  integrity sha512-97D7DwWanI7nN24v0D4SvbfjLE9656umNSJZkBkDIWL37aZqG/wRQ+Y9pWtXyBIM/NSfcBzHLErEsqHmJNSVUg==
   dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
+    "@emotion/is-prop-valid" "1.2.2"
+    "@emotion/unitless" "0.8.1"
+    "@types/stylis" "4.2.5"
+    css-to-react-native "3.2.0"
+    csstype "3.1.3"
+    postcss "8.4.49"
+    shallowequal "1.1.0"
+    stylis "4.3.2"
+    tslib "2.6.2"
 
 stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
-supports-color@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
+stylis@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
+  integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
+
+stylis@^4.0.0:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.6.tgz#7c7b97191cb4f195f03ecab7d52f7902ed378320"
+  integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -9803,6 +9786,11 @@ tsconfig-paths@^4.2.0:
     json5 "^2.2.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
# styled-components v6へのアップデート対応

## 変更内容

このPRではstyled-components v5からv6へアップデートを行い、それに伴う以下の変更を実施しました：

### 依存関係の更新
- `styled-components`を`5.3.5`から`6.1.17`へアップデート
- `stylis`を依存関係に追加（`4.3.6`）
- `@types/styled-components`を削除（v6では不要）

### コード修正
1. `ThemeProvider.tsx`の修正
   - `StyleSheetManager`を導入し、`disableVendorPrefixes={false}`設定を追加

2. 型定義の修正
   - `ThemedStyledProps`から独自の`StyledProps`型への置き換え
   - コンポーネントの型定義を追加・強化（`ContextMenu2HeadingItem.tsx`、`ContextMenu2SeparatorItem.tsx`など）

3. Stories内の不正なpropsの削除
   - `ContextMenu2HeadingItem`から不正な`closeOnClick`および`onClick`プロパティを削除

### その他の変更
- 互換性を保つための型インポートの修正
- `utils/spacer.ts`の型定義を更新

## テスト方法

以下を確認してください：
- `yarn lint`でエラーが出ないこと
- Storybookが正しく動作すること
- 既存コンポーネントのスタイルに問題がないこと

## 関連情報

- styled-components v6の変更点: https://styled-components.com/releases#v6.0.0
