### PR TITLE
Select2: options propsの廃止と宣言的API（JSX）への統一リファクタリングと選択肢の変更を検知するコールバックの追加

### DIFF
--- a/.changeset/famous-buses-add.md
+++ b/.changeset/famous-buses-add.md
@@ -1,0 +1,6 @@
+---
+"ingred-ui": major
+---
+
+Select2: options propsを廃止し、宣言的API（JSXの子要素）に統一しました。  
+

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -476,3 +476,62 @@ Select2Separatorはグループ間にセパレータを追加します。
     },
   },
 };
+
+// 選択数上限サンプル（厳密版）
+export const WithMaxSelectionStrict = () => {
+  const MAX = 5;
+  const [selected, setSelected] = React.useState<(string | number)[]>([]);
+  const [tempSelected, setTempSelected] = React.useState<(string | number)[]>(
+    [],
+  );
+  const options = [
+    { value: "a", label: "A" },
+    { value: "b", label: "B" },
+    { value: "c", label: "C" },
+    { value: "d", label: "D" },
+    { value: "e", label: "E" },
+    { value: "f", label: "F" },
+    { value: "g", label: "G" },
+  ];
+  return (
+    <div style={{ width: 300 }}>
+      <Select2
+        multiple
+        value={selected}
+        onChange={(newSelected: string[] | number[] | string | number) => {
+          if (Array.isArray(newSelected) && newSelected.length > MAX) {
+            // 上限を超えたら何もしない
+            return;
+          }
+          setSelected(newSelected as (string | number)[]);
+        }}
+        onTempChange={setTempSelected}
+        placeholder={`最大${MAX}件まで選択可能`}
+        applyButtonText="適用"
+        cancelButtonText="キャンセル"
+      >
+        {options.map((opt) => (
+          <Select2Option
+            key={opt.value}
+            value={opt.value}
+            disabled={
+              tempSelected.length >= MAX && !tempSelected.includes(opt.value)
+            }
+          >
+            {opt.label}
+          </Select2Option>
+        ))}
+      </Select2>
+      <div style={{ marginTop: 16 }}>
+        <p>選択中: {selected.join(", ")}</p>
+      </div>
+    </div>
+  );
+};
+WithMaxSelectionStrict.parameters = {
+  docs: {
+    description: {
+      story: `選択数の上限（${5}件）を超えた場合、未選択のオプションがdisabledになり、onChangeでも5件を超える選択は受け付けません。`,
+    },
+  },
+};

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -505,10 +505,10 @@ export const WithMaxSelectionStrict = () => {
           }
           setSelected(newSelected as (string | number)[]);
         }}
-        onTempChange={setTempSelected}
         placeholder={`最大${MAX}件まで選択可能`}
         applyButtonText="適用"
         cancelButtonText="キャンセル"
