### PR TITLE
Fix/filter icon default

### DIFF
--- a/.changeset/rare-grapes-complain.md
+++ b/.changeset/rare-grapes-complain.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": minor
+---
+
+filter系コンポーネントのドロップダウン周りとcontextmenu2のリストメニューのスタイリングの修正

--- a/src/components/ContextMenu2/ContextMenu2.stories.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.stories.tsx
@@ -68,6 +68,7 @@ export const Overview: StoryObj<typeof ContextMenu2> = {
             </ContextMenu2ButtonItem>
             <ContextMenu2ButtonItem
               color="danger"
+              prepend={<Icon name="image" />}
               onClick={() => alert("削除する")}
             >
               削除する

--- a/src/components/ContextMenu2/ContextMenu2.stories.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.stories.tsx
@@ -123,16 +123,17 @@ export const Overview: StoryObj<typeof ContextMenu2> = {
                 if (checked) setCheckedIndex(0);
               }}
             >
-              含む
+              通常時
             </ContextMenu2CheckItem>
             <ContextMenu2CheckItem
+              color="danger"
               checked={checkedIndex === 1}
               prepend={<Icon name="image" />}
               onChange={(checked) => {
                 if (checked) setCheckedIndex(1);
               }}
             >
-              含まない
+              危険な選択肢
             </ContextMenu2CheckItem>
             <ContextMenu2CheckItem
               disabled

