### PR TITLE
♻️ Select2 から export している命名を修正

### DIFF
--- a/.changeset/tough-pets-invite.md
+++ b/.changeset/tough-pets-invite.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Fix type name of Select2Option

--- a/src/components/Select2/Select2.stories.tsx
+++ b/src/components/Select2/Select2.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Story, Meta } from "@storybook/react";
 import { Select2 } from "./Select2";
 import { Select2Option } from "./Select2Option";
-import { Select2Props, Select2Option as Select2OptionType } from "./types";
+import { Select2Props, Select2OptionProps } from "./types";
 import { Select2OptionGroup } from "./Select2OptionGroup";
 import { Select2Separator } from "./Select2Separator";
 
@@ -64,7 +64,7 @@ export default {
   },
 } as Meta<typeof Select2>;
 
-const options: Select2OptionType[] = [
+const options: Select2OptionProps[] = [
   { value: "apple", label: "りんご" },
   { value: "banana", label: "バナナ" },
   { value: "orange", label: "オレンジ" },

--- a/src/components/Select2/Select2.tsx
+++ b/src/components/Select2/Select2.tsx
@@ -30,7 +30,7 @@ import {
   TagContainer,
   StyledTag,
 } from "./styled";
-import { Select2Props, Select2Option } from "./types";
+import { Select2Props, Select2OptionProps } from "./types";
 import { ContextMenu2NoResultsMessage } from "../ContextMenu2/ContextMenu2NoResultsMessage";
 
 export const Select2: React.FC<Select2Props> = ({
@@ -77,7 +77,7 @@ export const Select2: React.FC<Select2Props> = ({
   // 子要素からオプション情報を抽出する
   const extractOptionsFromChildren = useMemo(() => {
     if (!children) return [];
-    const options: Select2Option[] = [];
+    const options: Select2OptionProps[] = [];
     const extractOptions = (childElements: React.ReactNode) => {
       Children.forEach(childElements, (child) => {
         if (!isValidElement(child)) return;
@@ -132,7 +132,7 @@ export const Select2: React.FC<Select2Props> = ({
   );
 
   const handleSingleSelect = useCallback(
-    (option: Select2Option) => {
+    (option: Select2OptionProps) => {
       if (!option.disabled) {
         handleChange(option.value);
         setIsOpen(false);
@@ -143,7 +143,7 @@ export const Select2: React.FC<Select2Props> = ({
   );
 
   const handleMultipleSelect = useCallback(
-    (checked: boolean, option: Select2Option) => {
+    (checked: boolean, option: Select2OptionProps) => {
       if (option.disabled) return;
       setTempSelectedValues((prev) => {
         const newValues = checked

--- a/src/components/Select2/index.ts
+++ b/src/components/Select2/index.ts
@@ -1,4 +1,5 @@
 export { Select2 } from "./Select2";
+export { Select2Option } from "./Select2Option";
 export { Select2OptionGroup } from "./Select2OptionGroup";
 export { Select2Separator } from "./Select2Separator";
 export * from "./types";

--- a/src/components/Select2/index.tsx
+++ b/src/components/Select2/index.tsx
@@ -2,7 +2,7 @@ export { Select2 } from "./Select2";
 export { Select2Option } from "./Select2Option";
 export type {
   Select2Props,
-  Select2Option as Select2OptionType,
+  Select2OptionProps,
   Select2Size,
   Select2Variant,
 } from "./types";

--- a/src/components/Select2/types.ts
+++ b/src/components/Select2/types.ts
@@ -36,7 +36,7 @@ export const SELECT2_SIZES: Record<Select2Size, Select2SizeConfig> = {
   },
 } as const;
 
-export type Select2Option = {
+export type Select2OptionProps = {
   /**
    * 選択肢の値
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

Select2Option が export されていなかったので export した。
その際に型定義と命名が被ったので変更した。

## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
