### PR TITLE
🐛 Android 端末で FilterTagInput 内の入力値を確定できない不具合を修正

### DIFF
--- a/.changeset/lazy-bears-double.md
+++ b/.changeset/lazy-bears-double.md
@@ -1,0 +1,5 @@
+---
+"ingred-ui": patch
+---
+
+Android 端末で FilterTagInput の入力値を確定できない不具合を修正

--- a/src/components/FilterTagInput/FilterTagInput.tsx
+++ b/src/components/FilterTagInput/FilterTagInput.tsx
@@ -521,6 +521,7 @@ export const FilterTagInput = ({
                 aria-label="フィルターする値"
                 value={inputValue}
                 disabled={disabled}
+                enterKeyHint="enter" // Android の仮想キーボードの確定ボタンを「OK」表示にする
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
                 onCompositionStart={handleCompositionStart}

--- a/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
+++ b/src/components/FilterTagInput/__tests__/__snapshots__/FilterTagInput.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`FileUploader component testing FileUploader 1`] = `
         >
           <input
             aria-label="フィルターする値"
+            enterkeyhint="enter"
             type="text"
             value=""
           />


### PR DESCRIPTION
<!-- Thanks so much for your PR️!!! -->

## 概要

Android端末のFilterTagInputコンポーネントで入力値を確定できない不具合を修正

## 変更内容

- FilterTagInputコンポーネントのinput要素にenterKeyHint="enter"属性を追加
- これによりAndroid端末の仮想キーボードで確定ボタンが「OK」として表示され、入力値の確定が可能になる

## 修正理由

Android端末では仮想キーボードのEnterキーの表示と動作が曖昧で、FilterTagInputで値を入力後に確定できない問題があった。enterKeyHint="enter"を設定することで、
キーボードに明確な確定ボタンが表示される。

## 影響範囲

- FilterTagInputコンポーネントのみ
- Android端末のユーザー体験が改善される
- 既存の機能に破壊的変更なし
 
## 動作確認
Android の画面収録がわからず直写で申し訳ない、、

### 修正前

https://github.com/user-attachments/assets/f6e49c51-0c66-4565-8fbf-c50d37fec25c

### 修正後

https://github.com/user-attachments/assets/3388ec9d-a062-429a-8687-544e928a0d74


## Check List (If️ you added new component in this PR)
- [ ] Export the component in `src/components/index.ts`
- [ ] Add example to `.storybook/documents/Information/Samples/Samples.stories.tsx`
- [ ] Localize added component
