### PR TITLE
Fix / Dual listbox2でStickyの設定が正しくなかったのを修正

### DIFF
--- a/.changeset/bright-cobras-change.md
+++ b/.changeset/bright-cobras-change.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Dual listbox2のsticky設定のバグ修正

--- a/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
+++ b/src/components/DualListBox2/__tests__/__snapshots__/DualListBox2.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
   >
     <ul
       aria-label="リストの表示切り替え"
-      class="sc-jqUVSM byqyFJ"
+      class="sc-jqUVSM bZycZw"
       role="tablist"
     >
       <li>
@@ -50,7 +50,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD jaTTxd"
+          class="sc-breuTD cxAgmh"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -165,7 +165,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           </ul>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <div
             class="sc-cxabCf edqkNY"
@@ -416,7 +416,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-dIouRR kkysIy"
+          class="sc-dIouRR iJGmbm"
         >
           <div
             class="sc-hHLeRK fhzPNq"
@@ -480,10 +480,10 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
           </div>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -511,7 +511,7 @@ exports[`DualListBox2 component testing DualListBox2 1`] = `
             />
           </div>
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -559,7 +559,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
   >
     <ul
       aria-label="リストの表示切り替え"
-      class="sc-jqUVSM byqyFJ"
+      class="sc-jqUVSM bZycZw"
       role="tablist"
     >
       <li>
@@ -600,7 +600,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD ha-dJAk"
+          class="sc-breuTD hzKQQI"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -689,7 +689,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
           </ul>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <div
             class="sc-gicCDI bcXmbd"
@@ -860,7 +860,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-dIouRR kkysIy"
+          class="sc-dIouRR iJGmbm"
         >
           <div
             class="sc-hHLeRK fhzPNq"
@@ -924,10 +924,10 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
           </div>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -960,7 +960,7 @@ exports[`DualListBox2 component testing DualListBox2 Accordion 1`] = `
             />
           </div>
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -1013,7 +1013,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
   >
     <ul
       aria-label="リストの表示切り替え"
-      class="sc-jqUVSM byqyFJ"
+      class="sc-jqUVSM bZycZw"
       role="tablist"
     >
       <li>
@@ -1054,7 +1054,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
         role="tabpanel"
       >
         <div
-          class="sc-breuTD ha-dJAk"
+          class="sc-breuTD hzKQQI"
         >
           <div
             class="sc-ksZaOG HDGZE"
@@ -1146,7 +1146,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
           </ul>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <button
             aria-expanded="false"
@@ -1245,7 +1245,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
         class="sc-crXcEl bjMufC"
       >
         <div
-          class="sc-dIouRR kkysIy"
+          class="sc-dIouRR iJGmbm"
         >
           <div
             class="sc-hHLeRK fhzPNq"
@@ -1309,10 +1309,10 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
           </div>
         </div>
         <div
-          class="sc-evZas dnjCJp"
+          class="sc-evZas fZGMkm"
         >
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"
@@ -1345,7 +1345,7 @@ exports[`DualListBox2 component testing DualListBox2 Section 1`] = `
             />
           </div>
           <p
-            class="sc-bBrHrO gxaSUU"
+            class="sc-bBrHrO gXhUgk"
           >
             <span
               class="sc-eCYdqJ iymozk"

--- a/src/components/DualListBox2/styled.ts
+++ b/src/components/DualListBox2/styled.ts
@@ -60,6 +60,11 @@ export const TabList = styled.ul`
 
   @media (max-width: 640px) {
     display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: ${colors.basic[0]};
+    border-bottom: 1px solid ${colors.basic[400]};
   }
 
   button {
@@ -140,6 +145,10 @@ export const LeftPanel = styled.div<{ isShow: boolean }>`
 export const LeftPanelBody = styled.div`
   flex-grow: 1;
   overflow-y: auto;
+
+  @media (max-width: 640px) {
+    overflow: initial;
+  }
 `;
 
 export const LeftPanelHeader = styled.div<{ hasMenu?: boolean }>`
@@ -161,6 +170,9 @@ export const LeftPanelHeader = styled.div<{ hasMenu?: boolean }>`
 
   @media (max-width: 640px) {
     border-radius: 0;
+    position: sticky;
+    top: 36.5px;
+    z-index: 1;
   }
 `;
 
@@ -273,9 +285,13 @@ export const HeaderLoadButton = styled.button`
 export const RightPanel = LeftPanel;
 
 export const RightPanelHeader = styled.div`
-  position: sticky;
-  top: -1px;
-  z-index: 2;
+  @media (max-width: 640px) {
+    display: flex;
+    position: sticky;
+    top: 36.5px;
+    z-index: 1;
+    border-left: none;
+  }
   display: flex;
   justify-content: space-between;
   padding: 8px 16px;
@@ -336,6 +352,12 @@ export const SelectedPanelHeading = styled.p`
   line-height: 16px;
   color: ${colors.basic[900]};
   background: ${colors.basic[200]};
+
+  @media (max-width: 640px) {
+    border-left: none;
+    top: 81.5px;
+    z-index: 1;
+  }
 `;
 
 //


### PR DESCRIPTION
# バグ修正
アプリケーションに搭載した時、無駄にstickyが効いてしまいz-indexがおかしくなる。
これはモバイルでの表示時に必要なものなので、それ以外では無効になるようメディアクエリを追加して解消した。

<img width="549" alt="image" src="https://github.com/user-attachments/assets/a826ec1f-dbe8-40b1-8a92-65e82bb7485e" />

# その他、Sticky設定を正しくした
下記の挙動のように、モバイルでStickyにするための指定を追加した。


https://github.com/user-attachments/assets/0bfc7bbc-ec71-4232-a544-f9ed4e7b4c58