--- a/src/components/ContextMenu2/ContextMenu2.stories.tsx
+++ b/src/components/ContextMenu2/ContextMenu2.stories.tsx
@@ -67,6 +67,19 @@ export const Overview: StoryObj<typeof ContextMenu2> = {
               アーカイブする
             </ContextMenu2ButtonItem>
             <ContextMenu2ButtonItem
+              prepend={<Icon name="image" />}
+              onClick={() => alert("通常時")}
+            >
+              通常時
+            </ContextMenu2ButtonItem>
+            <ContextMenu2ButtonItem
+              disabled
+              prepend={<Icon name="image" />}
+              onClick={() => alert("disabled")}
+            >
+              無効時
+            </ContextMenu2ButtonItem>
+            <ContextMenu2ButtonItem
               color="danger"
               prepend={<Icon name="image" />}
               onClick={() => alert("削除する")}

--- a/src/components/ContextMenu2/ContextMenu2ButtonItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2ButtonItem.tsx
@@ -5,10 +5,13 @@ import React, {
   type ReactNode,
   type ButtonHTMLAttributes,
   type MouseEvent,
+  type ReactElement,
 } from "react";
 import { ContextMenu2Context } from "./context";
 import styled from "styled-components";
 import { colors } from "../../styles";
+import Icon from "../Icon";
+import type { Props as IconProps } from "../Icon/Icon";
 
 // 特に機能を持たない、見た目付きの入れ子メニューのボタン
 
@@ -17,10 +20,26 @@ type ContextMenu2ButtonItemProps = {
   prepend?: ReactNode;
   children: ReactNode;
   closeOnClick?: boolean;
+  color?: "danger" | undefined;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-const ButtonAppend = styled.span`
-  color: ${colors.basic[700]};
+const ButtonPrepend = styled.span`
+  /* アイコンのデフォルトサイズと色を設定 */
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* span要素のサイズも設定 */
+  span {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* disabled状態の時の色 */
+  button:disabled & {
+    color: ${colors.basic[400]};
+  }
 `;
 
 const InternalContextMenu2ButtonItem = forwardRef<
@@ -36,6 +55,15 @@ const InternalContextMenu2ButtonItem = forwardRef<
     },
     [closeOnClick, close, onClick],
   );
+
+  // prependがIconコンポーネントの場合、colorを自動設定
+  const prependWithColor =
+    React.isValidElement(prepend) && prepend.type === Icon
+      ? React.cloneElement(prepend as ReactElement<IconProps>, {
+          color: "currentColor",
+        })
+      : prepend;
+
   return (
     <button
       type="button"
@@ -44,7 +72,7 @@ const InternalContextMenu2ButtonItem = forwardRef<
       data-pressed={pressed}
       onClick={handleClick}
     >
-      {prepend && <ButtonAppend>{prepend}</ButtonAppend>}
+      {prepend && <ButtonPrepend>{prependWithColor}</ButtonPrepend>}
       {children}
     </button>
   );

--- a/src/components/ContextMenu2/ContextMenu2CheckItem.tsx
+++ b/src/components/ContextMenu2/ContextMenu2CheckItem.tsx
@@ -4,11 +4,13 @@ import React, {
   type ButtonHTMLAttributes,
   useContext,
   useCallback,
+  type ReactElement,
 } from "react";
 import styled from "styled-components";
 import { colors } from "../../styles";
 import { ContextMenu2Context } from "./context";
 import Icon from "../Icon";
+import type { Props as IconProps } from "../Icon/Icon";
 
 // 特に機能を持たない、見た目付きの入れ子メニューのボタン
 
@@ -18,10 +20,26 @@ type ContextMenu2CheckItemProps = {
   prepend?: ReactNode;
   children: ReactNode;
   onChange?: (checked: boolean) => void;
+  color?: "danger" | undefined;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const ButtonPrepend = styled.span`
-  color: ${colors.basic[900]};
+  /* アイコンのデフォルトサイズと色を設定 */
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* span要素のサイズも設定 */
+  span {
+    width: 22px;
+    height: 22px;
+  }
+
+  /* disabled状態の時の色 */
+  button:disabled & {
+    color: ${colors.basic[400]};
+  }
 `;
 
 const StyledIcon = styled.span`
@@ -38,9 +56,17 @@ const InternalContextMenu2CheckItem = forwardRef<
     closeOnChange && close();
   }, [checked, close, closeOnChange, onChange]);
 
+  // prependがIconコンポーネントの場合、colorを自動設定
+  const prependWithColor =
+    React.isValidElement(prepend) && prepend.type === Icon
+      ? React.cloneElement(prepend as ReactElement<IconProps>, {
+          color: "currentColor",
+        })
+      : prepend;
+
   return (
     <button type="button" {...props} ref={ref} onClick={handleClick}>
-      {prepend && <ButtonPrepend>{prepend}</ButtonPrepend>}
+      {prepend && <ButtonPrepend>{prependWithColor}</ButtonPrepend>}
       {children}
       <StyledIcon>
         {checked && <Icon name="check_thin" color={colors.blue[500]} />}

--- a/src/components/ContextMenu2/__tests__/__snapshots__/ContextMenu2.test.tsx.snap
+++ b/src/components/ContextMenu2/__tests__/__snapshots__/ContextMenu2.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
       >
         <div>
           <span
-            class="sc-dkzDqf kPdxGi"
+            class="sc-bczRLJ gJuzRf"
             size="18"
           >
             <svg
@@ -82,15 +82,15 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
         class="sc-kgflAQ tWjLj"
       />
       <button
-        class="sc-gsnTZi lhIOjZ"
+        class="sc-dkzDqf cdxsZa"
         tabindex="-1"
         type="button"
       >
         <span
-          class="sc-bczRLJ gjrGrq"
+          class="sc-gsnTZi cqsEkE"
         >
           <span
-            class="sc-dkzDqf kPdxGi"
+            class="sc-bczRLJ gJuzRf"
             size="18"
           >
             <svg
@@ -103,7 +103,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
               />
               <path
                 d="M10.25,8.25H14l-4.5,4.5L5,8.25H8.75V3h1.5ZM3.5,15h12V9.75H17v6a.75.75,0,0,1-.75.75H2.75A.75.75,0,0,1,2,15.75v-6H3.5Z"
-                fill="#596978"
+                fill="currentColor"
                 transform="translate(-0.5 -0.75)"
               />
             </svg>
@@ -112,14 +112,14 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
         アイコンボタン
       </button>
       <button
-        class="sc-gsnTZi lhIOjZ"
+        class="sc-dkzDqf cdxsZa"
         tabindex="-1"
         type="button"
       >
         ボタン
       </button>
       <button
-        class="sc-gsnTZi kHYuDQ"
+        class="sc-dkzDqf hClLqL"
         color="danger"
         tabindex="-1"
         type="button"
@@ -143,7 +143,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
           100
         </span>
         <span
-          class="sc-dkzDqf kPdxGi"
+          class="sc-bczRLJ gJuzRf"
           size="18"
         >
           <svg
@@ -162,10 +162,10 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
         type="button"
       >
         <span
-          class="sc-hKMtZM gEhuHi"
+          class="sc-hKMtZM fbdcDs"
         >
           <span
-            class="sc-dkzDqf kPdxGi"
+            class="sc-bczRLJ gJuzRf"
             size="18"
           >
             <svg
@@ -174,7 +174,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
             >
               <path
                 d="M4.828 21L4.808 21.02L4.787 21H2.992C2.72881 20.9997 2.4765 20.895 2.29049 20.7088C2.10448 20.5226 2 20.2702 2 20.007V3.993C2.00183 3.73038 2.1069 3.47902 2.29251 3.29322C2.47813 3.10742 2.72938 3.00209 2.992 3H21.008C21.556 3 22 3.445 22 3.993V20.007C21.9982 20.2696 21.8931 20.521 21.7075 20.7068C21.5219 20.8926 21.2706 20.9979 21.008 21H4.828ZM20 15V5H4V19L14 9L20 15ZM20 17.828L14 11.828L6.828 19H20V17.828ZM8 11C7.46957 11 6.96086 10.7893 6.58579 10.4142C6.21071 10.0391 6 9.53043 6 9C6 8.46957 6.21071 7.96086 6.58579 7.58579C6.96086 7.21071 7.46957 7 8 7C8.53043 7 9.03914 7.21071 9.41421 7.58579C9.78929 7.96086 10 8.46957 10 9C10 9.53043 9.78929 10.0391 9.41421 10.4142C9.03914 10.7893 8.53043 11 8 11Z"
-                fill="#596978"
+                fill="currentColor"
               />
             </svg>
           </span>
@@ -184,7 +184,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
           class="sc-eCYdqJ kxUHtX"
         >
           <span
-            class="sc-dkzDqf kPdxGi"
+            class="sc-bczRLJ gJuzRf"
             size="18"
           >
             <svg
@@ -205,10 +205,10 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
         type="button"
       >
         <span
-          class="sc-hKMtZM gEhuHi"
+          class="sc-hKMtZM fbdcDs"
         >
           <span
-            class="sc-dkzDqf kPdxGi"
+            class="sc-bczRLJ gJuzRf"
             size="18"
           >
             <svg
@@ -217,7 +217,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
             >
               <path
                 d="M4.828 21L4.808 21.02L4.787 21H2.992C2.72881 20.9997 2.4765 20.895 2.29049 20.7088C2.10448 20.5226 2 20.2702 2 20.007V3.993C2.00183 3.73038 2.1069 3.47902 2.29251 3.29322C2.47813 3.10742 2.72938 3.00209 2.992 3H21.008C21.556 3 22 3.445 22 3.993V20.007C21.9982 20.2696 21.8931 20.521 21.7075 20.7068C21.5219 20.8926 21.2706 20.9979 21.008 21H4.828ZM20 15V5H4V19L14 9L20 15ZM20 17.828L14 11.828L6.828 19H20V17.828ZM8 11C7.46957 11 6.96086 10.7893 6.58579 10.4142C6.21071 10.0391 6 9.53043 6 9C6 8.46957 6.21071 7.96086 6.58579 7.58579C6.96086 7.21071 7.46957 7 8 7C8.53043 7 9.03914 7.21071 9.41421 7.58579C9.78929 7.96086 10 8.46957 10 9C10 9.53043 9.78929 10.0391 9.41421 10.4142C9.03914 10.7893 8.53043 11 8 11Z"
-                fill="#596978"
+                fill="currentColor"
               />
             </svg>
           </span>
@@ -296,7 +296,7 @@ exports[`ContextMenu2 component testing ContextMenu2 1`] = `
         </li>
       </ul>
       <button
-        class="sc-gsnTZi lhIOjZ"
+        class="sc-dkzDqf cdxsZa"
         tabindex="-1"
         type="button"
       >

--- a/src/components/FilterComboBox/FilterComboBox.stories.tsx
+++ b/src/components/FilterComboBox/FilterComboBox.stories.tsx
@@ -76,23 +76,15 @@ export const Default: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon name="operator_contains" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
     ],
@@ -135,23 +127,15 @@ export const Sizes: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon name="operator_contains" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
     ],
@@ -213,17 +197,11 @@ export const Variants: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
     ],
@@ -280,23 +258,15 @@ export const Disabled: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon name="operator_contains" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
     ],
@@ -348,7 +318,7 @@ export const Error: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
     ],

--- a/src/components/FilterComboBox/FilterComboBox.tsx
+++ b/src/components/FilterComboBox/FilterComboBox.tsx
@@ -230,6 +230,7 @@ export const FilterComboBox = ({
 
   return (
     <FilterInputAbstract
+      variant={variant}
       size={size}
       selectedIndex={selectedIndex}
       selectOptions={selectOptions}
@@ -237,7 +238,6 @@ export const FilterComboBox = ({
       error={error}
       isOpen={isOpen}
       onSelectChange={onSelectChange}
-      variant={variant}
     >
       <styled.SelectContainer
         $variant={variant}

--- a/src/components/FilterComboBox/FilterComboBox.tsx
+++ b/src/components/FilterComboBox/FilterComboBox.tsx
@@ -237,6 +237,7 @@ export const FilterComboBox = ({
       error={error}
       isOpen={isOpen}
       onSelectChange={onSelectChange}
+      variant={variant}
     >
       <styled.SelectContainer
         $variant={variant}

--- a/src/components/FilterComboBox/__tests__/__snapshots__/FilterComboBox.test.tsx.snap
+++ b/src/components/FilterComboBox/__tests__/__snapshots__/FilterComboBox.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-label="フィルターのタイプを選ぶ"
-      class="sc-ivTmOn eMwvsv"
+      class="sc-ivTmOn ljHaqd"
       type="button"
     >
       <span
@@ -44,18 +44,18 @@ exports[`FileUploader component testing FileUploader 1`] = `
       </span>
     </button>
     <div
-      class="sc-gXmSlM iIwvza"
+      class="sc-jIZahH eQLyNq"
       data-overflowing="false"
     >
       <button
         aria-expanded="false"
         aria-haspopup="dialog"
         aria-label="タグを追加"
-        class="sc-ciZhAO cAVhoX"
+        class="sc-gXmSlM cLANdJ"
         type="button"
       >
         <span
-          class="sc-jdAMXn iuMSjz"
+          class="sc-cCsOjp FcuZJ"
         >
           <span
             class="sc-bczRLJ gJuzRf"
@@ -73,19 +73,19 @@ exports[`FileUploader component testing FileUploader 1`] = `
         </span>
       </button>
       <div
-        class="sc-cCsOjp frpgYO"
+        class="sc-himrzO fBFYmT"
       >
         <div
-          class="sc-gicCDI kPTQnR"
+          class="sc-llJcti eYebqi"
         >
           <div
-            class="sc-ezWOiH"
+            class="sc-iIPllB"
           >
             項目1
           </div>
           <button
             aria-label="削除"
-            class="sc-bZkfAO gPOYPi"
+            class="sc-gicCDI cEcDYS"
             type="button"
           >
             <span

--- a/src/components/FilterInputAbstract/FilterInputAbstract.tsx
+++ b/src/components/FilterInputAbstract/FilterInputAbstract.tsx
@@ -15,7 +15,7 @@ import {
   ContextMenu2CheckItem,
 } from "../ContextMenu2";
 import * as styled from "./styled";
-import { FilterSize } from "./types";
+import { FilterSize, FilterVariant } from "./types";
 import { Tag } from "../Tag";
 
 export const FilterInputContext = createContext({
@@ -61,6 +61,7 @@ type FilterInputAbstractProps = {
   children?: ReactNode;
   onSelectChange: (index: number) => void;
   size?: "small" | "medium" | "large";
+  variant?: FilterVariant;
   disabled?: boolean;
   error?: boolean;
   isOpen?: boolean;
@@ -71,6 +72,7 @@ export const FilterInputAbstract = ({
   onSelectChange,
   children,
   size = "medium",
+  variant = "light",
   disabled = false,
   error = false,
   isOpen = false,
@@ -150,6 +152,7 @@ export const FilterInputAbstract = ({
               disabled={disabled}
               aria-label="フィルターのタイプを選ぶ"
               onClick={handleClick}
+              $variant={variant}
             >
               {selectOptionsWithColor[selectedIndex].icon}
               <Icon name="arrow_down" color="currentColor" />

--- a/src/components/FilterInputAbstract/FilterInputAbstract.tsx
+++ b/src/components/FilterInputAbstract/FilterInputAbstract.tsx
@@ -8,6 +8,7 @@ import React, {
   createContext,
 } from "react";
 import Icon from "../Icon";
+import type { Props as IconProps } from "../Icon/Icon";
 import {
   ContextMenu2,
   ContextMenu2Container,
@@ -56,7 +57,7 @@ export const FilterTag = ({
 // 本体のコンポーネント
 type FilterInputAbstractProps = {
   selectedIndex: number;
-  selectOptions: { icon: ReactElement; label: string }[];
+  selectOptions: { icon: ReactElement<IconProps>; label: string }[];
   children?: ReactNode;
   onSelectChange: (index: number) => void;
   size?: "small" | "medium" | "large";
@@ -80,6 +81,17 @@ export const FilterInputAbstract = ({
   const [isSmall, setIsSmall] = useState(false);
 
   const el = useRef<HTMLDivElement>(null);
+
+  // selectOptionsのiconにデフォルトでcurrentColorを設定
+  const selectOptionsWithColor = selectOptions.map((option) => ({
+    ...option,
+    icon:
+      React.isValidElement(option.icon) && option.icon.type === Icon
+        ? React.cloneElement(option.icon as ReactElement<IconProps>, {
+            color: option.icon.props.color || "currentColor",
+          })
+        : option.icon,
+  }));
 
   const handleSelectChange = useCallback(
     (index: number) => {
@@ -139,13 +151,13 @@ export const FilterInputAbstract = ({
               aria-label="フィルターのタイプを選ぶ"
               onClick={handleClick}
             >
-              {selectOptions[selectedIndex].icon}
+              {selectOptionsWithColor[selectedIndex].icon}
               <Icon name="arrow_down" color="currentColor" />
             </styled.DropDownTrigger>
           }
           onOpenChange={handleOpenChange}
         >
-          {selectOptions.map(({ label, icon }, i) => (
+          {selectOptionsWithColor.map(({ label, icon }, i) => (
             <ContextMenu2CheckItem
               key={label}
               prepend={icon}

--- a/src/components/FilterInputAbstract/FilterInputAbstract.tsx
+++ b/src/components/FilterInputAbstract/FilterInputAbstract.tsx
@@ -148,11 +148,11 @@ export const FilterInputAbstract = ({
           open={disabled ? false : isSelectOpen}
           trigger={
             <styled.DropDownTrigger
+              $variant={variant}
               type="button"
               disabled={disabled}
               aria-label="フィルターのタイプを選ぶ"
               onClick={handleClick}
-              $variant={variant}
             >
               {selectOptionsWithColor[selectedIndex].icon}
               <Icon name="arrow_down" color="currentColor" />

--- a/src/components/FilterInputAbstract/__tests__/__snapshots__/FilterInputAbstract.test.tsx.snap
+++ b/src/components/FilterInputAbstract/__tests__/__snapshots__/FilterInputAbstract.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-label="フィルターのタイプを選ぶ"
-      class="sc-ivTmOn eMwvsv"
+      class="sc-ivTmOn fWOPLR"
       type="button"
     >
       <span

--- a/src/components/FilterInputAbstract/styled.tsx
+++ b/src/components/FilterInputAbstract/styled.tsx
@@ -1,7 +1,12 @@
 import styled, { css } from "styled-components";
 import { colors } from "../../styles";
 import { ContextMenu2CheckItem } from "../ContextMenu2/ContextMenu2CheckItem";
-import { FILTER_SIZES, FilterSize } from "./types";
+import {
+  FILTER_SIZES,
+  FilterSize,
+  FilterVariant,
+  FILTER_VARIANTS,
+} from "./types";
 
 // フィルターのベーススタイル
 export const filterBaseStyle = css`
@@ -124,7 +129,10 @@ export const FilterInputAbstract = styled.div<{
   }
 `;
 
-export const DropDownTrigger = styled.button`
+export const DropDownTrigger = styled.button<{
+  disabled?: boolean;
+  $variant?: FilterVariant;
+}>`
   flex-shrink: 0;
   position: relative;
   z-index: 1;
@@ -137,8 +145,8 @@ export const DropDownTrigger = styled.button`
   outline-offset: -1px;
   color: ${({ disabled }) =>
     disabled ? colors.basic[400] : colors.basic[900]};
-  background: ${({ disabled }) =>
-    disabled ? colors.basic[200] : colors.basic[0]};
+  background: ${({ disabled, $variant = "light" }) =>
+    disabled ? colors.basic[200] : FILTER_VARIANTS[$variant].background};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   transition: all 0.2s ease;
 

--- a/src/components/FilterInputAbstract/styled.tsx
+++ b/src/components/FilterInputAbstract/styled.tsx
@@ -38,10 +38,6 @@ export const getTriggerIconSizeStyle = (size: FilterSize) => css`
   padding: ${FILTER_SIZES[size].padding};
 `;
 
-export type FilterTagProps = {
-  $size: FilterSize;
-};
-
 export const FilterInputAbstract = styled.div<{
   $isOpen?: boolean;
   $error?: boolean;
@@ -171,93 +167,6 @@ export const DropDownTrigger = styled.button`
 
   &:where(${FilterInputAbstract.toString()}[data-small="true"] *) {
     display: none;
-  }
-`;
-
-export const FilterTag = styled.span<FilterTagProps>`
-  isolation: isolate;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  width: fit-content;
-  padding: ${({ $size }) => {
-    switch ($size) {
-      case "small":
-        return "2px 4px 2px 6px";
-      case "medium":
-        return "2px 5px 2px 7px";
-      case "large":
-        return "3px 6px 3px 8px";
-    }
-  }};
-  border: 1px solid ${colors.basic[400]};
-  border-radius: 2px;
-  font-weight: 400;
-  font-size: ${({ $size }) => {
-    switch ($size) {
-      case "small":
-        return "11px";
-      case "medium":
-        return "12px";
-      case "large":
-        return "13px";
-    }
-  }};
-  line-height: 14px;
-  word-break: break-all;
-  color: ${colors.basic[900]};
-  background-color: ${colors.basic[0]};
-`;
-
-export const FilterTagButton = styled.button<FilterTagProps>`
-  flex-shrink: 0;
-  height: ${({ $size }) => {
-    switch ($size) {
-      case "small":
-        return "14px";
-      case "medium":
-        return "16px";
-      case "large":
-        return "18px";
-    }
-  }};
-  aspect-ratio: 1;
-  padding: 0;
-  border: 0;
-  color: ${colors.basic[900]};
-  background-color: transparent;
-  cursor: pointer;
-
-  /* アイコンのサイズ調整 */
-  svg {
-    width: ${({ $size }) => {
-      switch ($size) {
-        case "small":
-          return "14px";
-        case "medium":
-          return "16px";
-        case "large":
-          return "18px";
-      }
-    }};
-    height: ${({ $size }) => {
-      switch ($size) {
-        case "small":
-          return "14px";
-        case "medium":
-          return "16px";
-        case "large":
-          return "18px";
-      }
-    }};
-  }
-
-  span {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
   }
 `;
 

--- a/src/components/FilterInputAbstract/styled.tsx
+++ b/src/components/FilterInputAbstract/styled.tsx
@@ -156,10 +156,6 @@ export const DropDownTrigger = styled.button<{
     transition: color 0.2s ease;
   }
 
-  &:hover:not([disabled]) {
-    background: ${colors.basic[100]};
-  }
-
   /* サイズバリエーション */
   &:where(${FilterInputAbstract}[data-size="small"] *) {
     ${getTriggerIconSizeStyle("small")}

--- a/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.stories.tsx
@@ -57,80 +57,31 @@ export const Default: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: (
-          <Icon
-            name="operator_match"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon
-            name="operator_contains"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_starts_with"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_starts_with" type="line" />,
         label: "で始まる",
       },
       {
-        icon: (
-          <Icon
-            name="operator_ends_with"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_ends_with" type="line" />,
         label: "で終わる",
       },
       {
-        icon: (
-          <Icon
-            name="operator_equal"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_equal" type="line" />,
         label: "同じ",
       },
       {
-        icon: (
-          <Icon
-            name="operator_not_equal"
-            type="line"
-            color="currentColor"
-            size={22}
-          />
-        ),
+        icon: <Icon name="operator_not_equal" type="line" />,
         label: "同じでない",
       },
     ],

--- a/src/components/FilterSelectInput/FilterSelectInput.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.tsx
@@ -144,6 +144,7 @@ export const FilterSelectInput = ({
 
   return (
     <FilterInputAbstract
+      variant={variant}
       size={size}
       selectedIndex={selectedIndex}
       selectOptions={selectOptions}
@@ -151,7 +152,6 @@ export const FilterSelectInput = ({
       error={error}
       isOpen={isOpen}
       onSelectChange={onSelectChange}
-      variant={variant}
     >
       <styled.SelectContainer ref={triggerEl}>
         <ContextMenu2Container>

--- a/src/components/FilterSelectInput/FilterSelectInput.tsx
+++ b/src/components/FilterSelectInput/FilterSelectInput.tsx
@@ -151,6 +151,7 @@ export const FilterSelectInput = ({
       error={error}
       isOpen={isOpen}
       onSelectChange={onSelectChange}
+      variant={variant}
     >
       <styled.SelectContainer ref={triggerEl}>
         <ContextMenu2Container>

--- a/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
+++ b/src/components/FilterSelectInput/__tests__/__snapshots__/FilterSelectInput.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-label="フィルターのタイプを選ぶ"
-      class="sc-ivTmOn eMwvsv"
+      class="sc-ivTmOn ljHaqd"
       type="button"
     >
       <span
@@ -44,21 +44,21 @@ exports[`FileUploader component testing FileUploader 1`] = `
       </span>
     </button>
     <div
-      class="sc-kLLXSd kMruRd"
+      class="sc-ezWOiH cxhZqn"
     >
       <button
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="sc-ikZpkk fPDWXB"
+        class="sc-bZkfAO gwHoRa"
         type="button"
       >
         <span
-          class="sc-jIZahH eBXoqc"
+          class="sc-kLLXSd dfQxVI"
         >
           項目1
         </span>
         <span
-          class="sc-himrzO emiHoQ"
+          class="sc-ikZpkk cQKpdf"
         >
           <span
             class="sc-bczRLJ gJuzRf"

--- a/src/components/FilterTagInput/FilterTagInput.stories.tsx
+++ b/src/components/FilterTagInput/FilterTagInput.stories.tsx
@@ -78,45 +78,31 @@ export const Default: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon name="operator_contains" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
       {
-        icon: (
-          <Icon name="operator_starts_with" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_starts_with" type="line" />,
         label: "で始まる",
       },
       {
-        icon: (
-          <Icon name="operator_ends_with" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_ends_with" type="line" />,
         label: "で終わる",
       },
       {
-        icon: <Icon name="operator_equal" type="line" color="currentColor" />,
+        icon: <Icon name="operator_equal" type="line" />,
         label: "同じ",
       },
       {
-        icon: (
-          <Icon name="operator_not_equal" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_not_equal" type="line" />,
         label: "同じでない",
       },
     ],
@@ -143,17 +129,11 @@ export const Sizes: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
     ],
@@ -193,17 +173,11 @@ export const Variants: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
     ],
@@ -246,17 +220,11 @@ export const Disabled: StoryObj<typeof meta> = {
     disabled: true,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
     ],
@@ -299,23 +267,15 @@ export const Error: StoryObj<typeof meta> = {
     selectedIndex: 0,
     selectOptions: [
       {
-        icon: <Icon name="operator_match" type="line" color="currentColor" />,
+        icon: <Icon name="operator_match" type="line" />,
         label: "含む",
       },
       {
-        icon: (
-          <Icon
-            name="operator_does_not_match"
-            type="line"
-            color="currentColor"
-          />
-        ),
+        icon: <Icon name="operator_does_not_match" type="line" />,
         label: "含まない",
       },
       {
-        icon: (
-          <Icon name="operator_contains" type="line" color="currentColor" />
-        ),
+        icon: <Icon name="operator_contains" type="line" />,
         label: "いずれかを含む",
       },
     ],

--- a/src/components/FilterTagInput/FilterTagInput.tsx
+++ b/src/components/FilterTagInput/FilterTagInput.tsx
@@ -497,6 +497,7 @@ export const FilterTagInput = ({
         error={error}
         isOpen={isFocused}
         onSelectChange={onSelectChange}
+        variant={variant}
       >
         <styled.InlineField ref={inlineFieldEl} $size={size} $variant={variant}>
           <styled.InlineFieldInner ref={inlineFieldInnerEl}>

--- a/src/components/FilterTagInput/FilterTagInput.tsx
+++ b/src/components/FilterTagInput/FilterTagInput.tsx
@@ -490,6 +490,7 @@ export const FilterTagInput = ({
   return (
     <>
       <FilterInputAbstract
+        variant={variant}
         size={size}
         selectedIndex={selectedIndex}
         selectOptions={selectOptions}
@@ -497,7 +498,6 @@ export const FilterTagInput = ({
         error={error}
         isOpen={isFocused}
         onSelectChange={onSelectChange}
-        variant={variant}
       >
         <styled.InlineField ref={inlineFieldEl} $size={size} $variant={variant}>
           <styled.InlineFieldInner ref={inlineFieldInnerEl}>

--- a/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
+++ b/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-label="フィルターのタイプを選ぶ"
-      class="sc-ivTmOn eMwvsv"
+      class="sc-ivTmOn ljHaqd"
       type="button"
     >
       <span
@@ -44,22 +44,22 @@ exports[`FileUploader component testing FileUploader 1`] = `
       </span>
     </button>
     <div
-      class="sc-gicCDI bACZxb"
+      class="sc-llJcti ePffZE"
     >
       <div
-        class="sc-ezWOiH jbWjVW"
+        class="sc-iIPllB KFycW"
       >
         <div
-          class="sc-kgUAyh dpPXav"
+          class="sc-cOFTSb kJOXzF"
         >
           <div
-            class="sc-hTtwUo"
+            class="sc-BeQoi"
           >
             テキスト
           </div>
           <button
             aria-label="削除"
-            class="sc-jgbSNz evgNjR"
+            class="sc-kgUAyh iXpbNY"
             type="button"
           >
             <span
@@ -79,16 +79,16 @@ exports[`FileUploader component testing FileUploader 1`] = `
           </button>
         </div>
         <div
-          class="sc-kgUAyh dpPXav"
+          class="sc-cOFTSb kJOXzF"
         >
           <div
-            class="sc-hTtwUo"
+            class="sc-BeQoi"
           >
             value2
           </div>
           <button
             aria-label="削除"
-            class="sc-jgbSNz evgNjR"
+            class="sc-kgUAyh iXpbNY"
             type="button"
           >
             <span
@@ -108,16 +108,16 @@ exports[`FileUploader component testing FileUploader 1`] = `
           </button>
         </div>
         <div
-          class="sc-kgUAyh dpPXav"
+          class="sc-cOFTSb kJOXzF"
         >
           <div
-            class="sc-hTtwUo"
+            class="sc-BeQoi"
           >
             value3
           </div>
           <button
             aria-label="削除"
-            class="sc-jgbSNz evgNjR"
+            class="sc-kgUAyh iXpbNY"
             type="button"
           >
             <span
@@ -137,10 +137,10 @@ exports[`FileUploader component testing FileUploader 1`] = `
           </button>
         </div>
         <div
-          class="sc-kLLXSd bbGbdZ"
+          class="sc-ezWOiH bwxRDj"
         >
           <div
-            class="sc-ikZpkk gseRNm"
+            class="sc-bZkfAO ijetUZ"
           >
             <span
               class="sc-bczRLJ gJuzRf"
@@ -166,7 +166,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
     </div>
     <button
       aria-label="フィルター入力パネルを開く"
-      class="sc-bZkfAO dbnBPR"
+      class="sc-gicCDI ictzgV"
       data-overflowing="false"
       type="button"
     >


### PR DESCRIPTION
## ContextMenu2のリストメニューのスタイル調整
filter系コンポーネントの調整に必要な内部コンポーネントの修正としてContextMenu2の修正をした。
currentColorやdisabled、danger系のデフォルト指定をアップデートした。

### Before
<img width="325" alt="image" src="https://github.com/user-attachments/assets/9cd9bba8-c6d1-4657-a61f-5e20f1e65776" />

### After
<img width="337" alt="image" src="https://github.com/user-attachments/assets/6f9b1055-9003-4d07-9795-8c165154a0d3" />


## アイコンの色とサイズの指定を不要にした
currentColorやsizeを入れないと変な色やサイズになってしまっていたので、ContextMenu2の修正と合わせてデフォルト値を入れて整えた。
実装側のイメージは下記のようになる。

### Before
```js
 icon: (
          <Icon
            name="operator_match"
            type="line"
            color="currentColor"
            size={22}
          />
```

### After
```js
icon: <Icon name="operator_match" type="line" />,
```

## ドロップダウンボタンの背景色をvariantに連動させた
filterSelectInputなどのフィルター系で、variantでdarkを指定した時にドロップダウンボタンの背景色が追随できていなかったので修正した。

### Before
<img width="170" alt="image" src="https://github.com/user-attachments/assets/d479dc31-4365-41e1-ac49-23100d6d255c" />

### After
<img width="192" alt="image" src="https://github.com/user-attachments/assets/5f60b109-1366-4db8-a09f-310314985067" />