+        onTempChange={setTempSelected}
       >
         {options.map((opt) => (
           <Select2Option

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -167,11 +167,33 @@ WithManyOptions.args = {
 };
 WithManyOptions.decorators = [(Story) => <Story />];
 
-export const WithDisabledOptions: Story<Select2Props> = Template.bind({});
+export const WithDisabledOptions: Story<Select2Props> = (args) => {
+  return (
+    <div style={{ width: 300 }}>
+      <Select2 {...args}>
+        <Select2Option value="apple">りんご</Select2Option>
+        <Select2Option disabled value="banana">
+          バナナ
+        </Select2Option>
+        <Select2Option value="orange">オレンジ</Select2Option>
+        <Select2Option disabled value="grape">
+          ブドウ
+        </Select2Option>
+        <Select2Option value="melon">メロン</Select2Option>
+      </Select2>
+    </div>
+  );
+};
 WithDisabledOptions.args = {
   placeholder: "果物を選択",
 };
-WithDisabledOptions.decorators = [(Story) => <Story />];
+WithDisabledOptions.parameters = {
+  docs: {
+    description: {
+      story: `一部のオプション（バナナ・ブドウ）はdisabled（選択不可）です。`,
+    },
+  },
+};
 
 export const MultipleSelection: Story<Select2Props> = (args) => {
   const [selectedValues, setSelectedValues] = useState<(string | number)[]>([

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -3,7 +3,9 @@ import { Story, Meta } from "@storybook/react";
 import { Select2 } from "./Select2";
 import { Select2Option } from "./Select2Option";
 import { Select2Props, Select2Option as Select2OptionType } from "./types";
-import { ContextMenu2HeadingItem } from "../ContextMenu2";
+import { ContextMenu2HeadingItem, ContextMenu2SeparatorItem } from "../ContextMenu2";
+import { Select2OptionGroup } from "./Select2OptionGroup";
+import { Select2Separator } from "./Select2Separator";
 
 export default {
   title: "Components/Inputs/Select2",
@@ -310,26 +312,42 @@ export const WithDeclarativeAPI = () => {
         value={value}
         onChange={(newValue: any) => setValue(newValue as string | number)}
       >
-        <ContextMenu2HeadingItem>果物</ContextMenu2HeadingItem>
-        {fruitOptions.map((option) => (
-          <Select2Option key={option.value} value={option.value}>
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2OptionGroup label="果物">
+          {fruitOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
 
-        <ContextMenu2HeadingItem>野菜</ContextMenu2HeadingItem>
-        {vegetableOptions.map((option) => (
-          <Select2Option key={option.value} value={option.value}>
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2Separator />
 
-        <ContextMenu2HeadingItem>肉類</ContextMenu2HeadingItem>
-        {meatOptions.map((option) => (
-          <Select2Option key={option.value} value={option.value}>
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2OptionGroup label="野菜">
+          {vegetableOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
+
+        <Select2Separator />
+
+        <Select2OptionGroup label="肉類">
+          {meatOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
       </Select2>
       <div style={{ marginTop: "16px" }}>
         <p>選択された値: {value}</p>
@@ -341,8 +359,9 @@ WithDeclarativeAPI.parameters = {
   docs: {
     description: {
       story: `
-ContextMenu2HeadingItemとContextMenu2SeparatorItemを直接使用した例です。
-Select2コンポーネント内で、これらのコンポーネントと組み合わせることができます。
+Select2OptionGroupコンポーネントとSelect2Separatorコンポーネントを使用した例です。
+Select2OptionGroupはオプションをグループ化し、各グループにラベルを付けることができます。
+Select2Separatorはグループ間にセパレータを追加します。
       `,
     },
   },
@@ -397,30 +416,43 @@ export const WithDeclarativeAPIMultiple = () => {
           }
         }}
       >
-        <ContextMenu2HeadingItem>果物</ContextMenu2HeadingItem>
-        {fruitOptions.map((option) => (
-          <Select2Option key={option.value} value={option.value}>
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2OptionGroup label="果物">
+          {fruitOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
 
-        <ContextMenu2HeadingItem>野菜</ContextMenu2HeadingItem>
-        {vegetableOptions.map((option) => (
-          <Select2Option key={option.value} value={option.value}>
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2Separator />
 
-        <ContextMenu2HeadingItem>肉類</ContextMenu2HeadingItem>
-        {meatOptions.map((option) => (
-          <Select2Option
-            key={option.value}
-            value={option.value}
-            disabled={option.value === "beef"}
-          >
-            {option.label}
-          </Select2Option>
-        ))}
+        <Select2OptionGroup label="野菜">
+          {vegetableOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
+
+        <Select2Separator />
+
+        <Select2OptionGroup label="肉類">
+          {meatOptions.map((option) => (
+            <Select2Option
+              key={option.value}
+              value={option.value}
+              disabled={option.value === "beef"}
+            >
+              {option.label}
+            </Select2Option>
+          ))}
+        </Select2OptionGroup>
       </Select2>
       <div style={{ marginTop: "16px" }}>
         <p>選択された値: {values.join(", ")}</p>
@@ -432,8 +464,11 @@ WithDeclarativeAPIMultiple.parameters = {
   docs: {
     description: {
       story: `
-ContextMenu2HeadingItemとContextMenu2SeparatorItemを直接使用した複数選択の例です。
-複数選択モード（multiple={true}）と宣言的APIを組み合わせることで、グループ化された選択肢から複数の項目を選択できます。
+Select2OptionGroupコンポーネントとSelect2Separatorコンポーネントを使用した複数選択の例です。
+Select2OptionGroupはオプションをグループ化し、各グループにラベルを付けることができます。
+Select2Separatorはグループ間にセパレータを追加します。
+複数選択モード（multiple={true}）と組み合わせることで、グループ化された選択肢から複数の項目を選択できます。
+選択済みの項目はタグとして表示され、タグの削除ボタンをクリックすると選択を解除できます。
       `,
     },
   },

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -3,7 +3,6 @@ import { Story, Meta } from "@storybook/react";
 import { Select2 } from "./Select2";
 import { Select2Option } from "./Select2Option";
 import { Select2Props, Select2Option as Select2OptionType } from "./types";
-import { ContextMenu2HeadingItem, ContextMenu2SeparatorItem } from "../ContextMenu2";
 import { Select2OptionGroup } from "./Select2OptionGroup";
 import { Select2Separator } from "./Select2Separator";
 
@@ -323,8 +322,6 @@ export const WithDeclarativeAPI = () => {
           ))}
         </Select2OptionGroup>
 
-        <Select2Separator />
-
         <Select2OptionGroup label="野菜">
           {vegetableOptions.map((option) => (
             <Select2Option
@@ -427,8 +424,6 @@ export const WithDeclarativeAPIMultiple = () => {
           ))}
         </Select2OptionGroup>
 
-        <Select2Separator />
-
         <Select2OptionGroup label="野菜">
           {vegetableOptions.map((option) => (
             <Select2Option
@@ -439,8 +434,6 @@ export const WithDeclarativeAPIMultiple = () => {
             </Select2Option>
           ))}
         </Select2OptionGroup>
-
-        <Select2Separator />
 
         <Select2OptionGroup label="肉類">
           {meatOptions.map((option) => (

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -97,21 +97,29 @@ const Template: Story<Select2Props> = (args) => {
         onChange={(newValue: string | number | (string | number)[]) =>
           setValue(newValue)
         }
-      />
+      >
+        {options.map((option) => (
+          <Select2Option
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </Select2Option>
+        ))}
+      </Select2>
     </div>
   );
 };
 
 export const Basic: Story<Select2Props> = Template.bind({});
 Basic.args = {
-  options,
   placeholder: "果物を選択",
   searchable: false,
 };
 
 export const WithSearch: Story<Select2Props> = Template.bind({});
 WithSearch.args = {
-  options,
   placeholder: "果物を選択",
   searchable: true,
   searchPlaceholder: "果物を検索",
@@ -130,7 +138,6 @@ searchPlaceholderで検索入力欄のプレースホルダーを指定できま
 
 export const Error: Story<Select2Props> = Template.bind({});
 Error.args = {
-  options,
   placeholder: "果物を選択",
   error: true,
 };
@@ -145,46 +152,26 @@ Error.parameters = {
 
 export const Disabled: Story<Select2Props> = Template.bind({});
 Disabled.args = {
-  options,
   placeholder: "果物を選択",
   disabled: true,
 };
 
 export const WithDefaultValue: Story<Select2Props> = Template.bind({});
 WithDefaultValue.args = {
-  options,
   value: "apple",
 };
 
 export const WithManyOptions: Story<Select2Props> = Template.bind({});
 WithManyOptions.args = {
-  options: [
-    ...options,
-    { value: "watermelon", label: "スイカ" },
-    { value: "lemon", label: "レモン" },
-    { value: "lime", label: "ライム" },
-    { value: "cherry", label: "さくらんぼ" },
-    { value: "blueberry", label: "ブルーベリー" },
-    { value: "raspberry", label: "ラズベリー" },
-    { value: "blackberry", label: "ブラックベリー" },
-    { value: "plum", label: "プラム" },
-    { value: "persimmon", label: "柿" },
-    { value: "fig", label: "イチジク" },
-  ],
   placeholder: "果物を選択",
 };
+WithManyOptions.decorators = [(Story) => <Story />];
 
 export const WithDisabledOptions: Story<Select2Props> = Template.bind({});
 WithDisabledOptions.args = {
-  options: [
-    { value: "apple", label: "りんご" },
-    { value: "banana", label: "バナナ", disabled: true },
-    { value: "orange", label: "オレンジ" },
-    { value: "grape", label: "ブドウ", disabled: true },
-    { value: "melon", label: "メロン" },
-  ],
   placeholder: "果物を選択",
 };
+WithDisabledOptions.decorators = [(Story) => <Story />];
 
 export const MultipleSelection: Story<Select2Props> = (args) => {
   const [selectedValues, setSelectedValues] = useState<(string | number)[]>([
@@ -203,7 +190,17 @@ export const MultipleSelection: Story<Select2Props> = (args) => {
             setSelectedValues(newValues);
           }
         }}
-      />
+      >
+        {options.map((option) => (
+          <Select2Option
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </Select2Option>
+        ))}
+      </Select2>
       <div style={{ marginTop: "16px" }}>
         <p>選択された値: {selectedValues.join(", ")}</p>
       </div>
@@ -211,7 +208,6 @@ export const MultipleSelection: Story<Select2Props> = (args) => {
   );
 };
 MultipleSelection.args = {
-  options,
   placeholder: "果物を選択（複数可）",
   searchable: false,
   applyButtonText: "適用",
@@ -246,7 +242,17 @@ export const MultipleSelectionWithSearch: Story<Select2Props> = (args) => {
             setSelectedValues(newValues);
           }
         }}
-      />
+      >
+        {options.map((option) => (
+          <Select2Option
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </Select2Option>
+        ))}
+      </Select2>
       <div style={{ marginTop: "16px" }}>
         <p>選択された値: {selectedValues.join(", ")}</p>
       </div>
@@ -254,7 +260,6 @@ export const MultipleSelectionWithSearch: Story<Select2Props> = (args) => {
   );
 };
 MultipleSelectionWithSearch.args = {
-  options,
   placeholder: "果物を選択（複数可）",
   searchable: true,
   searchPlaceholder: "果物を検索",
@@ -304,7 +309,6 @@ export const WithDeclarativeAPI = () => {
   return (
     <div style={{ width: "300px" }}>
       <Select2
-        options={[]} // 子要素を使う場合はoptionsは空配列でOK
         placeholder="食材を選択"
         searchable={true}
         searchPlaceholder="検索..."
@@ -313,10 +317,7 @@ export const WithDeclarativeAPI = () => {
       >
         <Select2OptionGroup label="果物">
           {fruitOptions.map((option) => (
-            <Select2Option
-              key={option.value}
-              value={option.value}
-            >
+            <Select2Option key={option.value} value={option.value}>
               {option.label}
             </Select2Option>
           ))}
@@ -324,10 +325,7 @@ export const WithDeclarativeAPI = () => {
 
         <Select2OptionGroup label="野菜">
           {vegetableOptions.map((option) => (
-            <Select2Option
-              key={option.value}
-              value={option.value}
-            >
+            <Select2Option key={option.value} value={option.value}>
               {option.label}
             </Select2Option>
           ))}
@@ -337,10 +335,7 @@ export const WithDeclarativeAPI = () => {
 
         <Select2OptionGroup label="肉類">
           {meatOptions.map((option) => (
-            <Select2Option
-              key={option.value}
-              value={option.value}
-            >
+            <Select2Option key={option.value} value={option.value}>
               {option.label}
             </Select2Option>
           ))}
@@ -399,7 +394,6 @@ export const WithDeclarativeAPIMultiple = () => {
   return (
     <div style={{ width: "300px" }}>
       <Select2
-        options={[]} // 子要素を使う場合はoptionsは空配列でOK
         placeholder="食材を選択（複数可）"
         searchable={true}
         searchPlaceholder="検索..."
@@ -415,10 +409,7 @@ export const WithDeclarativeAPIMultiple = () => {
       >
         <Select2OptionGroup label="果物">
           {fruitOptions.map((option) => (
-            <Select2Option
-              key={option.value}
-              value={option.value}
-            >
+            <Select2Option key={option.value} value={option.value}>
               {option.label}
             </Select2Option>
           ))}
@@ -426,10 +417,7 @@ export const WithDeclarativeAPIMultiple = () => {
 
         <Select2OptionGroup label="野菜">
           {vegetableOptions.map((option) => (
-            <Select2Option
-              key={option.value}
-              value={option.value}
-            >
+            <Select2Option key={option.value} value={option.value}>
               {option.label}
             </Select2Option>
           ))}

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -498,6 +498,9 @@ export const WithMaxSelectionStrict = () => {
       <Select2
         multiple
         value={selected}
+        placeholder={`最大${MAX}件まで選択可能`}
+        applyButtonText="適用"
+        cancelButtonText="キャンセル"
         onChange={(newSelected: string[] | number[] | string | number) => {
           if (Array.isArray(newSelected) && newSelected.length > MAX) {
             // 上限を超えたら何もしない
@@ -505,9 +508,6 @@ export const WithMaxSelectionStrict = () => {
           }
           setSelected(newSelected as (string | number)[]);
         }}
-        placeholder={`最大${MAX}件まで選択可能`}
-        applyButtonText="適用"
-        cancelButtonText="キャンセル"
         onTempChange={setTempSelected}
       >
         {options.map((opt) => (

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -299,8 +299,8 @@ MultipleSelectionWithSearch.parameters = {
   },
 };
 
-// 宣言的APIの例
-export const WithDeclarativeAPI = () => {
+// グループ化やセパレータの例
+export const WithOptionGroups = () => {
   const [value, setValue] = useState<string | number>("");
 
   // フルーツのオプション
@@ -369,7 +369,7 @@ export const WithDeclarativeAPI = () => {
     </div>
   );
 };
-WithDeclarativeAPI.parameters = {
+WithOptionGroups.parameters = {
   docs: {
     description: {
       story: `
@@ -382,7 +382,7 @@ Select2Separatorはグループ間にセパレータを追加します。
 };
 
 // 宣言的APIを使用した複数選択の例
-export const WithDeclarativeAPIMultiple = () => {
+export const WithOptionGroupsMultiple = () => {
   const [values, setValues] = useState<(string | number)[]>([
     "apple",
     "potato",
@@ -463,7 +463,7 @@ export const WithDeclarativeAPIMultiple = () => {
     </div>
   );
 };
-WithDeclarativeAPIMultiple.parameters = {
+WithOptionGroupsMultiple.parameters = {
   docs: {
     description: {
       story: `
@@ -523,7 +523,7 @@ export const WithMaxSelectionStrict = () => {
         ))}
       </Select2>
       <div style={{ marginTop: 16 }}>
-        <p>選択中: {selected.join(", ")}</p>
+        <p>選択中（上限5個まで）: {selected.join(", ")}</p>
       </div>
     </div>
   );

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { Story, Meta } from "@storybook/react";
 import { Select2 } from "./Select2";
-import { Select2Option, Select2Props } from "./types";
+import { Select2Option } from "./Select2Option";
+import { Select2Props, Select2Option as Select2OptionType } from "./types";
+import { ContextMenu2HeadingItem } from "../ContextMenu2";
 
 export default {
   title: "Components/Inputs/Select2",
@@ -61,7 +63,7 @@ export default {
   },
 } as Meta<typeof Select2>;
 
-const options: Select2Option[] = [
+const options: Select2OptionType[] = [
   { value: "apple", label: "りんご" },
   { value: "banana", label: "バナナ" },
   { value: "orange", label: "オレンジ" },
@@ -264,6 +266,174 @@ MultipleSelectionWithSearch.parameters = {
       story: `
 複数選択モードと検索機能を組み合わせた例です。
 多くの選択肢から複数の項目を選択する場合に特に有用です。
+      `,
+    },
+  },
+};
+
+// 宣言的APIの例
+export const WithDeclarativeAPI = () => {
+  const [value, setValue] = useState<string | number>("");
+
+  // フルーツのオプション
+  const fruitOptions = [
+    { value: "apple", label: "りんご" },
+    { value: "orange", label: "オレンジ" },
+    { value: "banana", label: "バナナ" },
+    { value: "grape", label: "ブドウ" },
+    { value: "melon", label: "メロン" },
+  ];
+
+  // 野菜のオプション
+  const vegetableOptions = [
+    { value: "carrot", label: "にんじん" },
+    { value: "potato", label: "じゃがいも" },
+    { value: "lettuce", label: "レタス" },
+    { value: "tomato", label: "トマト" },
+    { value: "cucumber", label: "きゅうり" },
+  ];
+
+  // 肉類のオプション
+  const meatOptions = [
+    { value: "beef", label: "牛肉" },
+    { value: "pork", label: "豚肉" },
+    { value: "chicken", label: "鶏肉" },
+  ];
+
+  return (
+    <div style={{ width: "300px" }}>
+      <Select2
+        options={[]} // 子要素を使う場合はoptionsは空配列でOK
+        placeholder="食材を選択"
+        searchable={true}
+        searchPlaceholder="検索..."
+        value={value}
+        onChange={(newValue: any) => setValue(newValue as string | number)}
+      >
+        <ContextMenu2HeadingItem>果物</ContextMenu2HeadingItem>
+        {fruitOptions.map((option) => (
+          <Select2Option key={option.value} value={option.value}>
+            {option.label}
+          </Select2Option>
+        ))}
+
+        <ContextMenu2HeadingItem>野菜</ContextMenu2HeadingItem>
+        {vegetableOptions.map((option) => (
+          <Select2Option key={option.value} value={option.value}>
+            {option.label}
+          </Select2Option>
+        ))}
+
+        <ContextMenu2HeadingItem>肉類</ContextMenu2HeadingItem>
+        {meatOptions.map((option) => (
+          <Select2Option key={option.value} value={option.value}>
+            {option.label}
+          </Select2Option>
+        ))}
+      </Select2>
+      <div style={{ marginTop: "16px" }}>
+        <p>選択された値: {value}</p>
+      </div>
+    </div>
+  );
+};
+WithDeclarativeAPI.parameters = {
+  docs: {
+    description: {
+      story: `
+ContextMenu2HeadingItemとContextMenu2SeparatorItemを直接使用した例です。
+Select2コンポーネント内で、これらのコンポーネントと組み合わせることができます。
+      `,
+    },
+  },
+};
+
+// 宣言的APIを使用した複数選択の例
+export const WithDeclarativeAPIMultiple = () => {
+  const [values, setValues] = useState<(string | number)[]>([
+    "apple",
+    "potato",
+  ]);
+
+  // フルーツのオプション
+  const fruitOptions = [
+    { value: "apple", label: "りんご" },
+    { value: "orange", label: "オレンジ" },
+    { value: "banana", label: "バナナ" },
+    { value: "grape", label: "ブドウ" },
+    { value: "melon", label: "メロン" },
+  ];
+
+  // 野菜のオプション
+  const vegetableOptions = [
+    { value: "carrot", label: "にんじん" },
+    { value: "potato", label: "じゃがいも" },
+    { value: "lettuce", label: "レタス" },
+    { value: "tomato", label: "トマト" },
+    { value: "cucumber", label: "きゅうり" },
+  ];
+
+  // 肉類のオプション
+  const meatOptions = [
+    { value: "beef", label: "牛肉" },
+    { value: "pork", label: "豚肉" },
+    { value: "chicken", label: "鶏肉" },
+  ];
+
+  return (
+    <div style={{ width: "300px" }}>
+      <Select2
+        options={[]} // 子要素を使う場合はoptionsは空配列でOK
+        placeholder="食材を選択（複数可）"
+        searchable={true}
+        searchPlaceholder="検索..."
+        multiple={true}
+        value={values}
+        applyButtonText="適用"
+        cancelButtonText="キャンセル"
+        onChange={(newValues: any) => {
+          if (Array.isArray(newValues)) {
+            setValues(newValues);
+          }
+        }}
+      >
+        <ContextMenu2HeadingItem>果物</ContextMenu2HeadingItem>
+        {fruitOptions.map((option) => (
+          <Select2Option key={option.value} value={option.value}>
+            {option.label}
+          </Select2Option>
+        ))}
+
+        <ContextMenu2HeadingItem>野菜</ContextMenu2HeadingItem>
+        {vegetableOptions.map((option) => (
+          <Select2Option key={option.value} value={option.value}>
+            {option.label}
+          </Select2Option>
+        ))}
+
+        <ContextMenu2HeadingItem>肉類</ContextMenu2HeadingItem>
+        {meatOptions.map((option) => (
+          <Select2Option
+            key={option.value}
+            value={option.value}
+            disabled={option.value === "beef"}
+          >
+            {option.label}
+          </Select2Option>
+        ))}
+      </Select2>
+      <div style={{ marginTop: "16px" }}>
+        <p>選択された値: {values.join(", ")}</p>
+      </div>
+    </div>
+  );
+};
+WithDeclarativeAPIMultiple.parameters = {
+  docs: {
+    description: {
+      story: `
+ContextMenu2HeadingItemとContextMenu2SeparatorItemを直接使用した複数選択の例です。
+複数選択モード（multiple={true}）と宣言的APIを組み合わせることで、グループ化された選択肢から複数の項目を選択できます。
       `,
     },
   },

--- a/src/components/Select2/Select2.tsx
+++ b/src/components/Select2/Select2.tsx
@@ -49,6 +49,7 @@ export const Select2: React.FC<Select2Props> = ({
   cancelButtonText = "キャンセル",
   children,
   onChange,
+  onTempChange,
   ...rest
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -241,6 +242,13 @@ export const Select2: React.FC<Select2Props> = ({
       setTempSelectedValues(value);
     }
   }, [multiple, value]);
+
+  useEffect(() => {
+    if (multiple && typeof onTempChange === "function") {
+      onTempChange(tempSelectedValues);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [multiple, tempSelectedValues]);
 
   const stickyHeader = useMemo(
     () =>

--- a/src/components/Select2/Select2.tsx
+++ b/src/components/Select2/Select2.tsx
@@ -15,6 +15,8 @@ import {
   ContextMenu2CheckItem,
   ContextMenu2Container,
   ContextMenu2ButtonControlsItem,
+  ContextMenu2HeadingItem,
+  ContextMenu2SeparatorItem,
 } from "../ContextMenu2";
 import {
   Select2Container,
@@ -325,9 +327,9 @@ export const Select2: React.FC<Select2Props> = ({
 
   // 子要素を処理する関数
   const renderMenuContent = () => {
-    // 子要素があればそれを使用し、なければoptionsからリストを生成
-    if (children) {
-      return Children.map(children, (child) => {
+    // 子要素を再帰的に処理する関数
+    const processChildren = (childrenElements: React.ReactNode): React.ReactNode => {
+      return Children.map(childrenElements, (child) => {
         if (!isValidElement(child)) return null;
 
         // 子要素が "Select2Option" タイプなどの時の処理
@@ -384,12 +386,33 @@ export const Select2: React.FC<Select2Props> = ({
             );
           }
 
+          // Select2OptionGroupの場合
+          if (componentName === "Select2OptionGroup") {
+            // OptionGroupの子要素を再帰的に処理
+            return (
+              <>
+                <ContextMenu2HeadingItem>{childElement.props.label}</ContextMenu2HeadingItem>
+                {processChildren(childElement.props.children)}
+              </>
+            );
+          }
+
+          // Select2Separatorの場合
+          if (componentName === "Select2Separator") {
+            return <ContextMenu2SeparatorItem />;
+          }
+
           // それ以外のコンポーネント（HeadingItem、SeparatorItemなど）はそのまま返す
           return childElement;
         }
 
         return childElement; // 単純なテキストノードなどはそのまま返す
       });
+    };
+
+    // 子要素があればそれを使用し、なければoptionsからリストを生成
+    if (children) {
+      return processChildren(children);
     }
 
     // 子要素がない場合は従来通りoptionsからリストを生成

--- a/src/components/Select2/Select2Option.tsx
+++ b/src/components/Select2/Select2Option.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export type Select2OptionProps = {
+  /**
+   * 選択肢の値
+   */
+  value: string | number;
+  /**
+   * 無効状態
+   */
+  disabled?: boolean;
+  /**
+   * 表示するラベル
+   */
+  children: React.ReactNode;
+};
+
+/**
+ * Select2Optionコンポーネント
+ *
+ * Select2コンポーネント内で使用することを想定しています。
+ * 実際に何かをレンダリングせず、Select2の選択肢として登録するための宣言的なコンポーネントです。
+ */
+export const Select2Option: React.FC<Select2OptionProps> = (_props) => {
+  // 実際には何もレンダリングしない
+  // この情報はSelect2コンポーネントによって使用される
+  return null;
+};
+
+// コンポーネントの表示名を設定（デバッグ用）
+Select2Option.displayName = "Select2Option";

--- a/src/components/Select2/Select2OptionGroup.tsx
+++ b/src/components/Select2/Select2OptionGroup.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import { ContextMenu2HeadingItem } from "../ContextMenu2";
 
 export type Select2OptionGroupProps = {
   /**
@@ -14,17 +13,14 @@ export type Select2OptionGroupProps = {
 
 /**
  * Select2OptionGroupコンポーネント
- *
- * Select2コンポーネント内で使用することを想定しています。
- * オプションをグループ化するためのコンポーネントです。
+ * 
+ * このコンポーネントはグループ化された選択肢を表現します。
+ * 内部的には何もレンダリングせず、Select2コンポーネントがこのコンポーネントの
+ * プロパティを取得して、適切な方法でレンダリングします。
  */
-export const Select2OptionGroup: React.FC<Select2OptionGroupProps> = ({ label, children }) => {
-  return (
-    <>
-      <ContextMenu2HeadingItem>{label}</ContextMenu2HeadingItem>
-      {children}
-    </>
-  );
+export const Select2OptionGroup: React.FC<Select2OptionGroupProps> = (_props) => {
+  // 何もレンダリングしない
+  return null;
 };
 
 // コンポーネントの表示名を設定（デバッグ用）

--- a/src/components/Select2/Select2OptionGroup.tsx
+++ b/src/components/Select2/Select2OptionGroup.tsx
@@ -13,15 +13,17 @@ export type Select2OptionGroupProps = {
 
 /**
  * Select2OptionGroupコンポーネント
- * 
+ *
  * このコンポーネントはグループ化された選択肢を表現します。
  * 内部的には何もレンダリングせず、Select2コンポーネントがこのコンポーネントの
  * プロパティを取得して、適切な方法でレンダリングします。
  */
-export const Select2OptionGroup: React.FC<Select2OptionGroupProps> = (_props) => {
+export const Select2OptionGroup: React.FC<Select2OptionGroupProps> = (
+  _props,
+) => {
   // 何もレンダリングしない
   return null;
 };
 
 // コンポーネントの表示名を設定（デバッグ用）
-Select2OptionGroup.displayName = "Select2OptionGroup"; 
+Select2OptionGroup.displayName = "Select2OptionGroup";

--- a/src/components/Select2/Select2OptionGroup.tsx
+++ b/src/components/Select2/Select2OptionGroup.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from "react";
+import { ContextMenu2HeadingItem } from "../ContextMenu2";
+
+export type Select2OptionGroupProps = {
+  /**
+   * グループのラベル
+   */
+  label: string;
+  /**
+   * 子要素（Select2Option）
+   */
+  children: ReactNode;
+};
+
+/**
+ * Select2OptionGroupコンポーネント
+ *
+ * Select2コンポーネント内で使用することを想定しています。
+ * オプションをグループ化するためのコンポーネントです。
+ */
+export const Select2OptionGroup: React.FC<Select2OptionGroupProps> = ({ label, children }) => {
+  return (
+    <>
+      <ContextMenu2HeadingItem>{label}</ContextMenu2HeadingItem>
+      {children}
+    </>
+  );
+};
+
+// コンポーネントの表示名を設定（デバッグ用）
+Select2OptionGroup.displayName = "Select2OptionGroup"; 

--- a/src/components/Select2/Select2Separator.tsx
+++ b/src/components/Select2/Select2Separator.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { ContextMenu2SeparatorItem } from "../ContextMenu2";
+
+/**
+ * Select2Separatorコンポーネント
+ *
+ * Select2コンポーネント内で使用することを想定しています。
+ * オプショングループ間のセパレータとして機能します。
+ */
+export const Select2Separator: React.FC = () => {
+  return <ContextMenu2SeparatorItem />;
+};
+
+// コンポーネントの表示名を設定（デバッグ用）
+Select2Separator.displayName = "Select2Separator"; 

--- a/src/components/Select2/Select2Separator.tsx
+++ b/src/components/Select2/Select2Separator.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { ContextMenu2SeparatorItem } from "../ContextMenu2";
 
 /**
  * Select2Separatorコンポーネント
- *
- * Select2コンポーネント内で使用することを想定しています。
- * オプショングループ間のセパレータとして機能します。
+ * 
+ * このコンポーネントはセパレータを表現します。
+ * 内部的には何もレンダリングせず、Select2コンポーネントがこのコンポーネントを
+ * 検出して、適切な方法でセパレータをレンダリングします。
  */
 export const Select2Separator: React.FC = () => {
-  return <ContextMenu2SeparatorItem />;
+  // 何もレンダリングしない
+  return null;
 };
 
 // コンポーネントの表示名を設定（デバッグ用）

--- a/src/components/Select2/Select2Separator.tsx
+++ b/src/components/Select2/Select2Separator.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 /**
  * Select2Separatorコンポーネント
- * 
+ *
  * このコンポーネントはセパレータを表現します。
  * 内部的には何もレンダリングせず、Select2コンポーネントがこのコンポーネントを
  * 検出して、適切な方法でセパレータをレンダリングします。
@@ -13,4 +13,4 @@ export const Select2Separator: React.FC = () => {
 };
 
 // コンポーネントの表示名を設定（デバッグ用）
-Select2Separator.displayName = "Select2Separator"; 
+Select2Separator.displayName = "Select2Separator";

--- a/src/components/Select2/index.ts
+++ b/src/components/Select2/index.ts
@@ -1,0 +1,5 @@
+export { Select2 } from "./Select2";
+export { Select2Option } from "./Select2Option";
+export { Select2OptionGroup } from "./Select2OptionGroup";
+export { Select2Separator } from "./Select2Separator";
+export * from "./types"; 

--- a/src/components/Select2/index.ts
+++ b/src/components/Select2/index.ts
@@ -1,5 +1,4 @@
 export { Select2 } from "./Select2";
-export { Select2Option } from "./Select2Option";
 export { Select2OptionGroup } from "./Select2OptionGroup";
 export { Select2Separator } from "./Select2Separator";
 export * from "./types"; 

--- a/src/components/Select2/index.ts
+++ b/src/components/Select2/index.ts
@@ -1,4 +1,4 @@
 export { Select2 } from "./Select2";
 export { Select2OptionGroup } from "./Select2OptionGroup";
 export { Select2Separator } from "./Select2Separator";
-export * from "./types"; 
+export * from "./types";

--- a/src/components/Select2/index.tsx
+++ b/src/components/Select2/index.tsx
@@ -1,7 +1,8 @@
 export { Select2 } from "./Select2";
+export { Select2Option } from "./Select2Option";
 export type {
   Select2Props,
-  Select2Option,
+  Select2Option as Select2OptionType,
   Select2Size,
   Select2Variant,
 } from "./types";

--- a/src/components/Select2/types.ts
+++ b/src/components/Select2/types.ts
@@ -143,4 +143,9 @@ export type Select2Props = {
    * Select2Option、ContextMenu2HeadingItem、ContextMenu2SeparatorItemなどを指定できます
    */
   children?: React.ReactNode;
+  /**
+   * 複数選択時の一時的な選択値が変化したときに呼ばれるコールバック
+   * multiple=trueのときのみ有効
+   */
+  onTempChange?: (tempSelected: (string | number)[]) => void;
 };

--- a/src/components/Select2/types.ts
+++ b/src/components/Select2/types.ts
@@ -1,4 +1,5 @@
 import { Theme } from "../../themes";
+import React from "react";
 
 export type Select2Size = "small" | "medium" | "large";
 export type Select2Variant = "light" | "dark";
@@ -141,4 +142,9 @@ export type Select2Props = {
    * @default "キャンセル"
    */
   cancelButtonText?: string;
+  /**
+   * 子要素（宣言的API用）
+   * Select2Option、ContextMenu2HeadingItem、ContextMenu2SeparatorItemなどを指定できます
+   */
+  children?: React.ReactNode;
 };

--- a/src/components/Select2/types.ts
+++ b/src/components/Select2/types.ts
@@ -63,10 +63,6 @@ export type Select2StyleProps = {
 
 export type Select2Props = {
   /**
-   * 選択肢の配列
-   */
-  options: Select2Option[];
-  /**
    * 選択された値。multipleがtrueの場合は配列、falseの場合は単一の値
    */
   value?: string | number | (string | number)[];


### PR DESCRIPTION
# 概要
`Select2` コンポーネントのAPIを刷新し、従来の `options` props による配列渡しを廃止し、  
**宣言的API（JSXで `<Select2Option>` や `<Select2OptionGroup>` を子要素として記述）** のみで選択肢を定義できるようにリファクタリングしました。

## 主な修正内容

- `Select2Props` から `options` プロパティを削除
- `Select2` の実装から `options` 関連のロジック・変数を削除し、`children` ベースのパースに統一
- `Select2Option`, `Select2OptionGroup`, `Select2Separator` など宣言的API用のダミーコンポーネントを明示的にエクスポートし、`displayName` を付与
- Storybook（`Select2.stories.tsx`）もすべて宣言的APIの記法に統一
- 既存の利用例・型定義もすべて `options` props を使わない形に修正

## 使い方（新API例）

```jsx
<Select2 value={value} onChange={setValue}>
  <Select2Option value="apple">りんご</Select2Option>
  <Select2Option value="banana">バナナ</Select2Option>
  <Select2OptionGroup label="柑橘類">
    <Select2Option value="orange">オレンジ</Select2Option>
    <Select2Option value="lemon">レモン</Select2Option>
  </Select2OptionGroup>
  <Select2Separator />
  <Select2Option value="grape">ぶどう</Select2Option>
</Select2>
```

### 補足

- これにより、リストアイテムのグルーピングやセパレータもJSXで柔軟に記述でき、可読性・拡張性が向上します。
- 旧API（`options` props）は完全に削除されているため、既存の利用箇所は新APIに書き換える必要があります。

> [!NOTE]
> APIを追加しました。
 
# 追加したAPI
`onTempChange`（複数選択時の一時的な選択値を外部に通知するAPI）は、  
**「選択確定前の一時的な状態」を親コンポーネントでリアルタイムに把握できる**という点で、  
さまざまな用途に応用できます。

---

## 1. **選択数の上限・下限制御（今回の例）**
- 上限だけでなく「最低○件選択しないと適用できない」などのバリデーションにも使える

---

## 2. **リアルタイムなバリデーション・警告表示**
- 一時的な選択内容に応じて「この組み合わせは選択できません」などの警告やヒントを表示
- 例：特定の組み合わせを禁止したい場合、tempSelectedの内容を見て警告を出す

---

## 3. **動的なUI制御**
- 一時的な選択内容に応じて、他のフォーム項目やボタンの有効/無効を切り替える
- 例：5件選択したら「次へ」ボタンを有効化、など

---

## 4. **プレビュー表示**
- 「適用」前に、選択中の内容をサイドバーやプレビューエリアにリアルタイムで表示
- 例：タグや画像、詳細情報などをtempSelectedに応じて動的に表示

---

## 5. **外部APIとの連携・サジェスト**
- 一時的な選択内容を元に、外部APIから追加情報やサジェストを取得して表示
- 例：選択中のIDリストでサマリー情報を取得し、下部に表示

---

## 6. **カスタムの「適用」ボタン制御**
- tempSelectedの内容に応じて「適用」ボタン自体を有効/無効にしたり、ラベルを変えたりできる

---

## 7. **アナリティクス・ログ**
- ユーザーが「どのように選択肢を増減させたか」をリアルタイムでトラッキングする用途

---

## 8. **他のコンポーネントとの連動**
- tempSelectedの内容を他のSelectやフォームと連動させて、クロスフィルタリングや依存関係を実現

---

### まとめ

- **「確定前の一時的な選択状態」を外部で利用できる**ことで、  
  UI/UXの高度なカスタマイズやバリデーション、プレビュー、連動処理など多様な用途に活用できます。
