### PR TITLE
NavigationRailをスマホ対応した

### DIFF
--- a/src/components/NavigationRail/ExpansionMenu/ExpansionMenu.tsx
+++ b/src/components/NavigationRail/ExpansionMenu/ExpansionMenu.tsx
@@ -50,7 +50,9 @@ const ExpansionMenu = React.forwardRef<
   ref,
 ) {
   const theme = useTheme();
-  const { isOpen } = React.useContext(NavigationRailContext);
+  const { isOpen, isMobile, isMobileMenuOpen } = React.useContext(
+    NavigationRailContext,
+  );
 
   const [isExpand, setIsExpand] = React.useState<boolean>(defaultExpand);
   const [delayTransition, setDelayTransition] = React.useState<boolean>(false);
@@ -90,7 +92,7 @@ const ExpansionMenu = React.forwardRef<
             color={isActive ? "active" : theme.palette.black}
           />
         </NotificationBadge>
-        <Styled.TextContainer isOpen={isOpen}>
+        <Styled.TextContainer isOpen={isOpen || (isMobile && isMobileMenuOpen)}>
           <Styled.TextWrapper
             component="span"
             color={isActive ? "primary" : "initial"}
@@ -100,7 +102,10 @@ const ExpansionMenu = React.forwardRef<
             {title}
           </Styled.TextWrapper>
         </Styled.TextContainer>
-        <Styled.ArrowIconWrapper isExpand={isExpand} isOpen={isOpen}>
+        <Styled.ArrowIconWrapper
+          isExpand={isExpand}
+          isOpen={isOpen || (isMobile && isMobileMenuOpen)}
+        >
           <Icon
             name="arrow_bottom"
             color={isActive ? "active" : theme.palette.black}
@@ -110,7 +115,10 @@ const ExpansionMenu = React.forwardRef<
       </Styled.Container>
       <Styled.Expansion
         ref={expansionElement}
-        isExpand={(isExpand && isOpen) || expansionHeight === "auto"}
+        isExpand={
+          (isExpand && (isOpen || (isMobile && isMobileMenuOpen))) ||
+          expansionHeight === "auto"
+        }
         height={expansionHeight}
         delay={delayTransition}
       >

--- a/src/components/NavigationRail/Inner/Inner.tsx
+++ b/src/components/NavigationRail/Inner/Inner.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { addScrollbarProperties } from "../../../utils/scrollbar";
 import { NavigationRailContentHeight } from "../constants";
+import { BreakPoint } from "../../../styles/breakPoint";
 
 export const Header = styled.div`
   flex-shrink: 0;
@@ -25,4 +26,8 @@ export const Footer = styled.div`
   display: flex;
   align-items: center;
   border-top: 1px solid ${({ theme }) => theme.palette.gray.light};
+
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    display: none;
+  }
 `;

--- a/src/components/NavigationRail/MainContent/styled.ts
+++ b/src/components/NavigationRail/MainContent/styled.ts
@@ -3,6 +3,7 @@ import {
   NavigationRailWidth,
   NavigationRailTransitionDuration,
 } from "../constants";
+import { BreakPoint } from "../../../styles/breakPoint";
 
 export const Container = styled.div<{ isFixed: boolean }>`
   padding-left: ${({ isFixed }) =>
@@ -10,4 +11,8 @@ export const Container = styled.div<{ isFixed: boolean }>`
   width: 100%;
   height: 100%;
   transition: padding-left ${NavigationRailTransitionDuration}s;
+
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    padding-left: 0;
+  }
 `;

--- a/src/components/NavigationRail/NavigationRail.tsx
+++ b/src/components/NavigationRail/NavigationRail.tsx
@@ -40,6 +40,18 @@ const NavigationRail = React.forwardRef<HTMLDivElement, Props>(
       handleMobileMenuToggle,
     } = React.useContext(NavigationRailContext);
 
+    const handleMouseEnter = () => {
+      if (!isMobile) {
+        handleOpen?.();
+      }
+    };
+
+    const handleMouseLeave = () => {
+      if (!isMobile) {
+        handleClose?.();
+      }
+    };
+
     return (
       <>
         <Styled.MobileOverlay
@@ -52,16 +64,16 @@ const NavigationRail = React.forwardRef<HTMLDivElement, Props>(
           isFixed={isFixed}
           isMobile={isMobile}
           isMobileMenuOpen={isMobileMenuOpen}
-          onMouseEnter={!isMobile ? handleOpen : undefined}
-          onMouseLeave={!isMobile ? handleClose : undefined}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           {children}
           <Styled.MobileCloseButton>
             <Button
               color="clear"
               size="small"
-              onClick={handleMobileMenuToggle}
               aria-label="メニューを閉じる"
+              onClick={handleMobileMenuToggle}
             >
               <Icon name="close" size="md" />
             </Button>

--- a/src/components/NavigationRail/NavigationRail.tsx
+++ b/src/components/NavigationRail/NavigationRail.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import * as Styled from "./styled";
 import { NavigationRailContext } from "./utils";
+import Button from "../Button";
+import Icon from "../Icon";
 import { NavigationRailContainer } from "./NavigationRailContainer";
 import { Header, Content, Footer } from "./Inner";
 import { MainContent } from "./MainContent";
@@ -28,20 +30,44 @@ type Props = {
 
 const NavigationRail = React.forwardRef<HTMLDivElement, Props>(
   function NavigationRail({ children }, ref) {
-    const { isOpen, isFixed, handleOpen, handleClose } = React.useContext(
-      NavigationRailContext,
-    );
+    const {
+      isOpen,
+      isFixed,
+      handleOpen,
+      handleClose,
+      isMobile,
+      isMobileMenuOpen,
+      handleMobileMenuToggle,
+    } = React.useContext(NavigationRailContext);
 
     return (
-      <Styled.Container
-        ref={ref}
-        isOpen={isOpen}
-        isFixed={isFixed}
-        onMouseEnter={handleOpen}
-        onMouseLeave={handleClose}
-      >
-        {children}
-      </Styled.Container>
+      <>
+        <Styled.MobileOverlay
+          isVisible={isMobile && isMobileMenuOpen}
+          onClick={handleMobileMenuToggle}
+        />
+        <Styled.Container
+          ref={ref}
+          isOpen={isOpen}
+          isFixed={isFixed}
+          isMobile={isMobile}
+          isMobileMenuOpen={isMobileMenuOpen}
+          onMouseEnter={!isMobile ? handleOpen : undefined}
+          onMouseLeave={!isMobile ? handleClose : undefined}
+        >
+          {children}
+          <Styled.MobileCloseButton>
+            <Button
+              color="clear"
+              size="small"
+              onClick={handleMobileMenuToggle}
+              aria-label="メニューを閉じる"
+            >
+              <Icon name="close" size="md" />
+            </Button>
+          </Styled.MobileCloseButton>
+        </Styled.Container>
+      </>
     );
   },
 );

--- a/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
+++ b/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
@@ -81,6 +81,8 @@ const NavigationRailContainer = React.forwardRef<
         document.removeEventListener("keydown", handleKeyDown);
       };
     }
+
+    return undefined;
   }, [isMobile, isMobileMenuOpen]);
 
   return (
@@ -103,8 +105,8 @@ const NavigationRailContainer = React.forwardRef<
           <Button
             color="clear"
             size="small"
-            onClick={handleMobileMenuToggle}
             aria-label="メニューを開く"
+            onClick={handleMobileMenuToggle}
           >
             <Icon name="menu" size="md" />
           </Button>

--- a/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
+++ b/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import * as Styled from "./styled";
 import { NavigationRailContext } from "../utils";
+import useMediaQuery from "../../../hooks/useMediaQuery";
+import { BreakPoint } from "../../../styles/breakPoint";
 
 export type NavigationRailContainerProps = {
   /**
@@ -28,6 +30,11 @@ const NavigationRailContainer = React.forwardRef<
   const [isOpen, setIsOpen] = React.useState<boolean>(defaultFixed);
   const [isFixed, setIsFixed] = React.useState<boolean>(defaultFixed);
 
+  // Mobile detection and state
+  const isMobile = useMediaQuery(`(max-width: ${BreakPoint.MOBILE}px)`);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] =
+    React.useState<boolean>(false);
+
   const handleOpen = () => {
     if (!isFixed) {
       setIsOpen(true);
@@ -54,6 +61,10 @@ const NavigationRailContainer = React.forwardRef<
     if (onChangeFixed) onChangeFixed(false);
   };
 
+  const handleMobileMenuToggle = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
   return (
     <NavigationRailContext.Provider
       value={{
@@ -63,6 +74,9 @@ const NavigationRailContainer = React.forwardRef<
         handleClose,
         handleFixed,
         handleUnFixed,
+        isMobile,
+        isMobileMenuOpen,
+        handleMobileMenuToggle,
       }}
     >
       <Styled.Container ref={ref}>{children}</Styled.Container>

--- a/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
+++ b/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
@@ -3,6 +3,8 @@ import * as Styled from "./styled";
 import { NavigationRailContext } from "../utils";
 import useMediaQuery from "../../../hooks/useMediaQuery";
 import { BreakPoint } from "../../../styles/breakPoint";
+import Button from "../../Button";
+import Icon from "../../Icon";
 
 export type NavigationRailContainerProps = {
   /**
@@ -79,7 +81,19 @@ const NavigationRailContainer = React.forwardRef<
         handleMobileMenuToggle,
       }}
     >
-      <Styled.Container ref={ref}>{children}</Styled.Container>
+      <Styled.Container ref={ref}>
+        {children}
+        <Styled.MobileMenuButton>
+          <Button
+            color="clear"
+            size="small"
+            onClick={handleMobileMenuToggle}
+            aria-label="メニューを開く"
+          >
+            <Icon name="menu" size="md" />
+          </Button>
+        </Styled.MobileMenuButton>
+      </Styled.Container>
     </NavigationRailContext.Provider>
   );
 });

--- a/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
+++ b/src/components/NavigationRail/NavigationRailContainer/NavigationRailContainer.tsx
@@ -67,6 +67,22 @@ const NavigationRailContainer = React.forwardRef<
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
 
+  // Handle Escape key to close mobile menu
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isMobile && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    if (isMobile && isMobileMenuOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [isMobile, isMobileMenuOpen]);
+
   return (
     <NavigationRailContext.Provider
       value={{

--- a/src/components/NavigationRail/NavigationRailContainer/styled.ts
+++ b/src/components/NavigationRail/NavigationRailContainer/styled.ts
@@ -1,7 +1,19 @@
 import styled from "styled-components";
+import { BreakPoint } from "../../../styles/breakPoint";
 
 export const Container = styled.div`
   display: flex;
   width: 100vw;
   height: 100%;
+`;
+
+export const MobileMenuButton = styled.div`
+  position: fixed;
+  top: ${({ theme }) => theme.spacing * 2}px;
+  right: ${({ theme }) => theme.spacing * 2}px;
+  display: none;
+
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    display: block;
+  }
 `;

--- a/src/components/NavigationRail/styled.ts
+++ b/src/components/NavigationRail/styled.ts
@@ -4,10 +4,13 @@ import {
   NavigationRailTransitionDuration,
 } from "./constants";
 import { hexToRgba } from "../../utils/hexToRgba";
+import { BreakPoint } from "../../styles/breakPoint";
 
 type ContainerProps = {
   isOpen: boolean;
   isFixed: boolean;
+  isMobile: boolean;
+  isMobileMenuOpen: boolean;
 };
 
 export const Container = styled.div<ContainerProps>`
@@ -32,4 +35,54 @@ export const Container = styled.div<ContainerProps>`
   overflow-x: hidden;
   z-index: ${({ theme }) => theme.depth.drawer};
   transition: width ${NavigationRailTransitionDuration}s;
+
+  /* Mobile styles */
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    width: ${NavigationRailWidth.WIDE};
+    right: 0;
+    transform: translateX(
+      ${({ isMobileMenuOpen }) => (isMobileMenuOpen ? "0" : "100%")}
+    );
+    transition: transform ${NavigationRailTransitionDuration}s;
+    border-right: none;
+    border-left: 1px solid ${({ theme }) => theme.palette.gray.light};
+    box-shadow: ${({ isMobileMenuOpen, theme }) =>
+      isMobileMenuOpen
+        ? `-4px 0px ${theme.spacing * 2}px ${hexToRgba(
+            theme.palette.gray.dark,
+            theme.palette.action.shadowOpacity * 4,
+          )}`
+        : "none"};
+  }
+`;
+
+export const MobileOverlay = styled.div<{ isVisible: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => hexToRgba(theme.palette.black, 0.5)};
+  z-index: ${({ theme }) => theme.depth.drawer - 1};
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  visibility: ${({ isVisible }) => (isVisible ? "visible" : "hidden")};
+  transition:
+    opacity ${NavigationRailTransitionDuration}s,
+    visibility ${NavigationRailTransitionDuration}s;
+  display: none;
+
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    display: block;
+  }
+`;
+
+export const MobileCloseButton = styled.div`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing * 2}px;
+  right: ${({ theme }) => theme.spacing * 2}px;
+  display: none;
+
+  @media (max-width: ${BreakPoint.MOBILE}px) {
+    display: block;
+  }
 `;

--- a/src/components/NavigationRail/utils.ts
+++ b/src/components/NavigationRail/utils.ts
@@ -7,10 +7,16 @@ export type NavigationRailContextValues = {
   handleClose?: () => void;
   handleFixed?: () => void;
   handleUnFixed?: () => void;
+  // Mobile-specific properties
+  isMobile: boolean;
+  isMobileMenuOpen: boolean;
+  handleMobileMenuToggle?: () => void;
 };
 
 export const NavigationRailContext =
   React.createContext<NavigationRailContextValues>({
     isOpen: false,
     isFixed: false,
+    isMobile: false,
+    isMobileMenuOpen: false,
   });

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,52 @@
+import React from "react";
+
+const useEnhancedEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
+/**
+ * Hook to track media query matches
+ * @param query - Media query string (e.g., "(max-width: 816px)")
+ * @returns boolean indicating if the media query matches
+ */
+export default function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  });
+
+  useEnhancedEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    // Initial check
+    setMatches(mediaQueryList.matches);
+
+    // Add listener
+    if (mediaQueryList.addEventListener) {
+      mediaQueryList.addEventListener("change", handleChange);
+    } else {
+      // Fallback for older browsers
+      mediaQueryList.addListener(handleChange);
+    }
+
+    // Cleanup
+    return () => {
+      if (mediaQueryList.removeEventListener) {
+        mediaQueryList.removeEventListener("change", handleChange);
+      } else {
+        // Fallback for older browsers
+        mediaQueryList.removeListener(handleChange);
+      }
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/src/styles/breakPoint.ts
+++ b/src/styles/breakPoint.ts
@@ -1,6 +1,7 @@
 export const BreakPoint = {
   X_SMALL: 375,
   SMALL: 416,
+  MOBILE: 440,
   MEDIUM: 816,
   LARGE: 1008,
   X_LARGE: 1200,


### PR DESCRIPTION
## 📱 概要
NavigationRailコンポーネントにモバイル対応機能を追加しました。440px以下のデバイスで右側からスライドインするナビゲーションメニューを実装し、デスクトップの既存機能は完全に保持されています。

## ✨ 新機能
- **ハンバーガーメニューボタン**: 画面右上に配置、モバイル時のみ表示
- **右側スライドインナビゲーション**: スムーズなアニメーションで右側から表示
- **クローズボタン**: ナビゲーション内右上に配置
- **オーバーレイ**: 背景暗転、タップでクローズ
- **キーボードサポート**: Escキーでナビゲーションをクローズ
- **ExpansionMenu対応**: モバイルでも下層メニューが正常に動作
- **レスポンシブ最適化**: モバイル時はフッター非表示、MainContentのパディング調整

## 🎯 技術仕様
- **ブレークポイント**: 440px以下でモバイル判定（新規`BreakPoint.MOBILE`追加）
- **アニメーション**: 既存の`NavigationRailTransitionDuration`（0.3s）を使用
- **アクセシビリティ**: aria-label、Escキー対応
- **互換性**: 既存のAPIとpropsは完全に保持

## 🔧 実装詳細
- `useMediaQuery` hookを新規作成してメディアクエリを監視
- `NavigationRailContext`を拡張してモバイル状態管理を追加
- CSS media queryとtransformを使用したスライドアニメーション
- 既存コンポーネント構造を活用、新規コンポーネントは作成せず

## 🧪 テスト項目
- [ ] 440px以下でハンバーガーメニューボタンが表示される
- [ ] ハンバーガーメニュータップでナビゲーションがスライドイン
- [ ] クローズボタンでナビゲーションがスライドアウト
- [ ] オーバーレイタップでナビゲーションがクローズ
- [ ] Escキーでナビゲーションがクローズ
- [ ] ExpansionMenuの展開/折りたたみが正常に動作
- [ ] デスクトップでの既存動作が変更されていない
- [ ] モバイル時にフッターが非表示になる
- [ ] MainContentのパディングがモバイル時に0になる

## 🚀 破壊的変更
なし - 既存のAPIとpropsは完全に保持されています

## 📝 追加ファイル
- `src/hooks/useMediaQuery.ts` - メディアクエリ監視用hook
- `src/styles/breakPoint.ts` - `MOBILE: 440` ブレークポイント追加